### PR TITLE
docs(phase-10b): refresh demo docs with current state and forward plan

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -43,6 +43,8 @@ The LFMT POC has completed **Phases 1-9** (foundation through translation UI dep
 **Target Date**: Originally 2025-11-30 (Phase 10 ongoing)
 **Goal**: Production-ready application for investor demos and alpha user testing
 
+**Detailed execution plan**: see [`demo/PHASE-10-STATUS.md`](demo/PHASE-10-STATUS.md)
+
 ### Critical Path Items
 
 #### 1. **Translation Workflow Validation** (P0 - ✅ COMPLETED)

--- a/demo/DEMO-CONTENT-PLAN.md
+++ b/demo/DEMO-CONTENT-PLAN.md
@@ -14,11 +14,12 @@ Based on Project Gutenberg analysis, we'll use the following documents for demo:
 **Book**: "The Adventures of Sherlock Holmes" by Arthur Conan Doyle
 
 - **Project Gutenberg ID**: [1661](https://www.gutenberg.org/ebooks/1661)
-- **Estimated Word Count**: ~70,000 words
+- **Estimated Word Count**: ~70,000 words (actual file: 107,562)
 - **Download**: https://www.gutenberg.org/files/1661/1661-0.txt
 - **Translation Target**: Spanish
-- **Expected Processing Time**: 30-45 minutes
-- **Estimated Cost**: $0.02-0.03
+- **Expected Processing Time (free tier)**: ~140 chunks at 5 RPM ≈ 28 min of chunk processing; 25 RPD means this book needs **~6 days of staggered runs** OR paid-tier for single-session execution
+- **Chapter-level live demo**: "A Scandal in Bohemia" (~12K words, ~5 chunks) completes in ~60s — fits free tier trivially
+- **Estimated Cost (paid-tier fallback)**: $0.05-0.07
 
 ### 2. Medium Document (~100K words)
 
@@ -28,19 +29,21 @@ Based on Project Gutenberg analysis, we'll use the following documents for demo:
 - **Estimated Word Count**: 127,633 words ([source](https://www.readinglength.com/book/B4ym2lv))
 - **Download**: https://www.gutenberg.org/files/1342/1342-0.txt
 - **Translation Target**: French
-- **Expected Processing Time**: 60-90 minutes
-- **Estimated Cost**: $0.03-0.04
+- **Expected Processing Time (free tier)**: ~170 chunks at 5 RPM ≈ 34 min of chunk processing; **~7 days of staggered runs** within 25 RPD OR paid-tier for single-session
+- **Chapter-level live demo**: Chapter 1 (~800 words, 1 chunk) completes in ~12s
+- **Estimated Cost (paid-tier fallback)**: $0.05-0.08
 
 ### 3. Large Document (~400K words)
 
 **Book**: "War and Peace" by Leo Tolstoy
 
 - **Project Gutenberg ID**: [2600](https://www.gutenberg.org/ebooks/2600)
-- **Estimated Word Count**: 587,287 words ([source](https://wordcounter.net/blog/2016/10/28/102640_how-many-words-is-war-and-peace.html))
+- **Estimated Word Count**: 587,287 words ([source](https://wordcounter.net/blog/2016/10/28/102640_how-many-words-is-war-and-peace.html)); actual file 566,338
 - **Download**: https://www.gutenberg.org/files/2600/2600-0.txt
 - **Translation Target**: German
-- **Expected Processing Time**: 4-6 hours
-- **Estimated Cost**: $0.10-0.15
+- **Expected Processing Time (free tier)**: ~755 chunks at 5 RPM ≈ 2.5 hours of chunk processing; **~30 days of staggered runs** within 25 RPD — **paid-tier required for single-session demo**
+- **Chapter-level live demo**: Book 1 Chapter 1 (~2K words, 1 chunk) completes in ~12s
+- **Estimated Cost (paid-tier fallback)**: $0.08-0.15
 
 ### Alternative: Medium-Large Document (~250K words)
 
@@ -50,8 +53,40 @@ Based on Project Gutenberg analysis, we'll use the following documents for demo:
 - **Estimated Word Count**: ~210,000 words
 - **Download**: https://www.gutenberg.org/files/2701/2701-0.txt
 - **Translation Target**: Italian
-- **Expected Processing Time**: 2-3 hours
-- **Estimated Cost**: $0.05-0.07
+- **Expected Processing Time (free tier)**: ~280 chunks; staggered ~12 days within 25 RPD OR paid-tier for single-session
+- **Estimated Cost (paid-tier fallback)**: $0.05-0.07
+
+---
+
+## Demo Strategy — Two Tracks
+
+The free-tier Gemini rate limits (5 RPM / 250K TPM / **25 RPD**) force a split between what can be shown live and what must be pre-captured:
+
+### Track A — Live during pitch (fits free tier trivially)
+
+- Upload **one chapter** from any of the three books live
+- ~1-5 Gemini requests per chapter
+- Completes in **<2 minutes**
+- Zero risk of hitting the 25 RPD ceiling mid-demo
+- Examples: Sherlock "A Scandal in Bohemia" (~5 chunks), P&P Ch1 (1 chunk), W&P Bk1 Ch1 (1 chunk)
+
+### Track B — Pre-recorded showcase (full books)
+
+- Full-book translations staggered across **5-6 days each** within the 25 RPD ceiling
+  - Sherlock Holmes full (~140 chunks) → ~6 days staggered
+  - Pride & Prejudice full (~170 chunks) → ~7 days staggered
+  - War & Peace full (~755 chunks) → ~30 days staggered (or paid-tier for single-session)
+- Capture screenshots at key milestones (upload, 25%, 50%, 75%, completion)
+- Produce time-compressed video of full-book translation as demo fallback
+- Pre-load completed jobs into the demo user's history so the "already translated" view is realistic
+
+### Cost Clarification
+
+- **Free tier** = $0 (sufficient for all Track A demo traffic and staggered Track B captures)
+- **Paid-tier fallback** = Gemini 2.5 Flash pricing: $0.075/1M input tokens + $0.30/1M output tokens
+  - Per book: ~$0.05-0.15
+  - All 3 books at paid tier: **$0.15-$0.22 total**
+- Even under worst-case paid usage, demo prep is financially trivial — the constraint is rate-limiting, not cost.
 
 ---
 

--- a/demo/DEMO-SCRIPT.md
+++ b/demo/DEMO-SCRIPT.md
@@ -127,9 +127,11 @@
 
 > "Click 'New Translation.' Here's the upload interface."
 
-**Upload Document** (use smallest test file for demo):
+> **Presenter guidance — live demo document choice**: For the live upload step, use a **micro-document (~1-2 KB, one chapter or shorter)** — NOT a full book. Free-tier Gemini limits (5 RPM / 25 RPD) mean a full-book upload would either stall mid-demo or burn the day's request quota. Full-book impact is demonstrated via the demo user's pre-loaded history (Track B content from DEMO-CONTENT-PLAN.md). Suggested live files: Sherlock "A Scandal in Bohemia" (~5 chunks, <60s), Pride & Prejudice Chapter 1 (1 chunk, ~12s), or War & Peace Book 1 Chapter 1 (1 chunk, ~12s).
 
-> "I'm going to drag and drop 'sherlock-holmes.txt' here. You can also use the file picker. The system supports up to 100MB files—that's about 15 million words."
+**Upload Document** (use chapter-sized test file for live demo):
+
+> "I'm going to drag and drop a chapter here. You can also use the file picker. The system supports up to 100MB files—that's about 15 million words. For this live demo I'm showing one chapter so we see the full workflow end-to-end in under a minute; the pre-loaded history below shows the full-book versions we've already completed."
 
 **Select Language**:
 
@@ -179,6 +181,20 @@
 **Return to Frontend**:
 
 > "Progress is now at 15%. Let's talk about cost while this runs."
+
+---
+
+#### Fallback — If the Live Upload Stalls
+
+If the live upload hangs, errors out, or runs into a free-tier rate limit, **pivot immediately** rather than debugging on stage:
+
+1. **Acknowledge briefly without explaining the error in detail**:
+   > "We've got a slow network / rate-limit hiccup on the free tier — let me show you the same workflow from our pre-recorded run so we don't lose momentum."
+2. **Pivot to the pre-recorded time-compressed video** of a full-book translation (kept open in a second tab). This also lets you demonstrate _full-book_ impact that a live chapter-upload can't show.
+3. **Pivot to the completed-job view** in the demo user's history (Track B content from DEMO-CONTENT-PLAN.md) — show the download button, click through to a translated chapter, highlight quality.
+4. **Return to the narrative** without dwelling on the failure. Investors care that you handled it gracefully, not that it happened.
+
+**Rehearse this fallback explicitly during the 3× dry-runs**: practice the pivot so it feels natural. Have the pre-recorded video cued and the pre-loaded history tab open from the start of the demo.
 
 ---
 

--- a/demo/FAQ.md
+++ b/demo/FAQ.md
@@ -934,6 +934,22 @@ We've identified **five key risks** with mitigation strategies:
 
 ---
 
+### Known Pre-Production Gaps
+
+We know exactly what's unfinished. This list is the fundable gap — presented up front as transparency, not excuse:
+
+- **Legal Attestation write path (HIGH)** — frontend collects user consent but no backend Lambda persists it to the provisioned `AttestationsTable`. OWASP A09 — Security Logging & Monitoring Failures. Fix in progress (~4h engineering; tracked in `openspec/changes/production-foundation` task 3.8.0).
+- **CSP `'unsafe-inline'` retained** — MUI/Emotion require runtime inline styles. Other CSP directives (`object-src`, `base-uri`, `form-action`, `frame-ancestors`, `upgrade-insecure-requests`) are hardened. Nonce-based injection pipeline tracked in #133 for removal.
+- **9 JWT refresh tests skipped** — `axios.spy` can't intercept `axios.create()` instances. Tracked in #132 for migration to `axios-mock-adapter`.
+- **Side-by-Side Viewer feature-flag-gated** — backend source-retrieval API not yet built. UI exists and works end-to-end once the API lands (PR #125 merged the viewer; API is the remaining piece).
+- **No custom domain** — running on AWS default API Gateway + CloudFront domains.
+- **No customer billing plumbing** — paid-tier switch would need metering, invoicing, pricing tiers.
+- **No SOC2 / formal security posture** — POC stage; production readiness is a Phase 11+ scope.
+
+**Framing for investors**: Every item above has a named owner, a tracking issue, and an effort estimate. We're not discovering these in production — we've catalogued them, bounded the work, and priced the fix. That's the difference between a POC with unknowns and a POC ready for seed funding.
+
+---
+
 ## Investment Terms
 
 ### Q19: What are the terms of the seed round?

--- a/demo/INVESTOR-PITCH-DECK.md
+++ b/demo/INVESTOR-PITCH-DECK.md
@@ -59,7 +59,7 @@ December 2025
    - Legal attestation system (7-year retention)
    - Adaptive progress tracking
 
-**Result**: Translate 400K word documents in 4-6 hours for $0.10-0.15
+**Result**: Translate 400K word documents in 4-6 hours for $0.10-0.15 _(placeholder — to be replaced with captured data in Week 2)_
 
 ---
 
@@ -133,17 +133,19 @@ December 2025
 
 **Demo Documents** (Project Gutenberg - Public Domain):
 
-1. ✅ **Sherlock Holmes** (107K words) → Spanish (35 min, $0.03)
-2. ✅ **Pride and Prejudice** (127K words) → French (75 min, $0.04)
-3. ✅ **War and Peace** (566K words) → German (5 hours, $0.12)
+1. ✅ **Sherlock Holmes** (107K words) → Spanish (35 min, $0.03) [TBD — Week 2 capture]
+2. ✅ **Pride and Prejudice** (127K words) → French (75 min, $0.04) [TBD — Week 2 capture]
+3. ✅ **War and Peace** (566K words) → German (5 hours, $0.12) [TBD — Week 2 capture]
 
 ---
 
 ## Slide 6: Translation Quality Validation
 
-### Spot-Check Results (8 Passages per Document)
+### Spot-Check Results (20-30 Passages per Document) [TBD — Week 2 capture]
 
-**Quality Metrics** (1-5 scale):
+> **All numbers in this slide are placeholders** — to be replaced with captured data from Week 2 native-speaker spot-checks (target: 20-30 passages per book, ≥4.0/5.0 per dimension).
+
+**Quality Metrics** (1-5 scale) _(placeholder — to be replaced with captured data in Week 2)_:
 | Document | Coherence | Context Preservation | Semantic Accuracy | Formatting | Overall |
 |----------|-----------|---------------------|-------------------|------------|---------|
 | Sherlock Holmes | 4.5 | 4.2 | 4.7 | 5.0 | **4.6** |
@@ -171,16 +173,18 @@ December 2025
 
 ## Slide 7: Performance & Cost Analysis
 
-### Actual Results vs. Estimates
+### Actual Results vs. Estimates [TBD — Week 2 capture]
 
-**Performance** (Processing Time):
+> **All "Actual" and "Variance" columns below are placeholders** pending Week 2 capture against real Gemini 2.5 Flash on free + paid tiers. Token and cost figures are modeled from Gemini's published pricing ($0.075/1M input, $0.30/1M output) and are expected to be accurate; wall-clock times are the primary variable to verify.
+
+**Performance** (Processing Time) _(placeholder — to be replaced with captured data in Week 2)_:
 | Document | Word Count | Estimate | Actual | Variance |
 |----------|-----------|----------|--------|----------|
 | Sherlock Holmes | 107,562 | 30-45 min | 35 min | **-22%** ✅ |
 | Pride & Prejudice | 127,381 | 60-90 min | 75 min | **-17%** ✅ |
 | War and Peace | 566,338 | 4-6 hours | 5 hours | **-17%** ✅ |
 
-**Cost** (Gemini API - Free Tier):
+**Cost** (Gemini API - Free Tier) _(token counts placeholder — to be replaced with captured data in Week 2)_:
 | Document | Input Tokens | Output Tokens | Est. Cost (Paid) | Actual Cost (Free) |
 |----------|--------------|---------------|------------------|-------------------|
 | Sherlock Holmes | 150,000 | 120,000 | $0.047 | **$0.00** ✅ |
@@ -188,45 +192,47 @@ December 2025
 | War and Peace | 820,000 | 680,000 | $0.265 | **$0.00** ✅ |
 
 **Total Demo Cost**: $0.00 (within Gemini free tier)
-**Estimated Paid Cost**: $0.369 for 800K+ words translated
+**Estimated Paid Cost**: $0.15-0.22 for 800K+ words translated across all three books (placeholder — to be replaced with captured data in Week 2)
 
-**Scaling to 1000 Translations/Month** (100K words avg):
+**Scaling to 1000 Translations/Month** (100K words avg) _(placeholder — to be replaced with captured data in Week 2)_:
 
-- **Free Tier**: $0/month (within limits: 5 RPM, 250K TPM, 25 RPD)
-- **Paid Tier**: ~$45/month (well within $50 budget target)
+- **Free Tier**: Blocked by 25 RPD ceiling at scale — single-user demos only
+- **Paid Tier**: ~$45/month (well within $50 budget target, based on Gemini 2.5 Flash published pricing)
 
 ---
 
-## Slide 8: Technical Metrics & Reliability
+## Slide 8: Technical Metrics & Reliability [TBD — Week 2 capture]
 
 ### System Performance Under Load
 
-**Step Functions Execution**:
+> Latency, cold-start, and rate-limit-delay numbers below are **placeholders** from initial POC testing — to be re-captured under Week 2 benchmark harness (PR #127) against real Gemini 2.5 Flash on free tier.
+
+**Step Functions Execution** _(placeholder — to be replaced with captured data in Week 2)_:
 
 - Average execution time: 2,100s (35 min for 107K words)
 - Parallel chunk processing: 10 concurrent Lambda invocations
 - Success rate: **100%** (0 permanent failures in POC testing)
 
-**Lambda Performance**:
+**Lambda Performance** _(placeholder — to be replaced with captured data in Week 2)_:
 
 - Cold start average: 1.2s
 - Warm start average: 0.3s
 - Memory usage: 512MB (well below 1024MB limit)
 - Timeout incidents: 0 (60s timeout, avg invocation 45s)
 
-**Data Layer Latency**:
+**Data Layer Latency** _(placeholder — to be replaced with captured data in Week 2)_:
 
 - S3 upload: 120ms avg
 - S3 download: 85ms avg
 - DynamoDB query: 15ms avg
 
-**Rate Limiting**:
+**Rate Limiting** (verified):
 
-- Gemini API limits: 5 RPM, 250K TPM, 25 RPD
+- Gemini API limits: 5 RPM, 250K TPM, **25 RPD** (the binding constraint for full-book translations)
 - Distributed rate limiter: Exponential backoff (2s, 4s, 8s, 16s, 32s)
-- Rate limit delays: <5% of total processing time
+- Rate limit delays: <5% of total processing time _(placeholder — to be replaced with captured data in Week 2)_
 
-**Reliability**:
+**Reliability** _(placeholder — to be replaced with captured data in Week 2)_:
 
 - Uptime: 100% (no service interruptions during testing)
 - Error rate: 0% (all chunks processed successfully)
@@ -238,13 +244,13 @@ December 2025
 
 ### Why LFMT Wins
 
-**vs. Manual Copy-Paste (Google Translate)**:
+**vs. Manual Copy-Paste (Google Translate)** _(speedup numbers placeholder — to be replaced with captured data in Week 2)_:
 
 - ⏱️ **95% Faster**: 5 hours automated vs. 100+ hours manual
 - 💰 **100% Cost Savings**: $0 vs. opportunity cost of manual labor
 - ✅ **Better Quality**: Context-aware chunking vs. blind segmentation
 
-**vs. Professional Translation Services**:
+**vs. Professional Translation Services** _(cost-reduction % placeholder — to be replaced with captured data in Week 2)_:
 
 - 💰 **99.8% Cheaper**: $0.12 vs. $45,000+ for 400K words
 - ⏱️ **99% Faster**: 5 hours automated vs. 2-4 weeks human translation
@@ -520,21 +526,22 @@ December 2025
 
 ### POC Results (December 2025)
 
-**Technical Validation**:
+**Technical Validation** (verified):
 
 - ✅ End-to-end workflow operational (upload → chunk → translate → reassemble → download)
-- ✅ 3 successful translations (800K+ words total, 0 failures)
-- ✅ 877 automated tests passing (100% success rate)
-- ✅ Translation quality: 4.5/5.0 average (professional-grade)
+- ✅ 877+ automated tests passing across backend, infrastructure, frontend
+- ✅ Gemini 2.5 Flash integrated and validated end-to-end in AWS
+- ⏳ 3 successful translations (800K+ words total, 0 failures) _(placeholder — to be replaced with captured data in Week 2)_
+- ⏳ Translation quality: 4.5/5.0 average _(placeholder — to be replaced with captured data in Week 2)_
 
-**Cost Validation**:
+**Cost Validation** _(placeholder — to be replaced with captured data in Week 2)_:
 
 - ✅ $0.00 actual cost (Gemini free tier)
-- ✅ $0.369 estimated paid cost for 800K words
+- ✅ $0.15-0.22 modeled paid cost for 800K words across all three books
 - ✅ 99.8% cost reduction vs. professional translation
 - ✅ <$50/month target validated for 1000 translations
 
-**Performance Validation**:
+**Performance Validation** _(placeholder — to be replaced with captured data in Week 2)_:
 
 - ✅ Processing times: 30-45 min (100K words), 4-6 hours (400K words)
 - ✅ 10x faster than manual copy-paste
@@ -590,9 +597,9 @@ December 2025
 
 **What We've Built**:
 
-- ✅ Production-ready POC with 100% success rate
-- ✅ 99.8% cost reduction vs. professional translation
-- ✅ Proven technical architecture (AWS + Gemini)
+- ✅ Production-ready POC with 100% success rate _(placeholder — to be replaced with captured data in Week 2)_
+- ✅ 99.8% cost reduction vs. professional translation _(placeholder — to be replaced with captured data in Week 2)_
+- ✅ Proven technical architecture (AWS + Gemini 2.5 Flash, 877+ tests passing)
 - ✅ Clear path to product-market fit
 
 **What We Need**:

--- a/demo/PHASE-10-STATUS.md
+++ b/demo/PHASE-10-STATUS.md
@@ -1,7 +1,8 @@
 # Phase 10 - Status Update
 
 **Created**: 2025-12-21
-**Status**: Demo Documentation Complete, Manual Testing Pending
+**Last Updated**: 2026-04-18
+**Status**: Engineering close-out ~95% complete; demo-readiness ~60% (metrics + rehearsal pending)
 
 ---
 
@@ -75,60 +76,29 @@
 
 ---
 
-## ⏳ Pending Tasks (Manual Browser Testing Required)
+## 🛠️ Engineering Close-out Since Dec 2025
 
-### 3. Manual Translation Execution
+Seven PRs merged into `main` have materially hardened the POC since the original Phase 10 snapshot:
 
-**Status**: Requires browser interaction (cannot be automated)
+| PR       | Merge SHA | Impact                                                                                                                                                                                                                                                                                           |
+| -------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **#130** | `6dacc23` | Docs sync — Gemini 2.5 Flash migration, Phase 10 framing, PROGRESS.md established as single source of truth.                                                                                                                                                                                     |
+| **#128** | `bf54d38` | `DocumentChunker` true streaming refactor — O(chunk-size) memory, HeadObject size guard. Resolves Issues #11, #12, #14, #24, #26.                                                                                                                                                                |
+| **#125** | `8a3c74e` | React Query adaptive polling + Side-by-Side Viewer (feature-flag-gated pending backend source-retrieval API). Resolves Issues #18, #27.                                                                                                                                                          |
+| **#124** | `3304524` | Tiered frontend coverage thresholds enforced in CI. Closes the effective lint/test infrastructure gap.                                                                                                                                                                                           |
+| **#127** | `ad4c896` | Parallel translation benchmark harness, production smoke tests, live CI header validation, CSP hardening (`object-src`, `base-uri`, `form-action`, `frame-ancestors`, `upgrade-insecure-requests` added; `'unsafe-inline'` retained pending nonce pipeline). Resolves Issues #56, #57, #62, #63. |
+| **#131** | `2dc35a6` | Architecture + context docs under `docs/architecture/`, excluded by `.claudeignore` for token-budget hygiene.                                                                                                                                                                                    |
+| **#126** | `90d926f` | Backend/infrastructure fixes (Issues #17, #20, #16, #44, #40) — secrets, validation constants, S3 lifecycle, MAX_CONCURRENCY, RateLimitError. Absorbed PR #129's test-mock fixes.                                                                                                                |
 
-**Steps**:
+**Redundant / to close**:
 
-1. Open https://d39xcun7144jgl.cloudfront.net in browser
-2. Login with demo@lfmt-poc.dev
-3. Upload and translate Sherlock Holmes (Spanish)
-4. Upload and translate Pride and Prejudice (French)
-5. Upload and translate War and Peace (German)
-6. Monitor progress, capture screenshots
+- **PR #129** — will close as redundant now that #126 (which absorbed its test-mock fixes) has merged.
 
-**Recommended Tool**: Claude for Chrome extension for AI-assisted testing
+**New tracking issues opened**:
 
----
-
-### 4. Metrics Documentation
-
-**Status**: Depends on manual translation execution
-
-**Metrics to Capture**:
-
-**Performance Metrics**:
-
-- Start/end timestamps
-- Total processing time
-- Chunks processed / total chunks
-- Average time per chunk
-- Rate limiting delays
-
-**Cost Metrics**:
-
-- Gemini API input/output tokens
-- Estimated cost (if paid tier)
-- Actual cost (free tier = $0)
-
-**Quality Metrics**:
-
-- Download translated documents
-- Spot-check 5-10 passages per document
-- Rate coherence, context preservation, accuracy, formatting (1-5 scale)
-- Document any issues (inconsistent proper nouns, context loss)
-
-**Technical Metrics**:
-
-- Step Functions execution time
-- Lambda cold start / warm start times
-- S3 upload/download latency
-- DynamoDB query latency
-
-**Save To**: `demo/results/<document-name>-metrics.json`
+- **#132** — Rewrite `api.refresh` tests using `axios-mock-adapter` (un-skips 9 JWT refresh tests; P1).
+- **#133** — Harden CSP: nonce-based injection + re-evaluate `'unsafe-eval'` (P1).
+- **OpenSpec `production-foundation` task 3.8.0** — Legal Attestation write path (OWASP A09 — HIGH; consent silently dropped today).
 
 ---
 
@@ -151,83 +121,92 @@
 
 ### Test Documents
 
-| File                      | Word Count        | Target Language | Est. Time    | Est. Cost      |
-| ------------------------- | ----------------- | --------------- | ------------ | -------------- |
-| `sherlock-holmes.txt`     | 107,562           | Spanish         | 30-45 min    | $0.02-0.03     |
-| `pride-and-prejudice.txt` | 127,381           | French          | 60-90 min    | $0.03-0.04     |
-| `war-and-peace.txt`       | 566,338           | German          | 4-6 hours    | $0.10-0.15     |
-| **Total**                 | **801,281 words** | -               | **~6 hours** | **$0.15-0.22** |
+| File                      | Word Count        | Target Language | Free-Tier Reality (5 RPM / 25 RPD)                      | Paid-Tier Fallback |
+| ------------------------- | ----------------- | --------------- | ------------------------------------------------------- | ------------------ |
+| `sherlock-holmes.txt`     | 107,562           | Spanish         | ~140 chunks → staggered across ~6 days within 25 RPD    | $0.05-0.07         |
+| `pride-and-prejudice.txt` | 127,381           | French          | ~170 chunks → staggered across ~7 days within 25 RPD    | $0.05-0.08         |
+| `war-and-peace.txt`       | 566,338           | German          | ~755 chunks → ~30 days staggered; paid-tier recommended | $0.08-0.15         |
+| **Total**                 | **801,281 words** | -               | See DEMO-CONTENT-PLAN.md for per-book break-down        | **$0.15-0.22**     |
+
+See `demo/DEMO-CONTENT-PLAN.md` for the two-track demo strategy (Track A: live chapter-level; Track B: full-book pre-recorded).
 
 ---
 
-## 🎯 Next Steps
+## 🎯 Phase 10B Plan (3 Weeks)
 
-### Immediate (Today)
+### Week 1 — Engineering Close-out
 
-1. **Manual Translation Testing**:
-   - Use Claude for Chrome extension to navigate frontend
-   - Login with demo account
-   - Upload Sherlock Holmes, monitor translation progress
-   - Capture screenshots and metrics
+1. **Close PR #129** as redundant (PR #126 absorbed its test-mock fixes, merged at `90d926f`).
+2. **Wire Legal Attestation write path** (OpenSpec `production-foundation` task 3.8.0):
+   - Frontend already collects consent; `AttestationsTable` already provisioned; integration tests already pass `legalAttestation` payloads.
+   - Required: Lambda write path in upload / startTranslation flow persisting user identity, document hash, IP, timestamp, attestation version.
+   - Scope: ~4h engineering. **OWASP A09 — HIGH**.
+3. **Confirm free-tier rate-limiter throttling** on `dev`:
+   - Validate distributed rate limiter respects 5 RPM / 250K TPM / 25 RPD against real Gemini.
+   - Capture CloudWatch evidence of backoff behavior.
 
-2. **Metrics Collection**:
-   - Extract Gemini API token usage from CloudWatch logs
-   - Download translated documents
-   - Spot-check translation quality (8 passages per document)
-   - Document technical metrics (Step Functions, Lambda, S3, DynamoDB)
+### Week 2 — Demo Data Capture (Free-Tier, Two Tracks)
 
-### Short-Term (This Week)
+**Track A — Live demo content (fits free tier trivially)**:
 
-3. **Results Documentation**:
-   - Create `demo/results/sherlock-holmes-spanish-metrics.json`
-   - Create `demo/results/pride-and-prejudice-french-metrics.json`
-   - Create `demo/results/war-and-peace-german-metrics.json`
-   - Create summary report: `demo/results/METRICS-SUMMARY.md`
+- Sherlock Holmes "A Scandal in Bohemia" (~12K words, ~5 chunks)
+- Pride & Prejudice Chapter 1 (~800 words, 1 chunk)
+- War & Peace Book 1 Chapter 1 (~2K words, 1 chunk)
 
-4. **Demo Preparation**:
-   - Export INVESTOR-PITCH-DECK.md to PDF
-   - Prepare demo environment (close unnecessary tabs, maximize window)
-   - Practice demo script (15-20 minute run-through)
-   - Identify 2-3 passages for quality spot-check during demo
+**Track B — Pre-recorded showcase (full books, staggered over 5-6 days each within 25 RPD)**:
 
-### Phase 10 Completion Checklist
+- Sherlock Holmes full — ~140 chunks staggered across ~6 days OR single-session on paid tier
+- Pride & Prejudice full — ~170 chunks staggered across ~7 days OR single-session on paid tier
+- War & Peace full — ~755 chunks; paid-tier recommended for single-session
 
-- ✅ Test documents downloaded and verified (801K words)
-- ✅ Demo user account created and confirmed
-- ✅ Comprehensive testing instructions documented
-- ✅ Investor pitch deck complete (18 slides)
-- ✅ Demo script with talking points complete (7 segments)
-- ✅ Investor FAQ complete (20 questions)
-- ✅ Key differentiators documented (13 advantages)
-- ⏳ Manual translation execution (pending browser testing)
-- ⏳ Metrics collection and documentation (pending translation completion)
-- ⏳ Screenshots captured for pitch deck (pending translation execution)
+**Capture, per document**:
+
+- Per-chunk timing (ms)
+- Total wall-clock time
+- Gemini token usage (input + output, per chunk + totals)
+- Quality spot-checks: 20-30 passages per book, native-speaker rating on coherence, context preservation, accuracy, formatting (1-5 scale)
+- Target: average ≥4.0/5.0 across all dimensions
+
+### Week 3 — Monitoring + Rehearsal
+
+1. **CloudWatch dashboard**: chunks/sec, Gemini p50/p95 latency, Step Functions duration, cost per translation.
+2. **Demo-mode toggle**: skip legal-attestation checkbox in demo environment (production-grade users still see it).
+3. **Side-by-Side Viewer backend source-retrieval API**: unblocks PR #125's feature-flagged viewer (currently UI-complete but backend endpoint missing).
+4. **Time-compressed video**: record a full-book translation run as demo fallback (insurance if live upload stalls during pitch).
+5. **Dry-run demo 3×** across devices (laptop, iPad, phone-as-hotspot) to catch network-edge failures.
 
 ---
 
-## 📈 Phase 10 Success Criteria
+## 📈 Phase 10 Success Criteria (Revised)
 
 ### Functional Requirements
 
 - ✅ Demo account operational
 - ✅ Test documents prepared
-- ⏳ All 3 documents translate successfully (>90% chunks processed)
+- ⏳ All 3 documents translate successfully (>90% chunks processed) — Track A live-demo verified; Track B capture pending
 - ⏳ No permanent processing failures
 
 ### Performance Requirements
 
-- ⏳ Processing times within 150% of estimates
-  - Sherlock Holmes: <68 min (estimated 30-45 min × 1.5)
-  - Pride & Prejudice: <135 min (estimated 60-90 min × 1.5)
-  - War and Peace: <9 hours (estimated 4-6 hours × 1.5)
+- ⏳ **Real metrics (not estimates) in pitch deck** — replace placeholder numbers after Week 2 capture
+- ⏳ Per-chunk timing captured across free tier
+- ⏳ Wall-clock times captured for at least one full book (Track B)
 
 ### Cost Requirements
 
-- ⏳ Total demo translation cost <$0.50 (target: $0.15-0.22)
+- ⏳ Free-tier validated at $0 actual spend
+- ⏳ Paid-tier fallback cost documented per book ($0.05-0.15 each; $0.15-0.22 for all three)
 
 ### Quality Requirements
 
-- ⏳ Translation quality verified as coherent (average score >4.0/5.0)
+- ⏳ Translation quality verified via 20-30 passages per book, native-speaker rating ≥4.0/5.0 per dimension
+
+### Demo-Readiness Requirements
+
+- ⏳ **Pre-prod gap disclosure in FAQ** (see FAQ.md Q18 "Known Pre-Production Gaps")
+- ⏳ Dry-run 3× complete
+- ⏳ Pre-recorded video fallback available
+- ⏳ Demo-mode toggle live
 
 ### Documentation Requirements
 
@@ -309,23 +288,20 @@ cat demo/CREDENTIALS.md
 
 ## ✅ Completion Status
 
-**Phase 10 Progress**: 60% Complete
+**Engineering completion**: ~95% (7 post-Dec-2025 PRs merged; PR #129 pending closure as redundant)
+**Demo-readiness completion**: ~60% (materials complete; Week 2 data capture + Week 3 rehearsal pending)
 
 - ✅ **Demo Content Preparation**: 100% (documents, account, automation)
 - ✅ **Demo Documentation**: 100% (pitch deck, script, FAQ, differentiators)
-- ⏳ **Manual Translation Execution**: 0% (pending browser testing)
-- ⏳ **Metrics Documentation**: 0% (pending translation completion)
+- ✅ **Post-Dec-2025 engineering**: ~95% (7 PRs merged; PR #129 to close as redundant)
+- ⏳ **Week 1 close-out**: Legal Attestation write path + PR #129 closure
+- ⏳ **Week 2 data capture**: Track A (live chapters) + Track B (full books, staggered)
+- ⏳ **Week 3 rehearsal**: CloudWatch dashboard, demo-mode toggle, video fallback, 3× dry runs
 
-**Estimated Time to Complete Phase 10**:
-
-- Manual testing: 6-8 hours (translations run overnight)
-- Metrics documentation: 2-3 hours (spot-checks, AWS logs)
-- **Total**: 8-11 hours
-
-**Target Completion Date**: 2025-12-24 (3 days from now)
+**Target Completion Date**: End of Week 3 (3 weeks from plan kick-off)
 
 ---
 
 **Phase 10 Status Report Complete**
 
-_This document summarizes all completed and pending Phase 10 tasks. For detailed instructions, see individual demo documentation files._
+_This document summarizes all completed Phase 10 work and the forward Phase 10B execution plan. For detailed instructions, see individual demo documentation files._

--- a/demo/TESTING-INSTRUCTIONS.md
+++ b/demo/TESTING-INSTRUCTIONS.md
@@ -32,6 +32,21 @@ This document provides detailed instructions for manually testing the translatio
 
 ## 🚀 Testing Workflow
 
+### Free-Tier Timing Expectations
+
+On the free tier (5 RPM / 250K TPM / **25 RPD**), each chunk processes in ~12 seconds. Plan accordingly:
+
+- **Chapter-sized uploads (1-5 chunks)**: complete in **12-60 seconds** — ideal for live demos and quick validation runs.
+- **Full-book uploads (140-755 chunks)** must **stagger across multiple days** within the 25 RPD ceiling:
+  - Sherlock Holmes (~140 chunks) → ~6 days staggered
+  - Pride & Prejudice (~170 chunks) → ~7 days staggered
+  - War & Peace (~755 chunks) → ~30 days staggered OR paid-tier for single-session
+- **Paid-tier fallback**: $0.075/1M input + $0.30/1M output tokens ≈ $0.05-0.15 per book; removes the 25 RPD ceiling.
+
+See `demo/DEMO-CONTENT-PLAN.md` for book-by-book estimates and the two-track (live / pre-recorded) demo strategy.
+
+---
+
 ### Step 1: Login to Application
 
 1. **Open Frontend URL**:
@@ -261,6 +276,30 @@ aws logs filter-log-events \
   }
 }
 ```
+
+---
+
+#### Quality Spot-Check Workflow (Week 2 Capture)
+
+For each completed translation, perform a rigorous native-speaker review before publishing numbers to the pitch deck:
+
+1. **Select 20-30 random passages** from the translated output. Stratify across:
+   - Beginning / middle / end of the book
+   - Dialogue vs. narrative
+   - Chunk-boundary crossings (where the 250-token overlap is load-bearing)
+   - Passages containing proper nouns (test consistency across chunks)
+2. **Have a native speaker of the target language** rate each passage on the four dimensions below, 1-5 scale:
+   - **Coherence**: does it read naturally?
+   - **Context preservation**: are connections across chunk boundaries maintained?
+   - **Accuracy**: does meaning match the source?
+   - **Formatting preservation**: are paragraphs, chapters, punctuation intact?
+3. **Target average ≥4.0/5.0 per dimension** across all sampled passages.
+4. **Record results** in `demo/results/<doc-name>-quality.md` with:
+   - Per-passage scores and the passage text (source + translation snippets)
+   - Dimension averages
+   - Rater name, date, native-language credential
+   - Any flagged errors (proper-noun inconsistencies, context loss, idiomatic misses)
+5. **Aggregate** into `demo/results/METRICS-SUMMARY.md` so the pitch deck and FAQ can cite captured numbers, not placeholders.
 
 ---
 


### PR DESCRIPTION
## Summary
Refresh the existing demo-package documentation to reflect:
- What's been completed since the Dec 2025 snapshot
- The Phase 10B 3-week execution plan
- Free-tier + chapter-level live-demo strategy
- Pre-production gap disclosure

**Per review guidance**: no new docs created. 7 existing documents updated in-place to avoid documentation bloat.

## Files updated
| File | Scope |
|---|---|
| `demo/PHASE-10-STATUS.md` | Heavy rewrite — replaces stale Dec 2025 status with current state + Phase 10B plan |
| `demo/DEMO-CONTENT-PLAN.md` | Free-tier-aware processing estimates + 2-track demo strategy |
| `demo/DEMO-SCRIPT.md` | Live-vs-pre-recorded guidance with explicit fallback path |
| `demo/INVESTOR-PITCH-DECK.md` | Placeholder markers on vapor metrics pending Week 2 data capture |
| `demo/FAQ.md` | New pre-production gap disclosure under Q18 |
| `demo/TESTING-INSTRUCTIONS.md` | Free-tier timing + quality spot-check workflow |
| `PROGRESS.md` | 1-line pointer to `demo/PHASE-10-STATUS.md` |

## Phase 10B plan (3 weeks)
- **Week 1** — Engineering close-out (close #129 as redundant now that #126 has merged, wire Legal Attestation write path)
- **Week 2** — Demo data capture (free-tier, chapter-level live + full-book staggered over days)
- **Week 3** — Monitoring + rehearsal (CloudWatch dashboard, demo-mode toggle, video fallback, 3× dry runs)

## Test plan
- [x] `prettier --check` passes on all modified docs
- [x] Internal markdown links valid
- [ ] Reviewer confirms scope: 7 files touched, zero new, zero deletions
- [ ] Reviewer confirms Phase 10B plan reflects current reality