### PR TITLE
fix(ci): build shared-types before frontend build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,6 +73,14 @@ jobs:
           cache: 'npm'
           cache-dependency-path: frontend/package-lock.json
 
+      - name: Install shared-types dependencies
+        working-directory: shared-types
+        run: npm install
+
+      - name: Build shared-types
+        working-directory: shared-types
+        run: npm run build
+
       - name: Install frontend dependencies
         working-directory: frontend
         run: npm ci


### PR DESCRIPTION
## Summary
Fixes the GitHub Actions CI build failure by ensuring shared-types is built before the frontend build step.

## Problem
The frontend build was failing with:
```
error TS2307: Cannot find module '@lfmt/shared-types' or its corresponding type declarations.
```

## Root Cause
The `build-frontend` job in the GitHub Actions workflow was missing steps to install and build the `shared-types` package before building the frontend. The frontend requires the compiled `@lfmt/shared-types` module during TypeScript compilation.

## Solution
Added two steps to the `build-frontend` job before installing frontend dependencies:
1. Install shared-types dependencies
2. Build shared-types

This mirrors the pattern already used in the `test` job which was working correctly.

## Changes
- `.github/workflows/deploy.yml`: Added shared-types install and build steps to build-frontend job

## Testing
- Pre-push validation passed locally (all tests passing)
- Ready for CI verification

Resolves GitHub Actions run #19017059847 failure.