### PR TITLE
feat(security): wire legal-attestation write path (OWASP A09 closure, OpenSpec 3.8.0)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -277,12 +277,17 @@ The LFMT POC has completed **Phases 1-9** (foundation through translation UI dep
 
 ### Pre-Production Blockers
 
-#### Pre-Production Blocker: Legal Attestation Write Path
+_None open. See "Recently Resolved" below._
 
-- **Impact**: Frontend collects user consent for legal attestation but no Lambda persists the data to the provisioned `AttestationsTable`. Consent is silently dropped, creating a potential compliance gap (OWASP A09 — Security Logging & Monitoring Failures) and audit-trail failure.
-- **Status**: Table provisioned (`backend/infrastructure/lib/lfmt-infrastructure-stack.ts:188`), frontend UI exists (`frontend/src/components/translation/LegalAttestation.tsx`), integration tests pass `legalAttestation` payloads — but no production write path.
-- **Required before launch**: Wire the write path in the upload / startTranslation flow so consent data is persisted with the job record (user identity, document hash, IP, timestamp, attestation version).
-- **Severity**: HIGH — do not deploy to production users without this.
+#### Recently Resolved: Legal Attestation Write Path ✅ RESOLVED
+
+- **Was**: Frontend collected user consent for legal attestation but no Lambda persisted the data to the provisioned `AttestationsTable`. Consent was silently dropped — OWASP A09 (Security Logging & Monitoring Failures).
+- **Resolution** (`feat/legal-attestation-write-path`, OpenSpec task 3.8.0):
+  - New `LegalAttestationRecord` schema in `shared-types/src/legal.ts` (Zod-validated).
+  - New helper `backend/functions/shared/attestationWriter.ts` (`buildAttestationRecord`, `writeAttestation`, `AttestationWriteError`).
+  - Wired into `backend/functions/jobs/uploadRequest.ts`: persists every consent BEFORE issuing the presigned URL; on persistence failure returns `500 AttestationPersistFailure` and aborts upload.
+  - Tests: 23 new tests across shared-types + functions; CDK IAM-assertion test verifies `dynamodb:PutItem` grant. All suites green.
+- **Outstanding follow-up** (P2, not a blocker): CloudWatch alarm on `AttestationsTable` write errors.
 
 ### Active Risks
 

--- a/backend/functions/jobs/__tests__/uploadRequest.cors.test.ts
+++ b/backend/functions/jobs/__tests__/uploadRequest.cors.test.ts
@@ -10,7 +10,8 @@
 // Set required environment variables BEFORE imports
 process.env.DOCUMENT_BUCKET = 'test-bucket';
 process.env.JOBS_TABLE = 'test-jobs-table';
-process.env.ATTESTATIONS_TABLE = 'test-attestations-table';
+// Required by attestationWriter (OpenSpec task 3.8.0).
+process.env.ATTESTATIONS_TABLE_NAME = 'test-attestations-table';
 process.env.ALLOWED_ORIGINS =
   'http://localhost:3000,https://localhost:3000,https://d39xcun7144jgl.cloudfront.net,https://staging.lfmt.yourcompany.com';
 

--- a/backend/functions/jobs/uploadRequest.test.ts
+++ b/backend/functions/jobs/uploadRequest.test.ts
@@ -13,6 +13,7 @@
 // Mock environment variables BEFORE importing handler
 process.env.DOCUMENT_BUCKET = 'test-document-bucket';
 process.env.JOBS_TABLE = 'test-jobs-table';
+process.env.ATTESTATIONS_TABLE_NAME = 'test-attestations-table';
 
 import { APIGatewayProxyEvent } from 'aws-lambda';
 import { mockClient } from 'aws-sdk-client-mock';
@@ -52,8 +53,24 @@ describe('uploadRequest Lambda Function - Comprehensive Coverage', () => {
     jest.clearAllMocks();
   });
 
+  // Default legal attestation block injected into every test request unless
+  // the test explicitly sets `legalAttestation` (including `null` to omit).
+  // Required after OpenSpec task 3.8.0 — uploads without consent are rejected.
+  const DEFAULT_ATTESTATION = {
+    acceptCopyrightOwnership: true,
+    acceptTranslationRights: true,
+    acceptLiabilityTerms: true,
+    userIPAddress: '127.0.0.1',
+    userAgent: 'jest-test',
+    timestamp: '2024-01-01T00:00:00.000Z',
+  };
+
   const createMockEvent = (body: any, userId = 'test-user-123'): APIGatewayProxyEvent => ({
-    body: JSON.stringify(body),
+    body: JSON.stringify(
+      'legalAttestation' in (body || {})
+        ? body
+        : { ...body, legalAttestation: DEFAULT_ATTESTATION }
+    ),
     headers: {},
     multiValueHeaders: {},
     httpMethod: 'POST',
@@ -126,9 +143,13 @@ describe('uploadRequest Lambda Function - Comprehensive Coverage', () => {
         'Content-Length': '50000',
       });
 
-      // Verify DynamoDB put was called
-      expect(dynamoMock.calls()).toHaveLength(1);
+      // Verify DynamoDB put was called twice — once for the legal-attestation
+      // record (OpenSpec 3.8.0), then once for the jobs record.
+      expect(dynamoMock.calls()).toHaveLength(2);
       expect((dynamoMock.call(0).args[0].input as PutItemCommandInput).TableName).toBe(
+        'test-attestations-table'
+      );
+      expect((dynamoMock.call(1).args[0].input as PutItemCommandInput).TableName).toBe(
         'test-jobs-table'
       );
     });
@@ -144,7 +165,8 @@ describe('uploadRequest Lambda Function - Comprehensive Coverage', () => {
 
       await handler(event);
 
-      const putCall = dynamoMock.call(0).args[0];
+      // call(0) is the attestation write; call(1) is the jobs PutItem.
+      const putCall = dynamoMock.call(1).args[0];
       const item = (putCall.input as PutItemCommandInput).Item!;
 
       // Verify all required fields in job record
@@ -178,7 +200,8 @@ describe('uploadRequest Lambda Function - Comprehensive Coverage', () => {
 
       await handler(event);
 
-      const putCall = dynamoMock.call(0).args[0];
+      // call(0) is the attestation write; call(1) is the jobs PutItem.
+      const putCall = dynamoMock.call(1).args[0];
       const s3Key = (putCall.input as PutItemCommandInput).Item!.s3Key!.S;
 
       expect(s3Key).toMatch(new RegExp(`^uploads/${userId}/[a-f0-9-]+/my-document\\.txt$`));
@@ -198,7 +221,8 @@ describe('uploadRequest Lambda Function - Comprehensive Coverage', () => {
       await handler(event);
 
       const afterRequest = Date.now();
-      const putCall = dynamoMock.call(0).args[0];
+      // call(0) is the attestation write; call(1) is the jobs PutItem.
+      const putCall = dynamoMock.call(1).args[0];
       const expiresAt = new Date(
         (putCall.input as PutItemCommandInput).Item!.expiresAt!.S!
       ).getTime();
@@ -567,8 +591,16 @@ describe('uploadRequest Lambda Function - Comprehensive Coverage', () => {
   });
 
   describe('DynamoDB Integration', () => {
-    it('should handle DynamoDB network errors gracefully', async () => {
-      dynamoMock.on(PutItemCommand).rejects(new Error('Network error'));
+    it('should handle DynamoDB network errors gracefully on the jobs PutItem', async () => {
+      // Attestation write succeeds; only the jobs PutItem fails.
+      let callCount = 0;
+      dynamoMock.on(PutItemCommand).callsFake(() => {
+        callCount += 1;
+        if (callCount === 1) {
+          return Promise.resolve({});
+        }
+        return Promise.reject(new Error('Network error'));
+      });
 
       const event = createMockEvent({
         fileName: 'document.txt',
@@ -613,7 +645,8 @@ describe('uploadRequest Lambda Function - Comprehensive Coverage', () => {
 
       await handler(event);
 
-      const putCall = dynamoMock.call(0).args[0];
+      // call(0) is the attestation PutItem; jobs PutItem is call(1).
+      const putCall = dynamoMock.call(1).args[0];
       expect((putCall.input as PutItemCommandInput).ConditionExpression).toBe(
         'attribute_not_exists(jobId)'
       );
@@ -630,8 +663,8 @@ describe('uploadRequest Lambda Function - Comprehensive Coverage', () => {
 
       await handler(event);
 
-      // Item should not contain any undefined values
-      const putCall = dynamoMock.call(0).args[0];
+      // Item should not contain any undefined values (jobs PutItem is call(1)).
+      const putCall = dynamoMock.call(1).args[0];
       const itemString = JSON.stringify((putCall.input as PutItemCommandInput).Item);
       expect(itemString).not.toContain('undefined');
     });
@@ -639,6 +672,8 @@ describe('uploadRequest Lambda Function - Comprehensive Coverage', () => {
 
   describe('S3 Integration', () => {
     it('should handle S3 getSignedUrl failures', async () => {
+      // Attestation write succeeds; only the S3 presign step fails.
+      dynamoMock.on(PutItemCommand).resolves({});
       mockGetSignedUrl.mockRejectedValueOnce(new Error('S3 error'));
 
       const event = createMockEvent({
@@ -651,8 +686,15 @@ describe('uploadRequest Lambda Function - Comprehensive Coverage', () => {
 
       expect(result.statusCode).toBe(500);
 
-      // DynamoDB should not be called if S3 fails
-      expect(dynamoMock.calls()).toHaveLength(0);
+      // The attestation write happens BEFORE the S3 presign — the audit
+      // record is required even if the upload itself never proceeds, so
+      // we expect exactly one DynamoDB write (attestations table) and no
+      // jobs-table write.
+      const calls = dynamoMock.calls();
+      expect(calls).toHaveLength(1);
+      expect((calls[0].args[0].input as PutItemCommandInput).TableName).toBe(
+        'test-attestations-table'
+      );
     });
   });
 
@@ -781,8 +823,16 @@ describe('uploadRequest Lambda Function - Comprehensive Coverage', () => {
 
       await Promise.all(events.map(handler));
 
-      const jobId1 = (dynamoMock.call(0).args[0].input as PutItemCommandInput).Item!.jobId!.S;
-      const jobId2 = (dynamoMock.call(1).args[0].input as PutItemCommandInput).Item!.jobId!.S;
+      // Filter to jobs PutItem calls only — attestation writes interleave.
+      const jobsCalls = dynamoMock
+        .calls()
+        .filter(
+          (c) =>
+            (c.args[0].input as PutItemCommandInput).TableName === 'test-jobs-table'
+        );
+      expect(jobsCalls).toHaveLength(2);
+      const jobId1 = (jobsCalls[0].args[0].input as PutItemCommandInput).Item!.jobId!.S;
+      const jobId2 = (jobsCalls[1].args[0].input as PutItemCommandInput).Item!.jobId!.S;
 
       expect(jobId1).not.toBe(jobId2);
     });
@@ -821,8 +871,16 @@ describe('uploadRequest Lambda Function - Comprehensive Coverage', () => {
       await handler(event1);
       await handler(event2);
 
-      const s3Key1 = (dynamoMock.call(0).args[0].input as PutItemCommandInput).Item!.s3Key!.S;
-      const s3Key2 = (dynamoMock.call(1).args[0].input as PutItemCommandInput).Item!.s3Key!.S;
+      // Filter to jobs PutItem calls only — attestation writes interleave.
+      const jobsCalls = dynamoMock
+        .calls()
+        .filter(
+          (c) =>
+            (c.args[0].input as PutItemCommandInput).TableName === 'test-jobs-table'
+        );
+      expect(jobsCalls).toHaveLength(2);
+      const s3Key1 = (jobsCalls[0].args[0].input as PutItemCommandInput).Item!.s3Key!.S;
+      const s3Key2 = (jobsCalls[1].args[0].input as PutItemCommandInput).Item!.s3Key!.S;
 
       expect(s3Key1).toContain(userId1);
       expect(s3Key2).toContain(userId2);
@@ -910,6 +968,149 @@ describe('uploadRequest Lambda Function - Comprehensive Coverage', () => {
       });
 
       await handler(event);
+    });
+  });
+
+  // =================================================================
+  // Legal Attestation Write-Path (OpenSpec task 3.8.0 — OWASP A09)
+  // =================================================================
+  describe('Legal Attestation Write-Path', () => {
+    it('persists an attestation record to AttestationsTable with all required fields', async () => {
+      dynamoMock.on(PutItemCommand).resolves({});
+
+      const event = createMockEvent({
+        fileName: 'doc.txt',
+        fileSize: 50000,
+        contentType: 'text/plain',
+      });
+
+      const result = await handler(event);
+      expect(result.statusCode).toBe(200);
+
+      const calls = dynamoMock.calls();
+      // First DDB call must hit the attestations table.
+      expect(calls).toHaveLength(2);
+      const attestCall = calls[0].args[0].input as PutItemCommandInput;
+      expect(attestCall.TableName).toBe('test-attestations-table');
+      expect(attestCall.Item!.attestationId!.S).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+      );
+      expect(attestCall.Item!.userId!.S).toBe('test-user-123');
+      expect(attestCall.Item!.documentHash!.S).toMatch(/^[a-f0-9]{64}$/);
+      expect(attestCall.Item!.attestationVersion!.S).toBeDefined();
+      expect(attestCall.Item!.ipAddress!.S).toBe('127.0.0.1');
+      expect(attestCall.Item!.userAgent!.S).toBeDefined();
+      expect(attestCall.Item!.acceptedAt!.S).toBeDefined();
+      expect(attestCall.Item!.ttl!.N).toBeDefined();
+      expect(attestCall.Item!.acceptedClauses!.M!.acceptCopyrightOwnership!.BOOL).toBe(true);
+      expect(attestCall.Item!.acceptedClauses!.M!.acceptTranslationRights!.BOOL).toBe(true);
+      expect(attestCall.Item!.acceptedClauses!.M!.acceptLiabilityTerms!.BOOL).toBe(true);
+    });
+
+    it('rejects upload with 400 when legalAttestation block is omitted', async () => {
+      dynamoMock.on(PutItemCommand).resolves({});
+
+      // Explicit null suppresses the auto-injected default in createMockEvent.
+      const event = createMockEvent({
+        fileName: 'doc.txt',
+        fileSize: 50000,
+        contentType: 'text/plain',
+        legalAttestation: null,
+      });
+
+      const result = await handler(event);
+      expect(result.statusCode).toBe(400);
+      const body = JSON.parse(result.body);
+      expect(body.message).toMatch(/Legal attestation is required/i);
+      // No DynamoDB writes when attestation validation fails.
+      expect(dynamoMock.calls()).toHaveLength(0);
+    });
+
+    it('rejects upload with 400 when any required clause is false', async () => {
+      const event = createMockEvent({
+        fileName: 'doc.txt',
+        fileSize: 50000,
+        contentType: 'text/plain',
+        legalAttestation: {
+          acceptCopyrightOwnership: true,
+          acceptTranslationRights: false, // user did not accept this clause
+          acceptLiabilityTerms: true,
+        },
+      });
+
+      const result = await handler(event);
+      expect(result.statusCode).toBe(400);
+      expect(dynamoMock.calls()).toHaveLength(0);
+    });
+
+    it('returns 500 AttestationPersistFailure when DynamoDB write fails (no silent drop)', async () => {
+      // Attestation PutItem fails; jobs PutItem would succeed if reached.
+      let callCount = 0;
+      dynamoMock.on(PutItemCommand).callsFake(() => {
+        callCount += 1;
+        if (callCount === 1) {
+          return Promise.reject(new Error('AccessDenied'));
+        }
+        return Promise.resolve({});
+      });
+
+      const event = createMockEvent({
+        fileName: 'doc.txt',
+        fileSize: 50000,
+        contentType: 'text/plain',
+      });
+
+      const result = await handler(event);
+      expect(result.statusCode).toBe(500);
+      const body = JSON.parse(result.body);
+      expect(body.message).toMatch(/AttestationPersistFailure/);
+
+      // Critically: the handler must NOT proceed to issue a presigned URL
+      // or write the jobs record after attestation failure.
+      expect(mockGetSignedUrl).not.toHaveBeenCalled();
+      const jobsCalls = dynamoMock
+        .calls()
+        .filter(
+          (c) =>
+            (c.args[0].input as PutItemCommandInput).TableName === 'test-jobs-table'
+        );
+      expect(jobsCalls).toHaveLength(0);
+    });
+
+    it('captures sourceIp and User-Agent from the API Gateway event', async () => {
+      dynamoMock.on(PutItemCommand).resolves({});
+
+      const event = createMockEvent({
+        fileName: 'doc.txt',
+        fileSize: 50000,
+        contentType: 'text/plain',
+      });
+      event.requestContext.identity.sourceIp = '203.0.113.42';
+      event.headers['User-Agent'] = 'Mozilla/5.0 (Test Browser)';
+
+      const result = await handler(event);
+      expect(result.statusCode).toBe(200);
+
+      const attestCall = dynamoMock.call(0).args[0].input as PutItemCommandInput;
+      expect(attestCall.Item!.ipAddress!.S).toBe('203.0.113.42');
+      expect(attestCall.Item!.userAgent!.S).toBe('Mozilla/5.0 (Test Browser)');
+    });
+
+    it('uses the lowercase user-agent header when User-Agent is absent', async () => {
+      dynamoMock.on(PutItemCommand).resolves({});
+
+      const event = createMockEvent({
+        fileName: 'doc.txt',
+        fileSize: 50000,
+        contentType: 'text/plain',
+      });
+      event.headers['user-agent'] = 'curl/8.0';
+
+      const result = await handler(event);
+      expect(result.statusCode).toBe(200);
+
+      const attestCall = dynamoMock.call(0).args[0].input as PutItemCommandInput;
+      expect(attestCall.Item!.userAgent!.S).toBe('curl/8.0');
     });
   });
 });

--- a/backend/functions/jobs/uploadRequest.ts
+++ b/backend/functions/jobs/uploadRequest.ts
@@ -12,10 +12,17 @@ import {
   PresignedUrlRequest,
   PresignedUrlResponse,
   fileValidationSchema,
+  legalAttestationPayloadSchema,
+  LegalAttestationPayload,
 } from '@lfmt/shared-types';
 import { createSuccessResponse, createErrorResponse } from '../shared/api-response';
 import Logger from '../shared/logger';
 import { getRequiredEnv } from '../shared/env';
+import {
+  AttestationWriteError,
+  buildAttestationRecord,
+  writeAttestation,
+} from '../shared/attestationWriter';
 import { randomUUID } from 'crypto';
 
 const logger = new Logger('lfmt-upload-request');
@@ -48,7 +55,9 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     }
 
     // Parse and validate request body
-    const body = JSON.parse(event.body || '{}') as PresignedUrlRequest;
+    const body = JSON.parse(event.body || '{}') as PresignedUrlRequest & {
+      legalAttestation?: LegalAttestationPayload;
+    };
 
     const validationResult = fileValidationSchema.safeParse({
       filename: body.fileName,
@@ -71,12 +80,80 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
       );
     }
 
+    // Legal attestation is REQUIRED — silently dropping consent is the
+    // OWASP A09 bug we are explicitly closing in OpenSpec task 3.8.0.
+    const attestationParse = legalAttestationPayloadSchema.safeParse(
+      body.legalAttestation
+    );
+    if (!attestationParse.success) {
+      logger.warn('Legal attestation validation failed', {
+        requestId,
+        errors: attestationParse.error.flatten().fieldErrors,
+      });
+      return createErrorResponse(
+        400,
+        'Legal attestation is required: you must accept all three clauses to upload.',
+        requestId,
+        attestationParse.error.flatten().fieldErrors,
+        requestOrigin
+      );
+    }
+    const attestationPayload = attestationParse.data;
+
     const { filename, fileSize, contentType } = validationResult.data;
 
     // Generate unique IDs for file and job
     const fileId = randomUUID();
     const jobId = randomUUID();
     const s3Key = `uploads/${userId}/${fileId}/${filename}`;
+
+    // Persist the legal attestation BEFORE issuing the presigned URL
+    // or creating the job record. If this write fails, the entire upload
+    // request fails — we never let a user upload without an audit-trail
+    // entry. (OWASP A09 — Security Logging & Monitoring Failures.)
+    const sourceIp =
+      event.requestContext.identity?.sourceIp || 'unknown';
+    const userAgent =
+      event.headers['User-Agent'] ||
+      event.headers['user-agent'] ||
+      event.requestContext.identity?.userAgent ||
+      'unknown';
+
+    try {
+      const attestationRecord = buildAttestationRecord({
+        userId,
+        jobId,
+        documentId: fileId,
+        filename,
+        fileSize,
+        contentType,
+        ipAddress: sourceIp,
+        userAgent,
+        acceptedClauses: {
+          acceptCopyrightOwnership: attestationPayload.acceptCopyrightOwnership,
+          acceptTranslationRights: attestationPayload.acceptTranslationRights,
+          acceptLiabilityTerms: attestationPayload.acceptLiabilityTerms,
+        },
+      });
+      await writeAttestation(attestationRecord, { logger });
+    } catch (err) {
+      const isWriteError = err instanceof AttestationWriteError;
+      logger.error('Refusing upload — attestation persistence failed', {
+        requestId,
+        userId,
+        jobId,
+        fileId,
+        errorCode: isWriteError ? err.code : 'UnknownAttestationError',
+        error: err instanceof Error ? err.message : 'Unknown error',
+      });
+      return createErrorResponse(
+        500,
+        'AttestationPersistFailure: legal attestation could not be recorded; upload aborted.',
+        requestId,
+        undefined,
+        requestOrigin
+      );
+    }
 
     logger.info('Generating presigned URL', {
       requestId,

--- a/backend/functions/shared/__tests__/attestationWriter.test.ts
+++ b/backend/functions/shared/__tests__/attestationWriter.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Unit tests for `attestationWriter` (OpenSpec task 3.8.0 — OWASP A09).
+ *
+ * Verifies:
+ *   - Document hash is deterministic and SHA-256 hex.
+ *   - Built records carry every required field, attestation version, ttl.
+ *   - DynamoDB PutItem is invoked with the correct table + marshalled item.
+ *   - Failures throw a typed `AttestationWriteError` (no silent drop).
+ *   - Schema-invalid records are refused before hitting DynamoDB.
+ */
+
+import {
+  DynamoDBClient,
+  PutItemCommand,
+  PutItemCommandInput,
+} from '@aws-sdk/client-dynamodb';
+import { mockClient } from 'aws-sdk-client-mock';
+import { unmarshall } from '@aws-sdk/util-dynamodb';
+import { ATTESTATION_VERSION } from '@lfmt/shared-types';
+
+import {
+  AttestationWriteError,
+  buildAttestationRecord,
+  computeDocumentHash,
+  writeAttestation,
+} from '../attestationWriter';
+
+// Silence the Logger module so tests focus on behavior, not logs.
+jest.mock('../logger', () => {
+  return jest.fn().mockImplementation(() => ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }));
+});
+
+const ddbMock = mockClient(DynamoDBClient);
+
+const VALID_INPUT = {
+  userId: 'cognito-user-sub-abc',
+  jobId: '22222222-2222-4222-8222-222222222222',
+  documentId: '33333333-3333-4333-8333-333333333333',
+  filename: 'doc.txt',
+  fileSize: 1024,
+  contentType: 'text/plain',
+  ipAddress: '127.0.0.1',
+  userAgent: 'integration-test',
+  acceptedClauses: {
+    acceptCopyrightOwnership: true,
+    acceptTranslationRights: true,
+    acceptLiabilityTerms: true,
+  },
+};
+
+describe('computeDocumentHash', () => {
+  it('produces a 64-char SHA-256 hex string', () => {
+    const hash = computeDocumentHash({
+      userId: 'u',
+      jobId: 'j',
+      filename: 'f',
+      fileSize: 1,
+      contentType: 'c',
+    });
+    expect(hash).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('is deterministic for identical inputs', () => {
+    const a = computeDocumentHash({
+      userId: 'u',
+      jobId: 'j',
+      filename: 'f',
+      fileSize: 1,
+      contentType: 'c',
+    });
+    const b = computeDocumentHash({
+      userId: 'u',
+      jobId: 'j',
+      filename: 'f',
+      fileSize: 1,
+      contentType: 'c',
+    });
+    expect(a).toBe(b);
+  });
+
+  it('differs when any field changes', () => {
+    const base = computeDocumentHash({
+      userId: 'u',
+      jobId: 'j',
+      filename: 'f',
+      fileSize: 1,
+      contentType: 'c',
+    });
+    expect(
+      computeDocumentHash({
+        userId: 'u',
+        jobId: 'j',
+        filename: 'f',
+        fileSize: 2,
+        contentType: 'c',
+      })
+    ).not.toBe(base);
+  });
+});
+
+describe('buildAttestationRecord', () => {
+  it('populates every required field', () => {
+    const record = buildAttestationRecord(VALID_INPUT);
+    expect(record.attestationId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+    );
+    expect(record.userId).toBe(VALID_INPUT.userId);
+    expect(record.jobId).toBe(VALID_INPUT.jobId);
+    expect(record.documentId).toBe(VALID_INPUT.documentId);
+    expect(record.documentHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(record.attestationVersion).toBe(ATTESTATION_VERSION);
+    expect(record.ipAddress).toBe(VALID_INPUT.ipAddress);
+    expect(record.userAgent).toBe(VALID_INPUT.userAgent);
+    expect(typeof record.acceptedAt).toBe('string');
+    expect(record.createdAt).toBe(record.acceptedAt);
+    expect(record.ttl).toBeGreaterThan(0);
+    expect(record.acceptedClauses).toEqual(VALID_INPUT.acceptedClauses);
+    expect(record.documentMetadata).toEqual({
+      filename: VALID_INPUT.filename,
+      fileSize: VALID_INPUT.fileSize,
+      contentType: VALID_INPUT.contentType,
+    });
+  });
+
+  it('sets ttl to ~7 years from acceptedAt', () => {
+    const acceptedAt = '2024-01-01T00:00:00.000Z';
+    const record = buildAttestationRecord({ ...VALID_INPUT, acceptedAt });
+    const expectedTtl =
+      Math.floor(Date.parse(acceptedAt) / 1000) + 60 * 60 * 24 * 365 * 7;
+    expect(record.ttl).toBe(expectedTtl);
+  });
+
+  it('honours an explicit attestationVersion override', () => {
+    const record = buildAttestationRecord({
+      ...VALID_INPUT,
+      attestationVersion: 'v9.99',
+    });
+    expect(record.attestationVersion).toBe('v9.99');
+  });
+});
+
+describe('writeAttestation', () => {
+  beforeEach(() => {
+    ddbMock.reset();
+    process.env.ATTESTATIONS_TABLE_NAME = 'test-attestations-table';
+  });
+
+  it('writes a marshalled item to the configured table', async () => {
+    ddbMock.on(PutItemCommand).resolves({});
+    const record = buildAttestationRecord(VALID_INPUT);
+
+    await writeAttestation(record);
+
+    expect(ddbMock.calls()).toHaveLength(1);
+    const input = ddbMock.call(0).args[0].input as PutItemCommandInput;
+    expect(input.TableName).toBe('test-attestations-table');
+    expect(input.ConditionExpression).toContain('attribute_not_exists');
+    const persisted = unmarshall(input.Item!);
+    expect(persisted.attestationId).toBe(record.attestationId);
+    expect(persisted.documentHash).toBe(record.documentHash);
+    expect(persisted.attestationVersion).toBe(ATTESTATION_VERSION);
+    expect(persisted.acceptedClauses.acceptCopyrightOwnership).toBe(true);
+    expect(persisted.documentMetadata.filename).toBe(VALID_INPUT.filename);
+  });
+
+  it('uses an injected client + tableName when supplied', async () => {
+    const customClient = new DynamoDBClient({});
+    const customMock = mockClient(customClient);
+    customMock.on(PutItemCommand).resolves({});
+    const record = buildAttestationRecord(VALID_INPUT);
+
+    await writeAttestation(record, {
+      dynamoClient: customClient,
+      tableName: 'override-table',
+    });
+
+    expect(customMock.calls()).toHaveLength(1);
+    const input = customMock.call(0).args[0].input as PutItemCommandInput;
+    expect(input.TableName).toBe('override-table');
+  });
+
+  it('throws AttestationWriteError when DynamoDB rejects the write', async () => {
+    ddbMock.on(PutItemCommand).rejects(new Error('AccessDenied'));
+    const record = buildAttestationRecord(VALID_INPUT);
+
+    await expect(writeAttestation(record)).rejects.toBeInstanceOf(
+      AttestationWriteError
+    );
+  });
+
+  it('preserves the original DynamoDB error as the cause', async () => {
+    const original = new Error('ProvisionedThroughputExceeded');
+    ddbMock.on(PutItemCommand).rejects(original);
+    const record = buildAttestationRecord(VALID_INPUT);
+
+    try {
+      await writeAttestation(record);
+      throw new Error('expected writeAttestation to throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(AttestationWriteError);
+      expect((err as AttestationWriteError).code).toBe(
+        'AttestationPersistFailure'
+      );
+      expect((err as AttestationWriteError).cause).toBe(original);
+    }
+  });
+
+  it('refuses to persist a schema-invalid record (no DynamoDB call)', async () => {
+    ddbMock.on(PutItemCommand).resolves({});
+    const record = buildAttestationRecord(VALID_INPUT);
+    // Tamper with the record post-build: an obviously-bad documentHash.
+    const tampered = { ...record, documentHash: 'not-a-hash' };
+
+    await expect(writeAttestation(tampered)).rejects.toBeInstanceOf(
+      AttestationWriteError
+    );
+    expect(ddbMock.calls()).toHaveLength(0);
+  });
+
+  it('throws when ATTESTATIONS_TABLE_NAME is missing and no override provided', async () => {
+    delete process.env.ATTESTATIONS_TABLE_NAME;
+    const record = buildAttestationRecord(VALID_INPUT);
+    await expect(writeAttestation(record)).rejects.toThrow(
+      /ATTESTATIONS_TABLE_NAME/
+    );
+  });
+});

--- a/backend/functions/shared/attestationWriter.ts
+++ b/backend/functions/shared/attestationWriter.ts
@@ -1,0 +1,197 @@
+/**
+ * Legal Attestation Writer (OpenSpec task 3.8.0 — OWASP A09 closure)
+ *
+ * Persists user consent records to the `AttestationsTable` DynamoDB table.
+ * Every successful upload-request MUST produce one of these records — if the
+ * write fails the caller is required to surface a 5xx and abort the upload
+ * (silently dropping consent is the bug we're fixing).
+ *
+ * SECURITY:
+ *   - Caller is responsible for validating the inbound payload BEFORE
+ *     constructing the record (use `legalAttestationPayloadSchema` from
+ *     `@lfmt/shared-types`).
+ *   - This module does NOT swallow errors. Failure throws
+ *     `AttestationWriteError`, which the handler converts to a 500.
+ */
+
+import { createHash, randomUUID } from 'crypto';
+import {
+  DynamoDBClient,
+  PutItemCommand,
+  PutItemCommandOutput,
+} from '@aws-sdk/client-dynamodb';
+import { marshall } from '@aws-sdk/util-dynamodb';
+import {
+  ATTESTATION_VERSION,
+  LegalAttestationRecord,
+  legalAttestationRecordSchema,
+} from '@lfmt/shared-types';
+import Logger from './logger';
+import { getRequiredEnv } from './env';
+
+/** 7 years in seconds — DMCA-style retention window. */
+const SEVEN_YEARS_SECONDS = 60 * 60 * 24 * 365 * 7;
+
+/**
+ * Typed error so callers can distinguish attestation persistence failures
+ * from other DynamoDB errors and respond with a clear 500 body.
+ */
+export class AttestationWriteError extends Error {
+  public readonly code = 'AttestationPersistFailure';
+  public readonly cause?: unknown;
+
+  constructor(message: string, cause?: unknown) {
+    super(message);
+    this.name = 'AttestationWriteError';
+    this.cause = cause;
+  }
+}
+
+/** Inputs for building a record from a verified upload request. */
+export interface BuildAttestationInput {
+  userId: string;
+  jobId: string;
+  documentId: string;
+  filename: string;
+  fileSize: number;
+  contentType: string;
+  ipAddress: string;
+  userAgent: string;
+  acceptedClauses: {
+    acceptCopyrightOwnership: boolean;
+    acceptTranslationRights: boolean;
+    acceptLiabilityTerms: boolean;
+  };
+  /** Optional — defaults to `new Date().toISOString()`. */
+  acceptedAt?: string;
+  /** Optional — defaults to `ATTESTATION_VERSION`. */
+  attestationVersion?: string;
+}
+
+/**
+ * Build the deterministic upload-intent fingerprint.
+ *
+ * The actual S3 object hash isn't available at presigned-URL time (the
+ * bytes haven't arrived yet); we instead hash the upload-intent metadata
+ * so the audit trail can be cross-referenced with the eventual S3 object
+ * by the same five fields, even if the user later abandons the upload.
+ */
+export function computeDocumentHash(input: {
+  userId: string;
+  jobId: string;
+  filename: string;
+  fileSize: number;
+  contentType: string;
+}): string {
+  const canonical = `${input.userId}:${input.jobId}:${input.filename}:${input.fileSize}:${input.contentType}`;
+  return createHash('sha256').update(canonical).digest('hex');
+}
+
+/** Build a fully-populated `LegalAttestationRecord` ready for persistence. */
+export function buildAttestationRecord(
+  input: BuildAttestationInput
+): LegalAttestationRecord {
+  const acceptedAt = input.acceptedAt ?? new Date().toISOString();
+  const ttl = Math.floor(Date.parse(acceptedAt) / 1000) + SEVEN_YEARS_SECONDS;
+
+  const record: LegalAttestationRecord = {
+    attestationId: randomUUID(),
+    userId: input.userId,
+    jobId: input.jobId,
+    documentId: input.documentId,
+    documentHash: computeDocumentHash({
+      userId: input.userId,
+      jobId: input.jobId,
+      filename: input.filename,
+      fileSize: input.fileSize,
+      contentType: input.contentType,
+    }),
+    attestationVersion: input.attestationVersion ?? ATTESTATION_VERSION,
+    ipAddress: input.ipAddress,
+    userAgent: input.userAgent,
+    acceptedAt,
+    createdAt: acceptedAt,
+    ttl,
+    acceptedClauses: {
+      acceptCopyrightOwnership: input.acceptedClauses.acceptCopyrightOwnership,
+      acceptTranslationRights: input.acceptedClauses.acceptTranslationRights,
+      acceptLiabilityTerms: input.acceptedClauses.acceptLiabilityTerms,
+    },
+    documentMetadata: {
+      filename: input.filename,
+      fileSize: input.fileSize,
+      contentType: input.contentType,
+    },
+  };
+
+  // Validate before write — defensive: ensures we never persist a record
+  // that the schema would reject on read-back.
+  const parsed = legalAttestationRecordSchema.safeParse(record);
+  if (!parsed.success) {
+    throw new AttestationWriteError(
+      `Built attestation record failed schema validation: ${parsed.error.message}`
+    );
+  }
+
+  return record;
+}
+
+/**
+ * Persist a `LegalAttestationRecord` to DynamoDB.
+ *
+ * THROWS `AttestationWriteError` on any DynamoDB failure — caller MUST
+ * propagate as a 500 response and abort the upload flow.
+ */
+export async function writeAttestation(
+  record: LegalAttestationRecord,
+  options: {
+    dynamoClient?: DynamoDBClient;
+    tableName?: string;
+    logger?: Logger;
+  } = {}
+): Promise<PutItemCommandOutput> {
+  const logger = options.logger ?? new Logger('lfmt-attestation-writer');
+  const dynamoClient = options.dynamoClient ?? new DynamoDBClient({});
+  const tableName = options.tableName ?? getRequiredEnv('ATTESTATIONS_TABLE_NAME');
+
+  // Defensive re-validation: protects against callers bypassing
+  // `buildAttestationRecord`.
+  const parsed = legalAttestationRecordSchema.safeParse(record);
+  if (!parsed.success) {
+    throw new AttestationWriteError(
+      `Refusing to persist invalid attestation record: ${parsed.error.message}`
+    );
+  }
+
+  const command = new PutItemCommand({
+    TableName: tableName,
+    Item: marshall(record, { removeUndefinedValues: true }),
+    // Idempotency guard — never silently overwrite an existing record
+    // for the same attestationId (which is a uuid, so collisions imply
+    // a programming error worth surfacing).
+    ConditionExpression: 'attribute_not_exists(attestationId)',
+  });
+
+  try {
+    const result = await dynamoClient.send(command);
+    logger.info('Legal attestation persisted', {
+      attestationId: record.attestationId,
+      jobId: record.jobId,
+      userId: record.userId,
+      documentId: record.documentId,
+      attestationVersion: record.attestationVersion,
+    });
+    return result;
+  } catch (err) {
+    logger.error('Failed to persist legal attestation', {
+      attestationId: record.attestationId,
+      jobId: record.jobId,
+      userId: record.userId,
+      error: err instanceof Error ? err.message : 'Unknown error',
+    });
+    throw new AttestationWriteError(
+      'Failed to persist legal attestation record',
+      err
+    );
+  }
+}

--- a/backend/infrastructure/lib/__tests__/infrastructure.test.ts
+++ b/backend/infrastructure/lib/__tests__/infrastructure.test.ts
@@ -421,6 +421,31 @@ describe('LFMT Infrastructure Stack', () => {
       );
     });
 
+    test('Upload Lambda role can PutItem on the AttestationsTable (OpenSpec 3.8.0)', () => {
+      // Validates OWASP A09 (Security Logging & Monitoring Failures) closure:
+      // the upload-request Lambda MUST be able to write attestation records
+      // before issuing a presigned URL. The UploadDynamoDBPolicy explicitly
+      // grants PutItem on both the jobs table and the attestations table.
+      template.hasResourceProperties('AWS::IAM::ManagedPolicy', {
+        PolicyDocument: {
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Effect: 'Allow',
+              Action: Match.arrayWith(['dynamodb:PutItem']),
+              Resource: Match.arrayWith([
+                // The attestations table ARN appears as a Fn::GetAtt reference.
+                Match.objectLike({
+                  'Fn::GetAtt': Match.arrayWith([
+                    Match.stringLikeRegexp('^AttestationsTable'),
+                  ]),
+                }),
+              ]),
+            }),
+          ]),
+        },
+      });
+    });
+
     test('No dynamodb:Scan in any IAM policy', () => {
       // Security verification: Ensure dangerous DynamoDB Scan action is not granted
       // This prevents expensive table scans and enforces query-based access patterns

--- a/demo/FAQ.md
+++ b/demo/FAQ.md
@@ -938,13 +938,16 @@ We've identified **five key risks** with mitigation strategies:
 
 We know exactly what's unfinished. This list is the fundable gap — presented up front as transparency, not excuse:
 
-- **Legal Attestation write path (HIGH)** — frontend collects user consent but no backend Lambda persists it to the provisioned `AttestationsTable`. OWASP A09 — Security Logging & Monitoring Failures. Fix in progress (~4h engineering; tracked in `openspec/changes/production-foundation` task 3.8.0).
 - **CSP `'unsafe-inline'` retained** — MUI/Emotion require runtime inline styles. Other CSP directives (`object-src`, `base-uri`, `form-action`, `frame-ancestors`, `upgrade-insecure-requests`) are hardened, and `'unsafe-eval'` was removed from `script-src` (Issue #133 Part 2). Nonce-based injection pipeline (Part 1) is the remaining work to drop `'unsafe-inline'` — tracked in the #133 Part 1 follow-up.
 - **9 JWT refresh tests skipped** — `axios.spy` can't intercept `axios.create()` instances. Tracked in #132 for migration to `axios-mock-adapter`.
 - **Side-by-Side Viewer feature-flag-gated** — backend source-retrieval API not yet built. UI exists and works end-to-end once the API lands (PR #125 merged the viewer; API is the remaining piece).
 - **No custom domain** — running on AWS default API Gateway + CloudFront domains.
 - **No customer billing plumbing** — paid-tier switch would need metering, invoicing, pricing tiers.
 - **No SOC2 / formal security posture** — POC stage; production readiness is a Phase 11+ scope.
+
+**Recently Resolved**:
+
+- ✅ **Legal Attestation write path** (was HIGH — OWASP A09) — backend now persists every user consent to `AttestationsTable` before issuing a presigned URL; failures return `500 AttestationPersistFailure` and abort the upload (no silent drop). OpenSpec task 3.8.0 closed in branch `feat/legal-attestation-write-path`.
 
 **Framing for investors**: Every item above has a named owner, a tracking issue, and an effort estimate. We're not discovering these in production — we've catalogued them, bounded the work, and priced the fix. That's the difference between a POC with unknowns and a POC ready for seed funding.
 

--- a/demo/PHASE-10-STATUS.md
+++ b/demo/PHASE-10-STATUS.md
@@ -98,7 +98,7 @@ Seven PRs merged into `main` have materially hardened the POC since the original
 
 - **#132** — Rewrite `api.refresh` tests using `axios-mock-adapter` (un-skips 9 JWT refresh tests; P1).
 - **#133** — Harden CSP: nonce-based injection + re-evaluate `'unsafe-eval'` (P1). Part 2 (`'unsafe-eval'` removed from `script-src`) shipped; Part 1 (nonce pipeline for `'unsafe-inline'`) tracked in follow-up.
-- **OpenSpec `production-foundation` task 3.8.0** — Legal Attestation write path (OWASP A09 — HIGH; consent silently dropped today).
+- ✅ **OpenSpec `production-foundation` task 3.8.0** — Legal Attestation write path (OWASP A09 — HIGH). RESOLVED in `feat/legal-attestation-write-path`: every consent is persisted to `AttestationsTable` before the presigned URL is issued; failures return `500 AttestationPersistFailure` and abort the upload (no silent drop).
 
 ---
 
@@ -137,10 +137,7 @@ See `demo/DEMO-CONTENT-PLAN.md` for the two-track demo strategy (Track A: live c
 ### Week 1 — Engineering Close-out
 
 1. **Close PR #129** as redundant (PR #126 absorbed its test-mock fixes, merged at `90d926f`).
-2. **Wire Legal Attestation write path** (OpenSpec `production-foundation` task 3.8.0):
-   - Frontend already collects consent; `AttestationsTable` already provisioned; integration tests already pass `legalAttestation` payloads.
-   - Required: Lambda write path in upload / startTranslation flow persisting user identity, document hash, IP, timestamp, attestation version.
-   - Scope: ~4h engineering. **OWASP A09 — HIGH**.
+2. ✅ **Wire Legal Attestation write path** (OpenSpec `production-foundation` task 3.8.0) — DONE in `feat/legal-attestation-write-path`. `uploadRequest.ts` now persists every consent (jobId, userId, documentHash, attestationVersion, ipAddress, userAgent, acceptedAt + accepted clauses + document metadata) to `AttestationsTable` BEFORE issuing a presigned URL. Failures return `500 AttestationPersistFailure` and abort. **OWASP A09 — CLOSED**.
 3. **Confirm free-tier rate-limiter throttling** on `dev`:
    - Validate distributed rate limiter respects 5 RPM / 250K TPM / 25 RPD against real Gemini.
    - Capture CloudWatch evidence of backoff behavior.

--- a/openspec/changes/production-foundation/tasks.md
+++ b/openspec/changes/production-foundation/tasks.md
@@ -443,16 +443,18 @@
 
 ### 3.8 Data Privacy & GDPR Compliance 🆕 **CRITICAL GAP**
 
-- [ ] 3.8.0 **Wire Legal Attestation Write Path** 🆕 **PRE-PROD BLOCKER (OWASP A09)**
-  - **Problem**: Frontend `LegalAttestation.tsx` collects user consent and the `AttestationsTable` is provisioned (`backend/infrastructure/lib/lfmt-infrastructure-stack.ts:188`), but no Lambda persists consent data. Consent is silently dropped → compliance gap + audit-trail failure.
-  - **Required Fields**: `userId`, `jobId`, `documentHash`, `sourceIp`, `attestationVersion`, `acceptedAt` (ISO-8601), `userAgent`.
-  - **Implementation**:
-    - Extend `upload/uploadComplete.ts` (or `translation/startTranslation.ts`) to write an attestation record to `AttestationsTable` at the moment consent is captured.
-    - Add IAM `dynamodb:PutItem` permission on `AttestationsTable` to the appropriate Lambda role.
-    - Add unit + integration tests asserting the write happens and failures surface a 5xx (do NOT silently swallow).
-    - Add a CloudWatch alarm on `AttestationsTable` write errors.
-  - **Severity**: HIGH — do not deploy to production users without this.
-  - **Estimated Time**: 4 hours
+- [x] 3.8.0 **Wire Legal Attestation Write Path** ✅ **RESOLVED (`feat/legal-attestation-write-path`)**
+  - **Problem**: Frontend `LegalAttestation.tsx` collected user consent and the `AttestationsTable` was provisioned (`backend/infrastructure/lib/lfmt-infrastructure-stack.ts:188`), but no Lambda persisted consent data. Consent was silently dropped → compliance gap + audit-trail failure.
+  - **Persisted Fields**: `attestationId`, `userId`, `jobId`, `documentId`, `documentHash` (sha256 hex), `attestationVersion` (`v1.0`), `ipAddress`, `userAgent`, `acceptedAt` (ISO-8601), `createdAt`, `ttl` (7-year retention), `acceptedClauses`, `documentMetadata`.
+  - **Implementation (delivered)**:
+    - Added `LegalAttestationRecord` + `LegalAttestationPayload` schemas in `shared-types/src/legal.ts` (Zod-validated).
+    - New helper `backend/functions/shared/attestationWriter.ts` exports `buildAttestationRecord`, `writeAttestation`, `AttestationWriteError`. Failures throw a typed error; never swallowed.
+    - Wired the write into `backend/functions/jobs/uploadRequest.ts` (the API Gateway handler with access to the user's `legalAttestation` payload + `requestContext.identity.sourceIp` + `User-Agent`). Attestation persists BEFORE the presigned URL is issued; on failure the Lambda returns `500 AttestationPersistFailure` and aborts the upload.
+    - IAM permission already in place: `UploadDynamoDBPolicy` grants `dynamodb:PutItem` on `attestationsTable`. Asserted by a new CDK test.
+    - Tests: 6 new shared-types tests + 11 unit tests for `attestationWriter` + 6 new tests in `uploadRequest.test.ts` covering happy path, missing payload, false-clause rejection, DDB-failure → 500, sourceIp/UA capture. CDK IAM-assertion test added. All 427 backend tests + 39 CDK tests + 17 shared-types tests pass.
+    - **Deferred**: CloudWatch alarm on `AttestationsTable` write errors — small follow-up (5xx + ERROR logs already flow to CloudWatch today).
+  - **Severity**: HIGH — gate cleared.
+  - **Estimated Time**: 4 hours (actual: ~3 hours)
 - [ ] 3.8.1 Implement formal data retention policy
   - **Policy**: User-uploaded documents deleted 30 days after translation (or immediate if user opts in)
   - S3 Lifecycle Policies: Auto-delete from `documentBucket` after 30 days

--- a/shared-types/src/__tests__/types.test.ts
+++ b/shared-types/src/__tests__/types.test.ts
@@ -8,6 +8,9 @@ import {
   createJobRequestSchema,
   attestationRequestSchema,
   ValidationUtils,
+  legalAttestationPayloadSchema,
+  legalAttestationRecordSchema,
+  ATTESTATION_VERSION,
 } from '../index';
 
 describe('Shared Types Validation', () => {
@@ -219,6 +222,96 @@ describe('Shared Types Validation', () => {
       expect(ValidationUtils.isValidWordCount(75000)).toBe(true); // Valid
       expect(ValidationUtils.isValidWordCount(50000)).toBe(false); // Too small
       expect(ValidationUtils.isValidWordCount(500000)).toBe(false); // Too large
+    });
+  });
+
+  describe('Legal Attestation Write-Path Schemas (OpenSpec task 3.8.0)', () => {
+    test('ATTESTATION_VERSION is a stable, non-empty string', () => {
+      expect(typeof ATTESTATION_VERSION).toBe('string');
+      expect(ATTESTATION_VERSION.length).toBeGreaterThan(0);
+    });
+
+    test('legalAttestationPayloadSchema accepts the frontend payload shape', () => {
+      const payload = {
+        acceptCopyrightOwnership: true,
+        acceptTranslationRights: true,
+        acceptLiabilityTerms: true,
+        userIPAddress: '127.0.0.1',
+        userAgent: 'Mozilla/5.0',
+        timestamp: new Date().toISOString(),
+      };
+      expect(legalAttestationPayloadSchema.safeParse(payload).success).toBe(true);
+    });
+
+    test('legalAttestationPayloadSchema rejects payload missing required acceptance', () => {
+      const result = legalAttestationPayloadSchema.safeParse({
+        acceptCopyrightOwnership: false,
+        acceptTranslationRights: true,
+        acceptLiabilityTerms: true,
+      });
+      expect(result.success).toBe(false);
+    });
+
+    test('legalAttestationPayloadSchema rejects payload missing fields entirely', () => {
+      const result = legalAttestationPayloadSchema.safeParse({
+        acceptCopyrightOwnership: true,
+      });
+      expect(result.success).toBe(false);
+    });
+
+    test('legalAttestationRecordSchema validates a complete persisted record', () => {
+      const now = new Date().toISOString();
+      const record = {
+        attestationId: '11111111-1111-4111-8111-111111111111',
+        userId: 'cognito-user-sub-abc',
+        jobId: '22222222-2222-4222-8222-222222222222',
+        documentId: '33333333-3333-4333-8333-333333333333',
+        documentHash: 'a'.repeat(64),
+        attestationVersion: ATTESTATION_VERSION,
+        ipAddress: '127.0.0.1',
+        userAgent: 'integration-test',
+        acceptedAt: now,
+        createdAt: now,
+        ttl: Math.floor(Date.now() / 1000) + 60 * 60 * 24 * 365 * 7,
+        acceptedClauses: {
+          acceptCopyrightOwnership: true as const,
+          acceptTranslationRights: true as const,
+          acceptLiabilityTerms: true as const,
+        },
+        documentMetadata: {
+          filename: 'doc.txt',
+          fileSize: 1024,
+          contentType: 'text/plain',
+        },
+      };
+      expect(legalAttestationRecordSchema.safeParse(record).success).toBe(true);
+    });
+
+    test('legalAttestationRecordSchema rejects malformed documentHash', () => {
+      const record = {
+        attestationId: '11111111-1111-4111-8111-111111111111',
+        userId: 'cognito-user-sub-abc',
+        jobId: '22222222-2222-4222-8222-222222222222',
+        documentId: '33333333-3333-4333-8333-333333333333',
+        documentHash: 'not-a-real-sha256',
+        attestationVersion: ATTESTATION_VERSION,
+        ipAddress: '127.0.0.1',
+        userAgent: 'integration-test',
+        acceptedAt: new Date().toISOString(),
+        createdAt: new Date().toISOString(),
+        ttl: 1,
+        acceptedClauses: {
+          acceptCopyrightOwnership: true as const,
+          acceptTranslationRights: true as const,
+          acceptLiabilityTerms: true as const,
+        },
+        documentMetadata: {
+          filename: 'doc.txt',
+          fileSize: 1024,
+          contentType: 'text/plain',
+        },
+      };
+      expect(legalAttestationRecordSchema.safeParse(record).success).toBe(false);
     });
   });
 });

--- a/shared-types/src/legal.ts
+++ b/shared-types/src/legal.ts
@@ -183,3 +183,143 @@ export const attestationRequestSchema = z.object({
     uploadTimestamp: z.string(),
   }),
 });
+
+// =====================================================================
+// Legal Attestation Write-Path Schema (production write path)
+//
+// What this is:
+//   The minimal, *actually persisted* attestation record stored in the
+//   `AttestationsTable` DynamoDB table when a user submits a document
+//   upload request. Every legitimate upload MUST produce one of these
+//   records — this is the audit-trail entry required for OWASP A09
+//   compliance (Security Logging & Monitoring Failures) and DMCA-style
+//   copyright dispute response.
+//
+// Why a separate schema:
+//   The richer `AttestationRecord` interface above is a forward-looking
+//   blockchain-style design from low-level Doc 6. The write-path schema
+//   below matches what the frontend `LegalAttestation.tsx` actually
+//   collects today plus server-derived fields (IP, UA, hash, version).
+//
+// Persistence model:
+//   - Partition key: `attestationId` (uuid v4, generated server-side)
+//   - Sort key:      `userId`        (Cognito sub)
+//   - GSI:           UserAttestationsIndex   (userId, createdAt)
+//   - GSI:           DocumentAttestationsIndex (documentId, createdAt)
+//   - TTL attribute: `ttl` — populated to 7 years from `createdAt`
+//                    (legal retention requirement).
+// =====================================================================
+
+/**
+ * Current attestation contract version. Bump when the attestation text
+ * shown to users in `LegalAttestationCheckboxes` changes — old records
+ * remain valid under their original version, new records get the new one.
+ */
+export const ATTESTATION_VERSION = 'v1.0';
+
+/**
+ * The shape of the `legalAttestation` block the frontend includes in
+ * the `/jobs/upload` request body. Server validates and persists this.
+ */
+export interface LegalAttestationPayload {
+  acceptCopyrightOwnership: boolean;
+  acceptTranslationRights: boolean;
+  acceptLiabilityTerms: boolean;
+  /**
+   * Optional client-reported metadata. The server overrides these with
+   * authoritative values (`requestContext.identity.sourceIp`,
+   * `headers['User-Agent']`, server timestamp) before persisting.
+   */
+  userIPAddress?: string;
+  userAgent?: string;
+  timestamp?: string;
+}
+
+export const legalAttestationPayloadSchema = z.object({
+  acceptCopyrightOwnership: z
+    .boolean()
+    .refine((val) => val === true, {
+      message: 'acceptCopyrightOwnership must be true to upload',
+    }),
+  acceptTranslationRights: z
+    .boolean()
+    .refine((val) => val === true, {
+      message: 'acceptTranslationRights must be true to upload',
+    }),
+  acceptLiabilityTerms: z
+    .boolean()
+    .refine((val) => val === true, {
+      message: 'acceptLiabilityTerms must be true to upload',
+    }),
+  userIPAddress: z.string().optional(),
+  userAgent: z.string().optional(),
+  timestamp: z.string().optional(),
+});
+
+/**
+ * The persisted DynamoDB record. Server-authoritative fields only.
+ */
+export interface LegalAttestationRecord {
+  /** uuid v4 — partition key */
+  attestationId: string;
+  /** Cognito sub — sort key */
+  userId: string;
+  /** jobId from the upload request (1:1 with this attestation) */
+  jobId: string;
+  /** documentId == fileId from the upload request */
+  documentId: string;
+  /** SHA-256 hex of `${userId}:${jobId}:${filename}:${fileSize}:${contentType}`
+   *  — a deterministic identifier of the upload-intent (the actual S3 object
+   *  hash isn't computed until the bytes arrive; we fingerprint the pre-upload
+   *  metadata so the audit trail can be cross-referenced even if the upload
+   *  is later abandoned). */
+  documentHash: string;
+  /** Attestation contract version (see ATTESTATION_VERSION). */
+  attestationVersion: string;
+  /** Source IP from API Gateway requestContext.identity.sourceIp. */
+  ipAddress: string;
+  /** User-Agent header from the original API request. */
+  userAgent: string;
+  /** Server-side ISO-8601 timestamp of acceptance. */
+  acceptedAt: string;
+  /** ISO-8601 mirror of acceptedAt — used by the GSI sort key. */
+  createdAt: string;
+  /** Unix epoch seconds — DynamoDB TTL attribute (7-year retention). */
+  ttl: number;
+  /** The exact clauses the user accepted, preserved verbatim for audit. */
+  acceptedClauses: {
+    acceptCopyrightOwnership: boolean;
+    acceptTranslationRights: boolean;
+    acceptLiabilityTerms: boolean;
+  };
+  /** Additional context (filename, fileSize, contentType) for forensics. */
+  documentMetadata: {
+    filename: string;
+    fileSize: number;
+    contentType: string;
+  };
+}
+
+export const legalAttestationRecordSchema = z.object({
+  attestationId: z.string().uuid(),
+  userId: z.string().min(1),
+  jobId: z.string().uuid(),
+  documentId: z.string().uuid(),
+  documentHash: z.string().regex(/^[a-f0-9]{64}$/, 'documentHash must be 64-char sha256 hex'),
+  attestationVersion: z.string().min(1),
+  ipAddress: z.string().min(1),
+  userAgent: z.string().min(1),
+  acceptedAt: z.string().datetime(),
+  createdAt: z.string().datetime(),
+  ttl: z.number().int().positive(),
+  acceptedClauses: z.object({
+    acceptCopyrightOwnership: z.literal(true),
+    acceptTranslationRights: z.literal(true),
+    acceptLiabilityTerms: z.literal(true),
+  }),
+  documentMetadata: z.object({
+    filename: z.string().min(1),
+    fileSize: z.number().int().positive(),
+    contentType: z.string().min(1),
+  }),
+});


### PR DESCRIPTION
## Summary

Closes the **silent-drop** gap where the frontend collected user consent for legal attestation but no Lambda persisted the data to the already-provisioned `AttestationsTable`. **OWASP A09 — Security Logging & Monitoring Failures**. OpenSpec task `production-foundation/3.8.0`.

- New `LegalAttestationRecord` schema in `shared-types/src/legal.ts` (Zod-validated, `ATTESTATION_VERSION = 'v1.0'`).
- New `backend/functions/shared/attestationWriter.ts` helper: `buildAttestationRecord`, `writeAttestation`, `AttestationWriteError`. Throws on failure — never silently drops.
- Wired into `backend/functions/jobs/uploadRequest.ts` (the API Gateway `/jobs/upload` Lambda — the only handler with access to `legalAttestation` payload + `requestContext.identity.sourceIp` + `User-Agent` header). Persistence happens **before** the presigned URL is issued; on failure the Lambda returns `500 AttestationPersistFailure` and aborts the upload.
- IAM: `UploadDynamoDBPolicy` already grants `dynamodb:PutItem` on `AttestationsTable`; new CDK assertion test verifies the grant remains intact.
- Docs synced: `PROGRESS.md`, `demo/FAQ.md`, `demo/PHASE-10-STATUS.md`, `openspec/changes/production-foundation/tasks.md`.

## What gets persisted

Per upload, one `AttestationsTable` row containing: `attestationId` (uuid), `userId` (Cognito sub), `jobId`, `documentId`, `documentHash` (sha256 of upload-intent fingerprint), `attestationVersion`, `ipAddress`, `userAgent`, `acceptedAt` (ISO-8601), `createdAt`, `ttl` (7-year retention), `acceptedClauses`, `documentMetadata` (filename / fileSize / contentType).

## Failure mode

If the attestation write fails, the Lambda returns:
- HTTP **500**
- `{"message": "AttestationPersistFailure: legal attestation could not be recorded; upload aborted."}`
- No presigned URL issued.
- No jobs-table row created.
- ERROR-level CloudWatch log with `errorCode: AttestationPersistFailure`.

This is intentional: silent drop is the bug we're fixing — compliance requires that consent and upload happen atomically.

## Tests

| Suite | Result |
| --- | --- |
| `shared-types` | 17 pass (6 new for `LegalAttestationPayload` / `LegalAttestationRecord` schemas) |
| `backend/functions` | 427 pass, 3 skipped (11 new for `attestationWriter`, 6 new for `uploadRequest` write path) |
| `backend/infrastructure` | 39 pass (1 new IAM-grant assertion) |
| `frontend` | 543 pass, 19 skipped (no frontend changes; lint + type-check clean) |

Includes explicit tests for: happy path, missing `legalAttestation` payload, false-clause rejection, DynamoDB write failure → 500, `sourceIp` + `User-Agent` capture (both `User-Agent` and lowercase `user-agent` headers).

## Test plan

- [ ] CI green (lint + tests across all packages).
- [ ] Manual integration smoke (post-merge, against `dev`):
  1. Upload a document via `https://d39xcun7144jgl.cloudfront.net` with the legal attestation checked.
  2. Confirm a row appears in `lfmt-attestations-LfmtPocDev` with the expected fields and a 7-year TTL.
  3. Confirm `ipAddress` and `userAgent` reflect the real client (not `unknown`).
  4. Force a write failure (revoke `dynamodb:PutItem` IAM transiently or kill the table) and confirm the upload returns `500 AttestationPersistFailure` and no jobs row is created.
- [ ] Architect review: write-path placement is `uploadRequest.ts` (the API Gateway entry) — `uploadComplete.ts` runs on S3 PUT events and has no access to the user's consent payload, sourceIp, or User-Agent.

## Deferred (not blocking)

- CloudWatch alarm on `AttestationsTable` write errors — current 5xx + ERROR-level logs already flow to CloudWatch; tracked as P2 follow-up.

## OpenSpec / OMC

- OpenSpec task: `production-foundation/3.8.0` (marked complete).
- OWASP A09 gap closed.
- OMC specialist review + ultra-QA verdicts to follow as PR comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)