### PR TITLE
feat(security): drop 'unsafe-eval' from CSP script-src (#133 Part 2)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -304,12 +304,16 @@ jobs:
           echo "CSP Policy: $CSP"
           echo ""
 
-          # NOTE: 'unsafe-inline' (style-src) and 'unsafe-eval' (script-src)
-          # are intentionally allowed because MUI/Emotion emit runtime inline
-          # styles and Vite's legacy build uses eval. See the CSP definition
-          # in backend/infrastructure/lib/lfmt-infrastructure-stack.ts for
-          # the full trade-off rationale and future-hardening plan.
-          # We therefore validate only the non-unsafe hardening directives.
+          # CSP hardening status (Issue #133):
+          #   - 'unsafe-eval' has been REMOVED from script-src (Part 2). The
+          #     production bundle was inspected and contains no eval()/Function()
+          #     calls; standard Vite + MUI/Emotion do not require it.
+          #   - 'unsafe-inline' is still permitted (style-src + script-src) and
+          #     will be removed when the nonce-injection pipeline lands
+          #     (Lambda@Edge + Emotion CacheProvider). Tracked in the Part 1
+          #     follow-up issue.
+          # We therefore validate the non-unsafe hardening directives plus the
+          # absence of 'unsafe-eval' as a regression guard.
 
           # Check that CSP contains baseline directives
           required_directives=("default-src" "script-src" "style-src" "connect-src")
@@ -323,7 +327,7 @@ jobs:
           done
 
           # Check that CSP contains additional hardening directives (retained
-          # from the Issue #63 pass even though 'unsafe-*' remains).
+          # from the Issue #63 pass even though 'unsafe-inline' remains).
           hardening_directives=(
             "object-src 'none'"
             "base-uri 'self'"
@@ -339,6 +343,15 @@ jobs:
               exit 1
             fi
           done
+
+          # Regression guard (Issue #133 Part 2): 'unsafe-eval' must NOT appear
+          # in the script-src directive of the deployed CSP.
+          if echo "$CSP" | grep -iF "'unsafe-eval'" > /dev/null; then
+            echo "❌ FAIL: CSP contains 'unsafe-eval' (regression — Issue #133 Part 2)"
+            exit 1
+          else
+            echo "✅ PASS: CSP does not contain 'unsafe-eval' (Issue #133 Part 2)"
+          fi
 
           echo ""
           echo "========================================="

--- a/backend/infrastructure/lib/__tests__/infrastructure.test.ts
+++ b/backend/infrastructure/lib/__tests__/infrastructure.test.ts
@@ -804,9 +804,6 @@ describe('LFMT Infrastructure Stack', () => {
     test('CSP includes hardening directives (object-src, base-uri, form-action, frame-ancestors, upgrade-insecure-requests)', () => {
       // Regression coverage for the CSP hardening work on PR #127 / issue #63.
       // These directives MUST be present on every CSP emitted by the stack.
-      // We intentionally do NOT assert the absence of 'unsafe-inline' or
-      // 'unsafe-eval' — the team rolled those back because MUI/Emotion
-      // require them. The hardening-path follow-up is tracked in issue #133.
       const requiredDirectives = [
         "object-src 'none'",
         "base-uri 'self'",
@@ -850,6 +847,41 @@ describe('LFMT Infrastructure Stack', () => {
         requiredDirectives.forEach((directive) => {
           expect(flat).toContain(directive);
         });
+      });
+    });
+
+    test("CSP does not contain 'unsafe-eval' (Issue #133 Part 2)", () => {
+      // Regression guard for Issue #133 Part 2.
+      // 'unsafe-eval' was removed from script-src after verifying that the
+      // production Vite/MUI bundle contains no eval()/new Function() calls.
+      // Re-introducing it would weaken script-src CSP and must trip CI.
+      // Note: 'unsafe-inline' is intentionally NOT asserted absent yet —
+      // that lands with Part 1 (nonce-injection pipeline). Tracked in the
+      // Part 1 follow-up issue.
+      const flattenCsp = (csp: unknown): string => {
+        if (typeof csp === 'string') return csp;
+        if (csp && typeof csp === 'object' && 'Fn::Join' in (csp as object)) {
+          const join = (csp as { 'Fn::Join': [string, unknown[]] })['Fn::Join'];
+          const parts = join[1];
+          return parts
+            .map((p) => (typeof p === 'string' ? p : JSON.stringify(p)))
+            .join('');
+        }
+        return JSON.stringify(csp);
+      };
+
+      const policies = template.findResources('AWS::CloudFront::ResponseHeadersPolicy');
+      const cspCarryingPolicies = Object.values(policies).filter((policy: any) => {
+        return !!policy?.Properties?.ResponseHeadersPolicyConfig?.SecurityHeadersConfig
+          ?.ContentSecurityPolicy?.ContentSecurityPolicy;
+      });
+      expect(cspCarryingPolicies.length).toBeGreaterThanOrEqual(2);
+
+      cspCarryingPolicies.forEach((policy: any) => {
+        const csp = policy.Properties.ResponseHeadersPolicyConfig.SecurityHeadersConfig
+          .ContentSecurityPolicy.ContentSecurityPolicy;
+        const flat = flattenCsp(csp);
+        expect(flat).not.toContain("'unsafe-eval'");
       });
     });
 

--- a/backend/infrastructure/lib/lfmt-infrastructure-stack.ts
+++ b/backend/infrastructure/lib/lfmt-infrastructure-stack.ts
@@ -1552,22 +1552,23 @@ export class LfmtInfrastructureStack extends Stack {
           override: true,
         },
         contentSecurityPolicy: {
-          // NOTE: This CSP will be updated after API Gateway is created to include the actual API URL
+          // NOTE: This CSP will be updated after API Gateway is created to include the actual API URL.
           //
-          // CSP uses 'unsafe-inline' for style-src and 'unsafe-eval' for script-src
-          // because the current frontend stack (MUI/Emotion) emits runtime inline
-          // styles, and Vite's legacy build output uses eval. Removing these
-          // directives breaks the production UI.
-          //
-          // Future hardening path: implement a nonce-based CSP once the build
-          // pipeline can inject per-request nonces into index.html and MUI/Emotion
-          // are configured to consume them.
-          // Tracked in: https://github.com/leixiaoyu/lfmt-poc/issues/133
+          // CSP hardening status (Issue #133):
+          //   - 'unsafe-eval' REMOVED from script-src (Part 2 — verified safe via
+          //     bundle inspection; standard Vite + MUI/Emotion do not require eval).
+          //   - 'unsafe-inline' RETAINED on style-src — MUI/Emotion emit runtime
+          //     inline styles. Removal blocked on a nonce-injection pipeline
+          //     (Lambda@Edge + Emotion CacheProvider integration). Tracked in
+          //     follow-up issue (Part 1 of #133).
+          //   - 'unsafe-inline' RETAINED on script-src — kept until the same
+          //     nonce pipeline lands (so the script-src tightening rolls out
+          //     atomically with style-src).
           //
           // Other hardening directives retained: object-src 'none', base-uri 'self',
           // form-action 'self', frame-ancestors 'none', upgrade-insecure-requests.
           // See: https://github.com/leixiaoyu/lfmt-poc/issues/63
-          contentSecurityPolicy: "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://*.execute-api.us-east-1.amazonaws.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests;",
+          contentSecurityPolicy: "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://*.execute-api.us-east-1.amazonaws.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests;",
           override: true,
         },
       },
@@ -1671,21 +1672,22 @@ export class LfmtInfrastructureStack extends Stack {
           override: true,
         },
         contentSecurityPolicy: {
-          // CSP with specific API Gateway domain (Issue #63)
+          // CSP with specific API Gateway domain (Issue #63).
           //
-          // CSP uses 'unsafe-inline' for style-src and 'unsafe-eval' for script-src
-          // because the current frontend stack (MUI/Emotion) emits runtime inline
-          // styles, and Vite's legacy build output uses eval. Removing these
-          // directives breaks the production UI.
-          //
-          // Future hardening path: implement a nonce-based CSP once the build
-          // pipeline can inject per-request nonces into index.html and MUI/Emotion
-          // are configured to consume them.
-          // Tracked in: https://github.com/leixiaoyu/lfmt-poc/issues/133
+          // CSP hardening status (Issue #133):
+          //   - 'unsafe-eval' REMOVED from script-src (Part 2 — verified safe via
+          //     bundle inspection; standard Vite + MUI/Emotion do not require eval).
+          //   - 'unsafe-inline' RETAINED on style-src — MUI/Emotion emit runtime
+          //     inline styles. Removal blocked on a nonce-injection pipeline
+          //     (Lambda@Edge + Emotion CacheProvider integration). Tracked in
+          //     follow-up issue (Part 1 of #133).
+          //   - 'unsafe-inline' RETAINED on script-src — kept until the same
+          //     nonce pipeline lands (so the script-src tightening rolls out
+          //     atomically with style-src).
           //
           // Other hardening directives retained: object-src 'none', base-uri 'self',
           // form-action 'self', frame-ancestors 'none', upgrade-insecure-requests.
-          contentSecurityPolicy: `default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://${apiDomain}; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests;`,
+          contentSecurityPolicy: `default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://${apiDomain}; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests;`,
           override: true,
         },
       },

--- a/demo/FAQ.md
+++ b/demo/FAQ.md
@@ -939,7 +939,7 @@ We've identified **five key risks** with mitigation strategies:
 We know exactly what's unfinished. This list is the fundable gap — presented up front as transparency, not excuse:
 
 - **Legal Attestation write path (HIGH)** — frontend collects user consent but no backend Lambda persists it to the provisioned `AttestationsTable`. OWASP A09 — Security Logging & Monitoring Failures. Fix in progress (~4h engineering; tracked in `openspec/changes/production-foundation` task 3.8.0).
-- **CSP `'unsafe-inline'` retained** — MUI/Emotion require runtime inline styles. Other CSP directives (`object-src`, `base-uri`, `form-action`, `frame-ancestors`, `upgrade-insecure-requests`) are hardened. Nonce-based injection pipeline tracked in #133 for removal.
+- **CSP `'unsafe-inline'` retained** — MUI/Emotion require runtime inline styles. Other CSP directives (`object-src`, `base-uri`, `form-action`, `frame-ancestors`, `upgrade-insecure-requests`) are hardened, and `'unsafe-eval'` was removed from `script-src` (Issue #133 Part 2). Nonce-based injection pipeline (Part 1) is the remaining work to drop `'unsafe-inline'` — tracked in the #133 Part 1 follow-up.
 - **9 JWT refresh tests skipped** — `axios.spy` can't intercept `axios.create()` instances. Tracked in #132 for migration to `axios-mock-adapter`.
 - **Side-by-Side Viewer feature-flag-gated** — backend source-retrieval API not yet built. UI exists and works end-to-end once the API lands (PR #125 merged the viewer; API is the remaining piece).
 - **No custom domain** — running on AWS default API Gateway + CloudFront domains.

--- a/demo/PHASE-10-STATUS.md
+++ b/demo/PHASE-10-STATUS.md
@@ -97,7 +97,7 @@ Seven PRs merged into `main` have materially hardened the POC since the original
 **New tracking issues opened**:
 
 - **#132** — Rewrite `api.refresh` tests using `axios-mock-adapter` (un-skips 9 JWT refresh tests; P1).
-- **#133** — Harden CSP: nonce-based injection + re-evaluate `'unsafe-eval'` (P1).
+- **#133** — Harden CSP: nonce-based injection + re-evaluate `'unsafe-eval'` (P1). Part 2 (`'unsafe-eval'` removed from `script-src`) shipped; Part 1 (nonce pipeline for `'unsafe-inline'`) tracked in follow-up.
 - **OpenSpec `production-foundation` task 3.8.0** — Legal Attestation write path (OWASP A09 — HIGH; consent silently dropped today).
 
 ---


### PR DESCRIPTION
## Summary

Closes Part 2 + Part 3 of issue #133. Part 1 (nonce-injection pipeline) is deferred to a follow-up issue per the OMC orchestrator's >2-day-budget guidance.

- **Part 2 — `'unsafe-eval'` removed from `script-src`**: production Vite/MUI bundle was inspected for `eval(` and `new Function(` calls and contains zero matches. Removing the directive is verified safe.
- **Part 3 — CDK + CI regression guards added**: a new infrastructure-test asserts the synthesized CSP does not contain `'unsafe-eval'`; the live deploy.yml CSP check fails CI if it ever reappears in the deployed CloudFront response header.
- **Documentation updated**: rationale comments rewritten to enumerate REMOVED/RETAINED status per directive; `demo/FAQ.md` and `demo/PHASE-10-STATUS.md` reflect the partial close-out.

### Why Part 1 is not in this PR

Part 1 (replace `'unsafe-inline'` with per-request nonces) requires a Lambda@Edge function, HTML body rewriting, MUI Emotion `CacheProvider` integration, Vite plugin work to nonce-attribute Vite-injected `<script>` tags, and CDK `experimental.EdgeFunction` wiring. The OMC orchestrator scoped this as >2 days and explicitly instructed: ship Part 2 cleanly and track Part 1 as a follow-up. Part 1 will be filed as a new issue immediately after this PR.

## Changes

| File | What |
| --- | --- |
| `backend/infrastructure/lib/lfmt-infrastructure-stack.ts` | Both CSP blocks (initial + post-API-Gateway) drop `'unsafe-eval'` from `script-src`; comments rewritten to a clear status block. |
| `backend/infrastructure/lib/__tests__/infrastructure.test.ts` | New test: every ResponseHeadersPolicy with a CSP must NOT contain `'unsafe-eval'`. |
| `.github/workflows/deploy.yml` | Live deployed-CSP check adds `'unsafe-eval'` regression guard; comment block updated. |
| `demo/FAQ.md`, `demo/PHASE-10-STATUS.md` | Pre-production-gaps + tracking notes reflect Part 2 shipped. |

## OMC self-review (5/5 APPROVE)

- **code-reviewer**: APPROVE — surgical diff, comment quality improved, helper consistency preserved.
- **security-auditor**: APPROVE — closes the eval()-injection XSS class; defense in depth via two regression guards (unit + live CI); zero new attack surface.
- **architect-reviewer**: APPROVE — right-sized intervention; defers Lambda@Edge correctly; both CSP policies kept in lockstep.
- **performance-engineer**: APPROVE — zero runtime perf impact; deploy-time string change only; avoids the Lambda@Edge cold-start cost (deferred).
- **test-automator**: APPROVE — new positive regression assertion plus deployed-CSP grep guard; 39/39 infra tests green.

## Ultra QA: GO

CI run: https://github.com/leixiaoyu/lfmt-poc/actions/runs/24755181642
- Security Scan: ✅ pass
- Lint and Format Check: ✅ pass
- Test Frontend: ✅ pass (543/543 + 19 skipped)
- Run Tests (backend functions): ✅ pass (409/409 + 3 skipped)
- Build Infrastructure: ✅ pass (39/39 incl. new `'unsafe-eval'` regression test)
- CI Summary: ✅ pass

Local verification:
- `cd frontend && CI=true npm run build` → clean.
- `grep "eval(\|new Function(" frontend/dist/assets/*.js` → zero matches (the defining proof of Part 2 safety).
- `cd backend/infrastructure && npm test` → 39/39, including new regression-guard.

## Test plan

- [ ] Reviewer: confirm CSP string in both `lfmt-infrastructure-stack.ts` blocks no longer contains `'unsafe-eval'`.
- [ ] Reviewer: spot-check the new infrastructure test passes locally (`cd backend/infrastructure && npm test`).
- [ ] Post-merge: confirm `Validate CSP Hardening` step in deploy.yml prints `✅ PASS: CSP does not contain 'unsafe-eval'` against the deployed CloudFront response.
- [ ] Post-merge: file follow-up issue for Part 1 (Lambda@Edge nonce-injection pipeline).

## Refs

- Closes Parts 2 + 3 of #133.
- Related: PR #127 (foundation hardening), Issue #63 (original CSP hardening).