### PR TITLE
docs(openspec): Archive obsolete fix-cicd-deployment-workflow proposal

### DIFF
--- a/openspec/changes/archive/2025-11-09-fix-cicd-deployment-workflow/proposal.md
+++ b/openspec/changes/archive/2025-11-09-fix-cicd-deployment-workflow/proposal.md
@@ -1,11 +1,33 @@
 # Proposal: Fix CI/CD Deployment Workflow
 
 **Change ID**: `fix-cicd-deployment-workflow`
-**Status**: Proposed
+**Status**: ✅ COMPLETED (Superseded by PR #52)
 **Priority**: P1 - HIGH (Critical Team Velocity Blocker)
 **Related Issues**: N/A (workflow configuration issue)
 **Owner**: xlei-raymond (Principal Engineer / Team Lead)
 **Created**: 2025-11-08
+**Completed**: 2025-11-09
+**Resolution**: The actual issue was different from initial hypothesis. Fixed via PR #52 (Frontend API URL Configuration).
+
+---
+
+## Completion Summary
+
+**Original Problem**: Workflow not triggering on PR merge (INCORRECT HYPOTHESIS)
+
+**Actual Problem**: Frontend built WITHOUT `VITE_API_URL`, causing E2E test failures
+
+**Solution Implemented**: PR #52 - Rebuild frontend during deployment with correct API URL
+- Changed: `.github/workflows/deploy.yml` to rebuild frontend with `VITE_API_URL` env var
+- Impact: E2E tests now pass, frontend properly configured
+- Investigation: See `P0-INVESTIGATION-E2E-FAILURES.md` for full analysis
+
+**Why This Proposal Was Obsolete**:
+- Workflow WAS triggering correctly on every PR merge (verified via git log)
+- E2E test failures were due to misconfigured frontend, not workflow triggers
+- Root cause analysis revealed build-time vs runtime env var issue
+
+---
 
 ## Problem Statement
 


### PR DESCRIPTION
## Summary

Archives the `fix-cicd-deployment-workflow` OpenSpec proposal as it has been superseded by PR #52's solution.

## Background

The original proposal hypothesized that the CI/CD workflow wasn't triggering on PR merges. However, investigation revealed the actual issue was completely different:

- **Original Hypothesis**: Workflow not triggering on PR merge
- **Actual Issue**: Frontend built WITHOUT `VITE_API_URL` environment variable
- **Resolution**: PR #52 fixed by rebuilding frontend during deployment with correct API URL

## Changes

- Moved `openspec/changes/fix-cicd-deployment-workflow/` → `openspec/changes/archive/2025-11-09-fix-cicd-deployment-workflow/`
- Updated proposal status to "COMPLETED (Superseded by PR #52)"
- Added completion summary explaining why the proposal was obsolete

## Why Archive?

1. **Workflow IS triggering correctly**: Verified via git log - all 10 recent PR merges triggered deployments
2. **E2E failures had different root cause**: Frontend API URL configuration issue
3. **Problem already fixed**: PR #52 resolved the actual blocker
4. **Keeps OpenSpec clean**: Only active proposals in `changes/` directory

## References

- **PR #52**: Frontend API URL Configuration Fix (actual solution)
- **Investigation**: `P0-INVESTIGATION-E2E-FAILURES.md` (full root cause analysis)
- **OpenSpec Guidance**: Archive completed changes using `openspec archive`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>