### PR TITLE
fix(e2e): Replace __dirname with ES module equivalent

### DIFF
--- a/frontend/e2e/tests/translation/upload-workflow.spec.ts
+++ b/frontend/e2e/tests/translation/upload-workflow.spec.ts
@@ -14,6 +14,12 @@ import { generateTestUser } from '../../fixtures/auth';
 import { TEST_DOCUMENTS } from '../../fixtures/test-documents';
 import * as fs from 'fs';
 import * as path from 'path';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+
+// ES module equivalent of __dirname
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 test.describe('Translation Upload Workflow - Happy Path', () => {
   let loginPage: LoginPage;


### PR DESCRIPTION
## Summary
Fixes E2E test failure on main branch caused by `__dirname` undefined error in ES module context.

## Root Cause
- Frontend package.json has `"type": "module"` making all .ts files ES modules
- E2E test file `upload-workflow.spec.ts` used CommonJS `__dirname` global
- CommonJS globals like `__dirname` and `__filename` don't exist in ES module scope
- Error: `ReferenceError: __dirname is not defined in ES module scope`

## Changes
- Added ES module imports: `fileURLToPath` from 'url', `dirname` from 'path'
- Created `__dirname` equivalent using `import.meta.url`:
  ```typescript
  const __filename = fileURLToPath(import.meta.url);
  const __dirname = dirname(__filename);
  ```
- Verified no other problematic `__dirname` usage in E2E tests

## Testing
- ✅ All 375 frontend tests pass
- ✅ All 209 backend tests pass  
- ✅ Pre-push validation passed locally
- ✅ TypeScript compilation successful

## Related Issue
Fixes main branch E2E test failure (GitHub Actions run 19021188984)

🤖 Generated with [Claude Code](https://claude.com/claude-code)