### PR TITLE
spec(add-local-mock-api-foundation): formalize MSW-based local E2E foundation

### DIFF
--- a/openspec/changes/add-local-mock-api-foundation/design.md
+++ b/openspec/changes/add-local-mock-api-foundation/design.md
@@ -1,0 +1,681 @@
+# Technical Design: Local Mock API Foundation (MSW-Based)
+
+**Change ID**: `add-local-mock-api-foundation`
+**Author**: Raymond Lei
+**Created**: 2026-04-18
+**Status**: Proposed
+
+---
+
+## Context
+
+LFMT's frontend currently has **partial** local mocking via a custom axios
+interceptor (`frontend/src/utils/mockApi.ts`, 329 LOC) that covers six
+auth endpoints. The translation pipeline — the actual demo surface — is
+not mocked. Any work on upload, attestation, progress polling, history,
+or download requires a deployed dev stack (~3-5 min/iteration) and burns
+Gemini free-tier RPD.
+
+Phase 10B (demo prep) is gated on a fast iteration loop where UI/UX
+bugs can be reproduced and fixed inside a single browser refresh. This
+change introduces an **MSW (Mock Service Worker)**-based foundation that
+covers the full pipeline.
+
+The plan went through two reviewer rounds (v1 → spike → v2 → v3) and a
+45-minute MSW spike. The spike confirmed MSW intercepts all three
+transports the codebase uses today: raw `XMLHttpRequest`, raw
+`axios.put` to S3, and `fetch`. The v1 custom-axios extension cannot
+intercept the S3 PUT (it bypasses the configured axios instance), so
+any future expansion of `mockApi.ts` would still leave upload broken
+locally.
+
+**Constraints**:
+
+- Frontend-only change. No backend modifications.
+- Must coexist with PR #135's `axios-mock-adapter` (different layer,
+  no conflict).
+- Must NOT regress global coverage below 95%.
+- Must NOT ship a mock-mode bundle to CloudFront.
+- Single-person team (Raymond Lei) — simplicity > sophistication.
+
+---
+
+## Goals / Non-Goals
+
+### Goals
+
+1. Provide a local-only E2E loop that exercises the full translation
+   pipeline (upload → translate → progress → download) without AWS.
+2. Share handlers between Vitest (`msw/node`) and the browser SW so
+   contracts cannot drift between layers.
+3. Make it impossible (in three independent ways) for the mock to
+   ship to production.
+4. Keep the POC's existing test conventions intact (closure-scoped
+   in-memory state; clean-slate per page load; no flaky timers).
+5. Document the three mocking primitives the codebase now uses
+   (axios-mock-adapter / msw-node / msw-browser) so future contributors
+   pick the right tool per layer.
+
+### Non-Goals
+
+1. Mocking real Gemini translation logic — the mock returns fake text.
+2. Implementing real chunking — `totalChunks` is a function of file
+   size only.
+3. AWS service emulation (LocalStack, Moto, etc.) — MSW only.
+4. Multi-tab synchronization — clean-slate per page load is the
+   contract.
+5. Production use — see safety rails (Decision 5).
+
+---
+
+## Decisions
+
+### Decision 1: MSW Over Extending the Custom Axios Interceptor
+
+**Reviewer #1 finding**: The v1 plan to extend `mockApi.ts` had three
+defects: wrong endpoint URLs, S3 PUT cannot be intercepted by an axios
+interceptor (it uses raw axios on a different base URL), and the custom
+approach does not give us same-handler-shared-with-Node-tests parity.
+
+**Spike result**: 45-minute MSW spike intercepted all three transports
+the codebase uses today (raw XHR, raw `axios.put`, `fetch`). Strong
+GO.
+
+**Rationale**:
+
+- **Transport-agnostic**: MSW intercepts at the network layer (Service
+  Worker for browser, request interception for Node), so it doesn't
+  care which HTTP client emits the request.
+- **Handler reuse**: Same handler module imported by both
+  `setupWorker(handlers)` (browser) and `setupServer(handlers)` (Node
+  / Vitest). Single source of truth.
+- **Industry standard**: MSW is the de facto standard for React, Vite,
+  and Vitest projects in 2026; well-maintained, large community.
+
+**Alternatives considered**:
+
+- **Extend `mockApi.ts`**: REJECTED by reviewer #1 — cannot intercept
+  S3 PUT.
+- **`axios-mock-adapter` for everything**: REJECTED — does not work in
+  browser without bundling test code; cannot intercept non-axios
+  transports.
+- **LocalStack**: REJECTED — overkill for POC scale; adds Docker
+  dependency to local dev.
+
+**Risks**:
+
+- **Risk**: MSW v2 API differs from v1 (breaking changes around
+  `HttpResponse.error()`).
+- **Mitigation**: Pin exact MSW version; unit-test the network-error
+  shape against `frontend/src/utils/api.ts:230-236` expectations.
+
+---
+
+### Decision 2: Three-Layer Mock Strategy
+
+The codebase will deliberately use **three** mocking primitives — one
+per test layer. Documenting this is non-negotiable to prevent future
+contributors from re-litigating tool choice.
+
+| Layer                           | Environment | Tool                                   | Why                                                                                                        |
+| ------------------------------- | ----------- | -------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| Unit tests (jsdom)              | Vitest      | `axios-mock-adapter` (PR #135 pattern) | Tests the axios interceptor's internal behavior — needs to mock at the axios layer, not the network layer. |
+| Component / integration (jsdom) | Vitest      | `msw/node`                             | Tests real `apiClient` flow against full network stack — same handlers as browser.                         |
+| E2E (browser)                   | Playwright  | MSW Service Worker                     | Full-stack browser flow including the SW path.                                                             |
+
+**Rationale for keeping `axios-mock-adapter`**: PR #135 already rewrote
+the refresh-token tests on `axios-mock-adapter`. Those tests
+**explicitly target axios interceptor internals** — they need to mock
+at the axios layer to assert which interceptor handler runs first. MSW
+intercepts at the network layer (after interceptors run), so it cannot
+test interceptor ordering. Different tool, different layer.
+
+**Documentation**: Both `frontend/LOCAL-TESTING.md` (new) and root
+`CLAUDE.md` will carry the matrix.
+
+---
+
+### Decision 3: Closure-Scoped In-Memory State, Reset via Named Export
+
+**State store**:
+
+```ts
+// inside src/mocks/handlers.ts (closure-scoped — NOT exported)
+const jobs = new Map<string, JobState>();
+
+// the only public escape hatch:
+export function resetState(): void {
+  jobs.clear();
+}
+```
+
+**Why closure-scoped (not module-level export)?**
+
+- Prevents tests from poking the map directly and creating coupling
+  between tests and internal mock structure.
+- Forces all mutations through handlers — same path the real code
+  takes.
+
+**Why `resetState()` and NOT `worker.resetHandlers()`?**
+
+- `worker.resetHandlers()` only re-installs the original handler list;
+  it does NOT clear closure state inside those handlers.
+- This is a well-known MSW footgun. Reviewer #2 specifically called
+  it out.
+- Per-test reset hook calls `resetState()` AND `localStorage.clear()`.
+
+**Why no localStorage / sessionStorage?**
+
+- Clean-slate per page load matches existing unit-test conventions
+  (Vitest jsdom environment is fresh per test).
+- Avoids tab-coordination bugs documented in the "Known footguns"
+  section of `LOCAL-TESTING.md`.
+
+**Risks**:
+
+- **Risk**: Multi-tab `resetState()` from one tab nukes another tab's
+  state.
+- **Mitigation**: Documented as a known footgun. Mock mode is for
+  development; multi-tab is not a supported workflow.
+
+---
+
+### Decision 4: On-Demand Ticking, NO Background Timers, `VITE_MOCK_SPEED` Branching
+
+The progress simulation MUST advance state **only inside the status
+handler**, not on a `setInterval`. Background timers leak across:
+
+- Vitest tests (timer fires after `afterEach` resets state → flaky)
+- Playwright workers (workers run in parallel; one worker's timer
+  affects another's state)
+- Browser tabs (timer ticks even on hidden tabs → wastes CPU)
+
+**Three speed profiles** (selected by `import.meta.env.VITE_MOCK_SPEED`
+at module load):
+
+| Profile     | Default for    | Policy                                                                                                                                 |
+| ----------- | -------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `instant`   | Vitest         | Request-count: status handler advances `completedChunks` by 25% per call → 4 polls to 100%. Deterministic; no `Date.now()` dependency. |
+| `realistic` | `npm run dev`  | Wall-clock: `progress = min(1, (Date.now() - startTs) / 10_000)`. ~10s end-to-end.                                                     |
+| `slow`      | Demo rehearsal | Wall-clock, ~60s. Also force-triggered by reserved filename `__lfmt_mock_slow__.txt`.                                                  |
+
+**Why `instant` for tests?**
+
+- Eliminates wall-clock dependency → no `vi.useFakeTimers()` boilerplate.
+- 4 polls × ~50ms request time = ~200ms total → `<30s` E2E spec target
+  is comfortably met.
+
+---
+
+### Decision 5: Defense-in-Depth Production Safety (Three Layers)
+
+The mock MUST NEVER reach production. Three independent layers:
+
+#### Layer 1 — Visual: Non-Dismissible UI Banner
+
+- Renders only when `import.meta.env.VITE_MOCK_API === 'true'`.
+- Non-dismissible (no close button — anything dismissible WILL be
+  dismissed by accident).
+- `z-index: 2147483647` (MAX_SAFE_INTEGER for 32-bit) — survives any
+  z-index war from MUI/Modal/Dialog overlays.
+- `role="status"` `aria-live="polite"` — screen readers announce it.
+- High-contrast colors (yellow background, black text) that survive a
+  future dark-mode flag.
+
+#### Layer 2 — Build-Time: Vite Plugin Failure
+
+- Vite plugin throws with a clear error when both
+  `process.env.VITE_MOCK_API === 'true'` AND `command === 'build'`.
+- Regardless of `mode` — covers `npm run build`, `npm run build:dev`,
+  `npm run build:prod`, etc.
+- Error message points the user at `frontend/LOCAL-TESTING.md`.
+
+#### Layer 3 — Post-Build: `closeBundle` Hook Deletes the SW
+
+- Even if a developer somehow bypasses Layer 2, the
+  `mockServiceWorker.js` file in `dist/` is the only way the SW can
+  register at runtime.
+- Vite plugin `closeBundle` hook deletes
+  `dist/mockServiceWorker.js` after every prod build.
+- Acceptance test: `ls dist/mockServiceWorker.js` returns "no such
+  file" after `npm run build`.
+
+**Why three layers?** Reviewer #2: "If a demo team runs the mock in
+front of investors once, the project is done. One layer is one
+mistake."
+
+---
+
+### Decision 6: SW Startup Race Fix — Dynamic Import of `App` After `worker.start()`
+
+**Problem**: `apiClient` (`frontend/src/utils/api.ts`) is module-loaded
+when `App.tsx` is imported. If the SW is still starting up, the first
+few requests bypass the SW and hit the real network.
+
+**Solution**: In `frontend/src/main.tsx`, when `VITE_MOCK_API === 'true'`:
+
+```ts
+// frontend/src/main.tsx (sketch)
+async function bootstrap() {
+  if (import.meta.env.VITE_MOCK_API === 'true') {
+    const { worker } = await import('./mocks/browser');
+    await worker.start();
+  }
+  const { App } = await import('./App'); // <-- dynamic, AFTER worker.start()
+  ReactDOM.createRoot(document.getElementById('root')!).render(<App />);
+}
+bootstrap();
+```
+
+**Why dynamic import (not just `await` before render)?**
+
+- A static `import { App } from './App'` is hoisted by the bundler;
+  `App.tsx` (and transitively `apiClient`) executes at module-load
+  time, BEFORE the `await worker.start()` line runs.
+- Dynamic `import('./App')` defers `App.tsx` evaluation until after
+  the await resolves.
+
+**Risks**:
+
+- **Risk**: Dynamic import adds a network round-trip in dev (HMR).
+- **Mitigation**: Vite's dev server pre-warms; cost is ~10ms,
+  imperceptible.
+
+---
+
+### Decision 7: Error Injection via Reserved Filename Pattern
+
+**Problem**: Per-test API plumbing for error simulation (e.g., a
+`/api/__test/inject-error?code=429` endpoint) leaks test-only surface
+into the mock contract.
+
+**Solution**: Reserved filename pattern. The user uploads a file named
+`__lfmt_mock_error_429__.txt` and the mock recognizes the pattern at
+request time, returning 429.
+
+**Why request-time matching (not sticky state)?**
+
+- Sticky state (e.g., "next translate call returns 429") is global —
+  parallel tests cross-contaminate.
+- Request-time match is purely functional: same input → same output.
+  Re-uploading a clean file recovers normally.
+
+**Reserved patterns** (regex
+`/^__lfmt_mock_(error_(403|413|429|500|network)|slow)__\.txt$/`):
+
+- `__lfmt_mock_error_403__.txt` → upload returns 403
+- `__lfmt_mock_error_413__.txt` → upload returns 413 (file too large)
+- `__lfmt_mock_error_429__.txt` → translate returns 429 (rate limit)
+- `__lfmt_mock_error_500__.txt` → status returns 500
+- `__lfmt_mock_error_network__.txt` → `HttpResponse.error()` (axios
+  sees `!error.response`, matching `frontend/src/utils/api.ts:230-236`)
+- `__lfmt_mock_slow__.txt` → forces 60s wall-clock simulation
+
+**Risks**:
+
+- **Risk**: Real users upload a file matching the pattern.
+- **Mitigation**: Pattern is intentionally absurd
+  (`__lfmt_mock_*__.txt`); collision probability ~0. Pattern is only
+  active when `VITE_MOCK_API === 'true'`.
+
+---
+
+### Decision 8: Coverage Carve-Out for `src/mocks/**`
+
+**Problem (per reviewer #2)**: Adding ~400 LOC of mock handlers to a
+codebase at 95% global coverage drops the new global to ~94.25% (math:
+existing 95% × 19000 LOC + new 0% × 400 LOC ≈ 94.25%). CI breaks on
+the same PR that introduces the foundation.
+
+**Solution**: Add `src/mocks/**` to `vite.config.ts` coverage `exclude`
+array, with an inline comment explaining the carve-out.
+
+**Why is this acceptable?**
+
+- The existing `e2e/**` exclusion sets the precedent: dev-test-infra
+  is not "product code" and should not skew coverage math.
+- The mock handlers are themselves tested (Phase 4.3 and 5.2 tests),
+  but the test coverage is local to the mocks subtree, not part of
+  the global gate.
+- The implementation will set a **local** coverage floor of 85% on
+  `src/mocks/**` files (informational, not gated) to guard against
+  un-tested handler regressions.
+
+**Inline comment**:
+
+```ts
+// vite.config.ts (sketch)
+coverage: {
+  exclude: [
+    // ... existing entries
+    'e2e/**',     // E2E test infra; not product code.
+    'src/mocks/**', // MSW handlers; dev-test-infra (mirrors e2e/**).
+                   // Local coverage floor: 85% (informational).
+  ],
+}
+```
+
+---
+
+### Decision 9: Coordinated `mockApi.ts` Deletion (Atomic, Same PR)
+
+**Problem**: A two-PR sequence (add MSW, then delete `mockApi.ts`)
+produces a window where both mocks are wired and behaviors fight.
+
+**Solution**: One implementation PR. All four edits in a single commit:
+
+1. Delete `frontend/src/utils/mockApi.ts` (329 LOC).
+2. Edit `frontend/src/utils/api.ts:15` — remove
+   `import { installMockApi, isMockApiEnabled } from './mockApi'`.
+3. Edit `frontend/src/utils/api.ts:286-289` — remove the conditional
+   `installMockApi()` block.
+4. Delete the dead `vi.stubEnv('VITE_MOCK_API', 'false')` at
+   `frontend/src/utils/__tests__/api.refresh.test.ts:42`.
+
+**Why is the `api.refresh.test.ts` line dead?** PR #135 rewrote that
+file on `axios-mock-adapter`. The `vi.stubEnv` call was a guard against
+the legacy `installMockApi()` running during the test; with
+`installMockApi` removed, the stub is dead code.
+
+---
+
+### Decision 10: `mockServiceWorker.js` Lifecycle (Commit + `postinstall`)
+
+**Problem**: `npx msw init public/` generates a Service Worker file
+that the runtime must fetch from the server origin. This file cannot
+be loaded from `node_modules` at runtime.
+
+**Solution**:
+
+- Commit `frontend/public/mockServiceWorker.js` to git.
+- Add an `npm postinstall` script that re-runs `npx msw init public/`
+  so the file stays in sync when the MSW package updates (otherwise it
+  would silently fall behind on minor SW protocol changes).
+
+**Risks**:
+
+- **Risk**: `postinstall` adds time to `npm install`.
+- **Mitigation**: `msw init` runs in <1s; trivial.
+
+---
+
+### Decision 11: OMC Review Slate — 4 Specialists (Skip Performance)
+
+**4 specialists** for the implementation PR:
+
+- **code-reviewer**
+- **architect-reviewer**
+- **test-coverage** (test-automator)
+- **security-auditor** (added per reviewer #2 — see below)
+
+**Skip**: **performance-engineer**. Confirmed N/A: the in-memory
+`Map<jobId, JobState>` grows monotonically until page reload (clean-
+slate per load). Worst case ~100 KB across a long-running session is
+not a performance concern.
+
+**Why security-auditor?** The current `mockApi.ts:88-207` logs PII
+(emails, mock passwords) to `console.log`. Without an explicit security
+audit on the MSW implementation, that anti-pattern would propagate to
+the new handlers — and any future logging added "for debugging" could
+also leak PII to the browser console.
+
+---
+
+## Technical Architecture
+
+### Repository Layout (post-implementation)
+
+```
+frontend/
+├── public/
+│   └── mockServiceWorker.js          # NEW (auto-gen, committed)
+├── src/
+│   ├── main.tsx                      # MODIFIED (async dynamic import)
+│   ├── App.tsx                       # MODIFIED (mounts MockModeBanner)
+│   ├── components/
+│   │   └── common/
+│   │       └── MockModeBanner.tsx    # NEW
+│   ├── mocks/                        # NEW
+│   │   ├── handlers.ts               # All MSW handlers + state store + resetState()
+│   │   ├── browser.ts                # setupWorker(handlers) for browser
+│   │   ├── server.ts                 # setupServer(handlers) for msw/node
+│   │   └── __tests__/
+│   │       └── handlers.test.ts      # Unit tests for handlers + simulation
+│   └── utils/
+│       ├── api.ts                    # MODIFIED (remove mockApi imports)
+│       ├── mockApi.ts                # DELETED
+│       └── __tests__/
+│           └── api.refresh.test.ts   # MODIFIED (remove dead stubEnv)
+├── e2e/
+│   ├── tests/
+│   │   └── local/
+│   │       └── full-flow-mock.spec.ts  # NEW
+│   ├── utils/
+│   │   └── apiCall.ts                # NEW (page.evaluate fetch helper)
+│   └── fixtures/
+│       └── mockReset.ts              # NEW (beforeEach reset hook)
+├── vite.config.ts                    # MODIFIED (build guard, closeBundle, coverage exclude)
+├── playwright.config.ts              # MODIFIED (VITE_MOCK_API=true webServer env)
+├── setupTests.ts                     # MODIFIED (msw/node server lifecycle)
+├── package.json                      # MODIFIED (msw devDep, postinstall)
+└── LOCAL-TESTING.md                  # NEW
+```
+
+### State Machine (Job Lifecycle)
+
+```
+                          ┌────────────────┐
+                          │   no entry     │
+                          └────────┬───────┘
+                                   │ POST /jobs/upload
+                                   ▼
+                          ┌────────────────┐
+                          │   uploaded     │
+                          └────────┬───────┘
+                                   │ PUT /__mock-s3/:jobId
+                                   │ POST /jobs/:jobId/translate
+                                   ▼
+                          ┌────────────────┐
+                          │  translating   │◀──┐
+                          └────────┬───────┘   │
+                                   │           │ GET status
+                                   │           │ (advances completedChunks
+                                   │           │  per VITE_MOCK_SPEED policy)
+                                   │ progress  │
+                                   │  reaches  │
+                                   │   100%    │
+                                   ▼           │
+                          ┌────────────────┐   │
+                          │   completed    │───┘ (subsequent polls return same state)
+                          └────────────────┘
+                                   │ GET /translation/:jobId/download
+                                   ▼
+                            (returns text)
+```
+
+`failed` is reachable only via reserved-filename error injection
+(`__lfmt_mock_error_500__.txt` etc.).
+
+### Build Pipeline Guards (Defense in Depth)
+
+```
+                      ┌──────────────────────────────┐
+                      │  Developer runs `vite build` │
+                      └──────────────┬───────────────┘
+                                     │
+                  ┌──────────────────▼──────────────────┐
+                  │ Layer 2: Vite plugin checks env     │
+                  │ VITE_MOCK_API === 'true'?           │
+                  └──────────────────┬──────────────────┘
+                                     │
+                          yes ───────┼─────── no
+                          │                   │
+                          ▼                   ▼
+                ┌───────────────┐   ┌─────────────────────┐
+                │ THROW with    │   │ Continue build      │
+                │ clear error   │   └──────────┬──────────┘
+                └───────────────┘              │
+                                               ▼
+                                  ┌─────────────────────────┐
+                                  │ Vite emits dist/        │
+                                  │ (incl. mockServiceWorker│
+                                  │  .js if present in      │
+                                  │  public/)               │
+                                  └────────────┬────────────┘
+                                               │
+                                               ▼
+                                  ┌─────────────────────────┐
+                                  │ Layer 3: closeBundle    │
+                                  │ hook deletes            │
+                                  │ dist/mockServiceWorker  │
+                                  │ .js                     │
+                                  └────────────┬────────────┘
+                                               │
+                                               ▼
+                                          (clean dist/)
+```
+
+(Layer 1 — UI banner — is runtime, not build-time; it operates
+independently in the dev server.)
+
+---
+
+## Risks / Trade-offs
+
+### Risk 1: MSW v2 Network Error Shape Mismatch
+
+**Impact**: High — refresh-flow tests that depend on `!error.response`
+would silently break.
+**Probability**: Low (MSW v2 is mature).
+**Trade-off**: Modern MSW API vs. backward compat with v1.
+**Mitigation**: Unit test in `handlers.test.ts` asserts that the
+`__lfmt_mock_error_network__.txt` path produces an axios error
+satisfying `!error.response` — matching the contract at
+`frontend/src/utils/api.ts:230-236`.
+
+### Risk 2: Playwright `page.request.*` Bypassing the SW
+
+**Impact**: Medium — silent test failures or accidental real-network
+hits.
+**Probability**: Medium (idiomatic Playwright code uses
+`page.request.*`).
+**Mitigation**: `frontend/e2e/utils/apiCall.ts` helper wraps
+`page.evaluate(() => fetch(...))`. `LOCAL-TESTING.md` documents the
+footgun explicitly.
+
+### Risk 3: Coverage Exclusion Becomes a Hiding Place
+
+**Impact**: Low — un-tested handlers regress silently.
+**Probability**: Low (per-PR review catches new handler files).
+**Mitigation**: Local-floor convention (85%) on `src/mocks/**` —
+informational, not gated, but visible in coverage reports. Documented
+in `LOCAL-TESTING.md`.
+
+### Risk 4: `mockServiceWorker.js` Drift After MSW Package Bump
+
+**Impact**: Medium — silent SW protocol mismatch, mock requests fail
+intermittently.
+**Probability**: Low (MSW updates are infrequent).
+**Mitigation**: `npm postinstall` re-runs `msw init` so the committed
+file stays in sync. The file is human-reviewable in PRs.
+
+### Risk 5: Multi-Tab `resetState()` Cross-Pollution
+
+**Impact**: Low — confusing dev experience, not a bug.
+**Probability**: Low (mock mode is single-developer use).
+**Mitigation**: Documented as "Known footgun" in `LOCAL-TESTING.md`.
+
+---
+
+## Migration Plan
+
+### Phase 1: Spec PR (this PR)
+
+- Open this spec PR for team review.
+- Two reviewer rounds already complete (v1 → v2 → v3).
+- Approval required before any implementation.
+
+### Phase 2: Implementation PR (separate, post-approval)
+
+- Single PR; phases 1-10 from `tasks.md` execute sequentially.
+- OMC review (4 specialists) iterates on the implementation.
+- Ultra QA + Playwright MCP testing on the demo flow.
+- Merge after all gates green.
+
+### Phase 3: Adoption (post-merge)
+
+- Update Phase 10B demo-prep tickets to reference the new local loop.
+- Frontend contributors stop deploying for UI-only iteration.
+
+### Rollback
+
+- Single revert restores `frontend/src/utils/mockApi.ts` and the
+  legacy `installMockApi()` wiring.
+- Vitest + E2E suites should pass against the reverted state with no
+  further work (the implementation PR is the only consumer of the
+  new mocks).
+
+---
+
+## Open Questions
+
+None — the v3 plan resolved all 9 reviewer findings. The only items
+left for the implementation PR are mechanical (port handlers, write
+tests, write docs).
+
+---
+
+## References
+
+### Source Files (with line citations)
+
+- **`frontend/src/utils/mockApi.ts`** — current 329 LOC custom axios
+  interceptor (auth-only); to be deleted.
+  - Lines `88-207`: PII logging anti-pattern (motivates security-
+    auditor in OMC slate).
+- **`frontend/src/utils/api.ts`**
+  - Line `15`: `import { installMockApi, isMockApiEnabled } from './mockApi'`
+    — to be removed.
+  - Lines `230-236`: error-shape contract that MSW network-error mock
+    must satisfy.
+  - Lines `286-289`: conditional `installMockApi()` install — to be
+    removed.
+  - Line `304`: end-of-file marker (for context).
+- **`frontend/src/main.tsx`** — needs async dynamic-import refactor
+  for SW startup ordering.
+- **`frontend/vite.config.ts`**
+  - Lines `78-89`: existing coverage configuration; add `src/mocks/**`
+    to `exclude` array.
+  - Line `181`: end-of-file marker; add Vite plugin (build guard +
+    `closeBundle` hook).
+- **`frontend/src/services/translationService.ts`**
+  - Lines `20-38`: upload request shape #1.
+  - Lines `119, 170, 186, 201, 214`: other endpoint call sites the
+    mock must serve.
+- **`frontend/src/services/uploadService.ts`**
+  - Lines `59, 81`: alternative upload request shape; mock must
+    handle both.
+- **`frontend/src/utils/__tests__/api.refresh.test.ts`**
+  - Line `42`: dead `vi.stubEnv('VITE_MOCK_API', 'false')` — to be
+    deleted.
+
+### Related PRs
+
+- **PR #135** — `axios-mock-adapter` for unit refresh tests (merged).
+  Coexists with this change; different layer.
+- **PR #134** — Phase 10B demo-prep plan (merged). This change is a
+  prerequisite for the fast-iteration loop Phase 10B requires.
+
+### Industry References
+
+- **MSW Documentation** — https://mswjs.io/docs/
+  - Service Worker startup: https://mswjs.io/docs/api/setup-worker/start
+  - `msw/node` for tests: https://mswjs.io/docs/api/setup-server
+- **Vite Plugin Hooks** — `closeBundle` for post-build cleanup.
+- **WCAG 2.1** — `role="status"` `aria-live="polite"` for the mock-
+  mode banner accessibility.
+
+---
+
+**Status**: Proposed — Awaiting Team Approval
+**Next Steps**: Team review → Approve → Open implementation PR

--- a/openspec/changes/add-local-mock-api-foundation/proposal.md
+++ b/openspec/changes/add-local-mock-api-foundation/proposal.md
@@ -1,0 +1,458 @@
+# Proposal: Local Mock API Foundation (MSW-Based)
+
+**Change ID**: `add-local-mock-api-foundation`
+**Status**: Proposed
+**Priority**: P1 - Demo-Prep Prerequisite (blocks Phase 10B fast-iteration loop)
+**Owner**: Raymond Lei (Project Owner)
+**Created**: 2026-04-18
+**Target Completion**: 2026-04-20 (~2 days from approval, sequencing into Phase 10B)
+
+---
+
+## Why
+
+Phase 10B (demo prep) requires a tight UI/UX iteration loop where bugs in the
+translation workflow can be reproduced, fixed, and verified inside a single
+browser refresh — without round-tripping through AWS deploys (~3-5 min each)
+or burning Gemini free-tier quota. Today, that loop does not exist:
+
+- **`frontend/src/utils/mockApi.ts`** is a 329-line custom axios interceptor
+  that mocks **auth endpoints only** (register/login/refresh/logout/me/forgot-
+  password). The translation pipeline — the actual product surface area we
+  need to polish for demo — has zero local mocking. Touching upload, the
+  attestation flow, progress polling, history, or download requires a
+  deployed dev stack.
+- An MSW (Mock Service Worker) spike (45 min, recorded) proved MSW intercepts
+  all three transports the codebase uses today: raw `XMLHttpRequest` (upload
+  progress), raw `axios.put` to S3 presigned URLs, and `fetch`. The custom-
+  axios approach cannot intercept the S3 PUT (it bypasses the axios
+  instance), so any future expansion of `mockApi.ts` would still leave the
+  upload step broken locally.
+- Two independent reviewer rounds (v1 → spike → v2 → v3) converged on MSW
+  as the right primitive and produced 9 concrete blockers/should-adds that
+  this v3 proposal incorporates.
+
+**Business risk if we skip this**:
+
+- Phase 10B UI polish PRs cannot be reviewed end-to-end without a deploy,
+  multiplying cycle time by ~10x.
+- Demo-day reproductions of investor-facing bugs depend on Gemini free-tier
+  RPD (25/day) and a healthy dev stack.
+- New frontend contributors cannot run the product locally — onboarding
+  requires AWS credentials.
+
+This change establishes the **minimum local-E2E foundation** required for the
+demo-prep workstream and for sustainable frontend iteration thereafter.
+
+---
+
+## What Changes
+
+This change is **dev-tooling infrastructure**. It introduces no product
+capability; it does not modify the deployed contract. There are no spec
+deltas (see "Impact" below).
+
+### 1. Migrate Existing Auth Handlers to MSW (8 handlers, including 2 NEW)
+
+Port the six handlers currently in `frontend/src/utils/mockApi.ts` to MSW
+HTTP handlers, and add two that the current mock does not implement:
+
+- `POST /auth/register` — port from current mockApi
+- `POST /auth/login` — port from current mockApi
+- `POST /auth/refresh` — port from current mockApi
+- `POST /auth/logout` — port from current mockApi
+- `GET /auth/me` — port from current mockApi
+- `POST /auth/forgot-password` — port from current mockApi
+- `POST /auth/verify-email` — **NEW** (currently unmocked)
+- `POST /auth/reset-password` — **NEW** (currently unmocked)
+
+All handlers SHALL emit responses that conform to `@lfmt/shared-types` so
+the mock and the real backend cannot drift on the wire shape.
+
+### 2. Add Translation-Pipeline Handlers (6 handlers, including S3 PUT)
+
+The translation pipeline is the demo surface. These handlers close the
+gap between auth-only mocking and full E2E:
+
+- `POST /jobs/upload` — returns a presigned URL pointing at the **same-
+  origin** path `http://localhost:3000/__mock-s3/<jobId>` (so the browser
+  treats it as same-origin and the SW intercepts it). Handles both
+  request shapes used today: `translationService.uploadDocument`
+  (`frontend/src/services/translationService.ts:20-38`) and
+  `uploadService` (`frontend/src/services/uploadService.ts:59,81`).
+- `PUT /__mock-s3/:jobId` — intercepts the S3 PUT, captures the bytes,
+  returns 200. Spike-validated to work for raw `XMLHttpRequest`, raw
+  `axios.put`, and `fetch`.
+- `POST /jobs/:jobId/translate` — kicks off translation in mock state.
+- `GET /jobs/:jobId/translation-status` — returns ticking progress
+  0% → 100% per the simulation policy in §4.
+- `GET /jobs` — returns job history.
+- `GET /translation/:jobId/download` — returns the simulated translated
+  text.
+
+### 3. In-Memory Mock State Store (Closure-Scoped, Clean-Slate per Load)
+
+A single closure-scoped `Map<jobId, JobState>` lives inside
+`src/mocks/handlers.ts` and is the source of truth for job lifecycle:
+
+```ts
+type JobState = {
+  jobId: string;
+  status: 'uploaded' | 'translating' | 'completed' | 'failed';
+  totalChunks: number;
+  completedChunks: number;
+  failedChunks: number;
+  fileName: string;
+  sourceLang: string;
+  targetLang: string;
+  createdAt: string;
+  completedAt?: string;
+};
+```
+
+- **No localStorage** — page reload = clean slate (matches existing
+  unit-test conventions; avoids tab-coordination bugs).
+- **No background timers** — state machine ticks **on-demand** inside the
+  status handler. This is critical: `setInterval`-based simulations leak
+  across Vitest tests and Playwright workers.
+- **Reset only via named export**: `export function resetState(): void` —
+  consumed by Playwright `beforeEach` hooks. NOT `worker.resetHandlers()`,
+  which only re-installs handlers but does not clear closure state.
+
+### 4. State Machine Timing — `VITE_MOCK_SPEED` Branching
+
+Three speed profiles, selected by env var at startup:
+
+- **`VITE_MOCK_SPEED=instant`** (default for Vitest): request-count-driven.
+  Status handler advances `completedChunks` by 25% per call → 4 polls to
+  100%. Deterministic; no wall-clock dependency.
+- **`VITE_MOCK_SPEED=realistic`** (default for `npm run dev`): wall-clock,
+  ~10s end-to-end. Uses the timestamp captured at translate-start; status
+  handler computes `min(1, (now - start)/10s)`.
+- **`VITE_MOCK_SPEED=slow`** (demo rehearsal): wall-clock, ~60s — used
+  when rehearsing the live demo cadence.
+
+### 5. Error Injection via Reserved Filename Pattern
+
+To exercise error paths without per-test API plumbing, file names matching
+the reserved pattern trigger specific simulated errors at request time
+(no sticky state — match is recomputed per request, so re-uploading a
+"clean" file recovers normally):
+
+- `__lfmt_mock_error_403__.txt` → upload returns 403
+- `__lfmt_mock_error_413__.txt` → upload returns 413 (file too large)
+- `__lfmt_mock_error_429__.txt` → translate returns 429 (rate-limited)
+- `__lfmt_mock_error_500__.txt` → status returns 500
+- `__lfmt_mock_error_network__.txt` → network error (axios `!error.response`)
+- `__lfmt_mock_slow__.txt` → forces 60s wall-clock simulation regardless
+  of `VITE_MOCK_SPEED`
+
+### 6. Test Infrastructure (Vitest + Playwright)
+
+- **Vitest `setupTests.ts`** uses `msw/node` to start a Node-side server
+  with the **same handlers** as the browser. ~20 LOC. Handlers live in
+  `src/mocks/handlers.ts` and are imported by both contexts.
+- **Playwright global setup** launches the dev server with
+  `VITE_MOCK_API=true`. Standardize on
+  `await page.evaluate(() => fetch('/api/...').then(r => r.json()))`
+  for any in-test API call — `page.request.*` bypasses the SW and will
+  silently hit the real network (or fail). Document this footgun in
+  `LOCAL-TESTING.md`.
+- **New spec**: `frontend/e2e/tests/local/full-flow-mock.spec.ts`
+  exercises register → login → upload → attestation → translate → 100%
+  → history → download — entirely in-browser. Target: <30s wall-clock.
+
+### 7. Safety Rails (Defense in Depth — Mock Must Never Reach Production)
+
+- **UI banner**: visible whenever `VITE_MOCK_API=true`.
+  - Non-dismissible (no close button).
+  - `z-index: 2147483647` (MAX_SAFE_INTEGER) — survives any z-index war.
+  - `role="status"` `aria-live="polite"` — accessible.
+  - High-contrast colors that survive a future dark-mode flag.
+- **Vite plugin (build-time error)**: if
+  `VITE_MOCK_API=true && command === 'build'` (regardless of mode), Vite
+  fails the build with a clear error. Prevents shipping a mock-mode bundle
+  to CloudFront.
+- **Vite `closeBundle` hook**: deletes `dist/mockServiceWorker.js` after
+  every prod build. Without this, the SW infrastructure file ships to S3
+  and could be activated by a future page registering it.
+
+### 8. Coverage Carve-Out — `src/mocks/**`
+
+Add `src/mocks/**` to `vite.config.ts` coverage `exclude` list (mirrors
+the existing `e2e/**` exclusion, same dev-test-infra rationale). Inline
+comment SHALL document why.
+
+Without this, the math (per reviewer #2) puts the new global at 94.25%,
+which is below the 95% gate and would break CI on the same PR that
+introduces the foundation.
+
+### 9. Coordinated `mockApi.ts` Deletion (Atomic, Same PR)
+
+The implementation PR (separate from this spec PR) MUST do all of the
+following in a single commit so there is no broken intermediate state:
+
+- Delete `frontend/src/utils/mockApi.ts` (329 LOC).
+- Edit `frontend/src/utils/api.ts:15` — remove
+  `import { installMockApi, isMockApiEnabled } from './mockApi'`.
+- Edit `frontend/src/utils/api.ts:286-289` — remove the conditional
+  `installMockApi()` call.
+- Delete the dead `vi.stubEnv('VITE_MOCK_API', 'false')` at
+  `frontend/src/utils/__tests__/api.refresh.test.ts:42` (PR #135's
+  axios-mock-adapter rewrite already obviates it).
+
+### 10. Documented Three-Layer Mock Strategy
+
+The codebase uses three different mocking primitives — each appropriate for
+a different test layer. Both `frontend/LOCAL-TESTING.md` (new file) and
+the root `CLAUDE.md` SHALL document the matrix:
+
+| Layer                           | Environment | Tool                                   | Purpose                                |
+| ------------------------------- | ----------- | -------------------------------------- | -------------------------------------- |
+| Unit (jsdom)                    | Vitest      | `axios-mock-adapter` (PR #135 pattern) | Axios interceptor internals            |
+| Component / integration (jsdom) | Vitest      | `msw/node`                             | Real `apiClient` flow against handlers |
+| E2E (browser)                   | Playwright  | MSW Service Worker                     | Full-stack browser flow                |
+
+### 11. `mockServiceWorker.js` Lifecycle
+
+`public/mockServiceWorker.js` is auto-generated by `npx msw init public/`.
+It SHALL be committed to git (it is the SW MSW registers; runtime cannot
+fetch it from npm). A `postinstall` npm script SHALL re-run `msw init`
+so the file stays in sync when the MSW package updates.
+
+### 12. Documentation Updates
+
+- **NEW**: `frontend/LOCAL-TESTING.md` (sibling of existing
+  `frontend/DEPLOYMENT.md`, `TESTING_STRATEGY.md`, `VERIFICATION.md`).
+- **UPDATE**: root `CLAUDE.md` — add a "Local Testing" pointer + the
+  three-layer matrix summary.
+- **UPDATE**: `docs/DEPLOYMENT.md` and `docs/FRONTEND-DEPLOYMENT.md` —
+  both currently reference the legacy `mockApi.ts`.
+
+---
+
+## Out of Scope
+
+- **Real Gemini translation** — mock returns simulated translated text.
+- **Real document chunking** — mock fakes `totalChunks` based on file size.
+- **LocalStack or any AWS service emulator** — MSW only.
+- **Production use of mock** — mock SHALL NEVER ship to a deployed env.
+  See §7 safety rails.
+- **Backend code changes** — this is a frontend-only change.
+- **Refactoring existing real backend handlers** — mock contracts mirror
+  current backend; backend is unchanged.
+
+---
+
+## Success Criteria
+
+### Quantitative
+
+1. **Local E2E demo flow** runs entirely in-browser with
+   `VITE_MOCK_API=true npm run dev`: register → login → upload →
+   attestation → translate → progress → history → download. Browser
+   Network tab shows all responses are 200 against `localhost:3000`
+   only — zero requests to the real API.
+2. **`e2e/tests/local/full-flow-mock.spec.ts`** passes against
+   `npm run dev` in <30s wall-clock.
+3. **Vitest unit tests** consume the same MSW handlers via `msw/node`
+   (handlers shared between browser + node contexts — no duplication).
+4. **`VITE_MOCK_API=true vite build`** fails with a clear error message.
+5. **Coverage** on new MSW handler files ≥ 85% (per existing local
+   convention); global stays ≥ 95% (verified via the `src/mocks/**`
+   exclusion).
+6. **Production bundle size diff vs current main**: ≤ 0 KB.
+7. **`dist/mockServiceWorker.js`** does NOT exist after `vite build`.
+
+### Qualitative
+
+8. **UI banner** visible whenever mock mode is on; non-dismissible;
+   survives dark mode.
+9. **Three-layer mock strategy** documented in both
+   `frontend/LOCAL-TESTING.md` and root `CLAUDE.md`.
+10. **Network tab** during local demo shows zero AWS hosts.
+
+### Acceptance Tests
+
+1. **Build guard**: `VITE_MOCK_API=true npm run build` exits non-zero
+   with a clear error.
+2. **SW cleanup**: After `npm run build`, `ls dist/mockServiceWorker.js`
+   returns "no such file".
+3. **Banner visibility**: `VITE_MOCK_API=true npm run dev` → banner
+   visible on every route.
+4. **Error injection**: Upload `__lfmt_mock_error_429__.txt` → translate
+   step shows the rate-limit error path.
+5. **State reset**: Playwright `beforeEach` calls `resetState()` →
+   subsequent test starts with empty job list.
+
+---
+
+## Risks & Mitigation
+
+| Risk                                                                                                              | Mitigation                                                                                                                                                                                                     |
+| ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Mock + real backend drift on response shapes                                                                      | All handlers type-check against `@lfmt/shared-types`; types lead the contract.                                                                                                                                 |
+| Playwright `APIRequestContext` (`page.request.*`) bypasses the SW                                                 | Standardize on `await page.evaluate(() => fetch(...))` helper. Document the footgun in `LOCAL-TESTING.md`.                                                                                                     |
+| Coverage cliff from new code drags global below 95%                                                               | `src/mocks/**` excluded from coverage (matches `e2e/**` precedent — same dev-test-infra rationale, inline comment explains).                                                                                   |
+| Demo team accidentally runs mock in front of investors                                                            | Defense in depth: (a) non-dismissible UI banner; (b) Vite build-time prod-mode failure; (c) `closeBundle` hook deletes `mockServiceWorker.js` from `dist/`.                                                    |
+| Drift between current `mockApi.ts` behavior and new MSW handlers during transition                                | Implementation PR atomically commits MSW handlers AND deletes `mockApi.ts` AND removes its imports — no broken intermediate state. PR #135's axios-mock-adapter test rewrite already de-couples refresh tests. |
+| Concurrent Playwright workers + shared in-memory state cause flaky tests                                          | Per-test `resetState()` named export — NOT `worker.resetHandlers()`, which only clears the handler list, not closure state. Also `localStorage.clear()` in `beforeEach`.                                       |
+| MSW v2 `HttpResponse.error()` doesn't match axios's expected error shape                                          | Unit test asserting `!error.response` matches `frontend/src/utils/api.ts:230-236` expectations.                                                                                                                |
+| Multi-tab `resetState()` nukes another tab's state                                                                | Documented in `LOCAL-TESTING.md` "Known footguns" section.                                                                                                                                                     |
+| HMR + cached SW handlers cause stale behavior                                                                     | Document hard-refresh requirement; `?v=` query param convention for SW cache busting.                                                                                                                          |
+| `mockServiceWorker.js` regenerates inconsistently when MSW package updates                                        | `postinstall` npm script re-runs `msw init`; the generated file is committed to git.                                                                                                                           |
+| SW startup race: module-load `apiClient` fires before `worker.start()` resolves → first requests hit real network | `frontend/src/main.tsx` uses `await import('./App')` AFTER `await worker.start()` — guaranteed-after ordering, not "best-effort".                                                                              |
+
+---
+
+## Dependencies
+
+### External
+
+- **MSW (`msw` npm package)** — version pinned in `package.json`. Adds
+  ~30 KB dev-dep, 0 KB production.
+
+### Internal
+
+- **Blocked by**: nothing — this is foundational dev-tooling.
+- **Blocks**: Phase 10B (demo prep) UI polish PRs that depend on a
+  fast local iteration loop.
+- **Coexists with**: PR #135 (`axios-mock-adapter` for unit refresh
+  tests) — different tool for a different layer; no conflict.
+
+### Workflow Gates
+
+```
+this PR (plan) → plan review (team) → develop with scaffold checkpoint
+  → OMC review (4 specialists: code, architect, test, security)
+  → ultra QA + Playwright MCP testing → implementation PR
+  → team review → merge
+```
+
+### OMC Review Slate (Implementation PR)
+
+**4 specialists** (not the default 5):
+
+- **code-reviewer**
+- **architect-reviewer**
+- **test-coverage** (test-automator)
+- **security-auditor** — added per reviewer #2: current `mockApi.ts`
+  logs PII to `console` at `frontend/src/utils/mockApi.ts:88-207`. The
+  same anti-pattern would propagate to MSW handlers without an explicit
+  security audit.
+
+**Skip**: **performance-engineer** — confirmed N/A. The in-memory `Map`
+of jobs grows monotonically until page reload (clean-slate per load).
+Worst case ~100 KB across a long-running session is not a concern.
+
+---
+
+## Impact
+
+### Affected Specs
+
+**None.** This change introduces dev-tooling only — no product capability
+changes. Per `openspec/AGENTS.md`, dev-tooling-only changes do not require
+spec deltas.
+
+### Affected Code
+
+- **NEW**: `frontend/src/mocks/` directory (handlers, browser SW init,
+  node server init).
+- **NEW**: `frontend/public/mockServiceWorker.js` (auto-generated, committed).
+- **NEW**: `frontend/e2e/tests/local/full-flow-mock.spec.ts`.
+- **NEW**: `frontend/LOCAL-TESTING.md`.
+- **MODIFIED**: `frontend/src/main.tsx:1-9` — async dynamic import of
+  `App` after `worker.start()`.
+- **MODIFIED**: `frontend/vite.config.ts:78-89,181` — coverage exclusion;
+  build-time mock guard plugin; `closeBundle` hook.
+- **MODIFIED**: `frontend/package.json` — add `msw` dev dep, `postinstall`
+  hook, `setupTests` updates.
+- **DELETED**: `frontend/src/utils/mockApi.ts` (329 LOC).
+- **MODIFIED**: `frontend/src/utils/api.ts:15,286-289` — remove
+  `mockApi.ts` import and conditional install.
+- **MODIFIED**: `frontend/src/utils/__tests__/api.refresh.test.ts:42` —
+  remove dead `vi.stubEnv('VITE_MOCK_API', 'false')`.
+- **MODIFIED**: root `CLAUDE.md` — add three-layer mock matrix +
+  pointer to `frontend/LOCAL-TESTING.md`.
+- **MODIFIED**: `docs/DEPLOYMENT.md`, `docs/FRONTEND-DEPLOYMENT.md` —
+  update legacy `mockApi.ts` references.
+
+### Breaking Changes
+
+**NONE for users.** The deployed product is unaffected. For developers,
+the workflow improves: `VITE_MOCK_API=true npm run dev` now exercises
+the whole product, not just auth.
+
+---
+
+## Effort Estimate
+
+**~9-11 hours of agent work end-to-end** (implementation, not this spec):
+
+- Phase 1 (1.5h): MSW install, scaffold, `main.tsx` async refactor,
+  UI banner, Vite build guards, `closeBundle` hook.
+- Phase 2 (1.5h): Auth handler port (8 handlers, including 2 NEW).
+- Phase 3 (2h): Translation handlers + S3 PUT mock (6 handlers).
+- Phase 4 (2h): In-memory state store + on-demand ticking simulation +
+  `VITE_MOCK_SPEED` branching.
+- Phase 5 (0.5h): Error injection (reserved filename pattern).
+- Phase 6 (1h): Vitest `setupServer` + Playwright global setup +
+  `page.evaluate` helper.
+- Phase 7 (0.5h): New full-flow Playwright spec + smoke verification.
+- Phase 8 (0.5h): Coordinated `mockApi.ts` deletion + `api.ts` edits.
+- Phase 9 (1h): `LOCAL-TESTING.md` + `CLAUDE.md` update + DEPLOYMENT
+  docs updates.
+- Phase 10 (1.5h): OMC review iteration cycles + ultra QA + PR
+  submission.
+
+---
+
+## Plan History
+
+- **v1** (custom axios extension) — REWORK NEEDED per reviewer #1: wrong
+  endpoint URLs, S3 PUT bypass not addressed, MSW recommended.
+- **45-min MSW spike** — STRONG GO MSW: proven all three transports
+  intercepted (XHR, raw `axios.put`, `fetch`).
+- **v2** (MSW-based) — REWORK NEEDED per reviewer #2: 6 blockers + 3
+  should-adds (coverage cliff, prod SW leak, `mockApi.ts` import cleanup,
+  state-machine timing, reset semantics, SW startup race, reserved-
+  filename collision risk, security-auditor scope, three-layer mock
+  strategy docs).
+- **v3** (this proposal) — all 9 reviewer findings incorporated.
+
+---
+
+## Approval Gate
+
+**Do not start implementation until this proposal is reviewed and
+approved by the team.** The spec PR is ready for review immediately —
+v3 has already been through 2 review rounds.
+
+Implementation will land via a **separate** PR after approval.
+
+---
+
+## References
+
+- **`frontend/src/utils/mockApi.ts`** — current 329 LOC custom axios
+  interceptor (auth-only) being replaced.
+- **`frontend/src/utils/api.ts:15,230-236,286-289`** — import + error-
+  shape contract + conditional install to remove.
+- **`frontend/src/main.tsx`** — needs async dynamic import refactor for
+  SW startup ordering.
+- **`frontend/vite.config.ts:78-89,181`** — coverage exclusion + build
+  guard + `closeBundle` hook.
+- **`frontend/src/services/translationService.ts:20-38,119,170,186,201,214`** —
+  request shape consumed by `POST /jobs/upload` mock.
+- **`frontend/src/services/uploadService.ts:59,81`** — alternative
+  upload request shape; mock SHALL handle both.
+- **`frontend/src/utils/__tests__/api.refresh.test.ts:42`** — dead
+  `vi.stubEnv` to delete.
+- **PR #135** — `axios-mock-adapter` for unit refresh tests; coexists.
+- **PR #134** — Phase 10B demo-prep plan that depends on this foundation.
+
+---
+
+**Status**: Proposed — Awaiting Team Approval
+**Next Steps**: Team review → Approve → Open implementation PR

--- a/openspec/changes/add-local-mock-api-foundation/specs/local-dev-tooling/spec.md
+++ b/openspec/changes/add-local-mock-api-foundation/specs/local-dev-tooling/spec.md
@@ -1,0 +1,284 @@
+# Spec Delta: Local Dev Tooling
+
+This is a new capability being added to the LFMT frontend dev tooling. It
+formalizes the requirements for the MSW-based local mock API foundation
+that enables fully-local end-to-end testing of the translation pipeline
+without depending on deployed AWS infrastructure.
+
+## ADDED Requirements
+
+### Requirement: Local Mock API Service Worker
+
+The system SHALL provide a Mock Service Worker (MSW) infrastructure that
+intercepts network requests in the browser when `VITE_MOCK_API=true`,
+covering both authentication and the full translation pipeline so that a
+developer can run the demo flow end-to-end against `npm run dev` with
+zero AWS dependency.
+
+#### Scenario: Mock mode enabled via environment variable
+
+- **GIVEN** the frontend dev server is started with `VITE_MOCK_API=true npm run dev`
+- **WHEN** the browser loads the application
+- **THEN** the MSW Service Worker SHALL register before the React app renders
+- **AND** all subsequent network requests to `/auth/*`, `/jobs/*`,
+  `/translation/*`, and the same-origin `/__mock-s3/*` path SHALL be
+  intercepted by the MSW handlers
+- **AND** the browser Network tab SHALL show only `localhost:3000`
+  responses (zero AWS hosts)
+
+#### Scenario: Mock mode disabled in normal dev/prod
+
+- **GIVEN** the frontend is started without `VITE_MOCK_API=true` (or the
+  variable is unset / set to any other value)
+- **WHEN** the browser loads the application
+- **THEN** the MSW Service Worker SHALL NOT register
+- **AND** all network requests SHALL hit the real API endpoints as today
+
+#### Scenario: Service Worker startup race is prevented
+
+- **GIVEN** mock mode is enabled (`VITE_MOCK_API=true`)
+- **WHEN** the application bootstraps
+- **THEN** `frontend/src/main.tsx` SHALL `await worker.start()` BEFORE
+  dynamically importing `App.tsx`
+- **AND** `apiClient` (which is module-loaded via `App.tsx`) SHALL NOT
+  emit any request before the Service Worker is ready
+- **AND** the first request observed in the Network tab SHALL be served
+  by the SW, not by the real network
+
+### Requirement: Coverage of Auth and Translation Pipeline Endpoints
+
+The mock SHALL cover all endpoints exercised by the demo flow so that
+the full register → login → upload → attestation → translate →
+progress → history → download path runs in-browser.
+
+#### Scenario: All auth endpoints respond with shared-types-conformant shapes
+
+- **GIVEN** mock mode is enabled
+- **WHEN** the frontend calls any of `POST /auth/register`,
+  `POST /auth/login`, `POST /auth/refresh`, `POST /auth/logout`,
+  `GET /auth/me`, `POST /auth/forgot-password`,
+  `POST /auth/verify-email`, or `POST /auth/reset-password`
+- **THEN** the MSW handler SHALL return a response whose shape conforms
+  to `@lfmt/shared-types`
+- **AND** mock and real backend SHALL NOT drift on response shape
+
+#### Scenario: Upload presigned URL is same-origin and SW-interceptable
+
+- **GIVEN** mock mode is enabled
+- **WHEN** the frontend calls `POST /jobs/upload`
+- **THEN** the response SHALL include a presigned URL of the form
+  `http://localhost:3000/__mock-s3/<jobId>`
+- **AND** the subsequent S3 PUT request to that URL SHALL be intercepted
+  by the MSW handler regardless of transport (raw `XMLHttpRequest`,
+  `axios.put`, or `fetch`)
+- **AND** the handler SHALL return HTTP 200 with an `ETag` header
+
+#### Scenario: Translation pipeline endpoints are covered
+
+- **GIVEN** mock mode is enabled
+- **WHEN** the frontend calls `POST /jobs/:jobId/translate`,
+  `GET /jobs/:jobId/translation-status`, `GET /jobs`, or
+  `GET /translation/:jobId/download`
+- **THEN** each endpoint SHALL be served by an MSW handler that updates
+  / reads the in-memory `JobState` store
+
+### Requirement: In-Memory State Store With Per-Test Reset
+
+The mock SHALL maintain an in-memory job-state store that is closure-
+scoped (not exported), reset only via a named `resetState()` export,
+and clean-slate per page load (no persistence).
+
+#### Scenario: State persists within a page load
+
+- **GIVEN** mock mode is enabled and a job has been uploaded
+- **WHEN** the frontend polls the status endpoint
+- **THEN** the same `JobState` SHALL be returned across polls within
+  the same page load
+
+#### Scenario: State is cleared on page reload
+
+- **GIVEN** mock mode is enabled and one or more jobs exist
+- **WHEN** the user reloads the page
+- **THEN** the in-memory `JobState` map SHALL be empty
+- **AND** `GET /jobs` SHALL return an empty list
+
+#### Scenario: Tests can reset state via the named export
+
+- **GIVEN** Vitest or Playwright is running with mock mode enabled
+- **WHEN** a test imports and calls `resetState()` from
+  `src/mocks/handlers.ts`
+- **THEN** the in-memory `JobState` map SHALL be cleared
+- **AND** subsequent test starts with a fresh state
+
+#### Scenario: `worker.resetHandlers()` does NOT clear closure state
+
+- **GIVEN** the MSW worker is running
+- **WHEN** a test calls `worker.resetHandlers()` instead of `resetState()`
+- **THEN** the handler list SHALL be reset
+- **AND** the closure-scoped `JobState` map SHALL retain its entries
+- **AND** documentation SHALL warn about this footgun in
+  `frontend/LOCAL-TESTING.md`
+
+### Requirement: Configurable Simulation Speed
+
+The mock SHALL support three progression policies for the translation
+status simulation, selected via `VITE_MOCK_SPEED`, with NO background
+timers (state advances on-demand inside the status handler).
+
+#### Scenario: `instant` mode advances per request
+
+- **GIVEN** the dev server or Vitest is started with `VITE_MOCK_SPEED=instant`
+- **WHEN** the status endpoint is polled four times in a row
+- **THEN** `completedChunks` SHALL advance by 25% per call
+- **AND** the fourth poll SHALL return `completedChunks === totalChunks`
+  (status `completed`)
+- **AND** the simulation SHALL NOT depend on `Date.now()`
+
+#### Scenario: `realistic` mode reaches 100% in approximately 10 seconds
+
+- **GIVEN** the dev server is started with `VITE_MOCK_SPEED=realistic`
+- **WHEN** translation starts at time `t0`
+- **THEN** `progress` at time `t` SHALL equal `min(1, (t - t0) / 10000)`
+- **AND** the status endpoint SHALL return `completed` once `t - t0 >= 10000`
+
+#### Scenario: `slow` mode reaches 100% in approximately 60 seconds
+
+- **GIVEN** the dev server is started with `VITE_MOCK_SPEED=slow`
+- **WHEN** translation starts at time `t0`
+- **THEN** `progress` at time `t` SHALL equal `min(1, (t - t0) / 60000)`
+
+### Requirement: Error Injection via Reserved Filename Pattern
+
+The mock SHALL recognize a reserved filename pattern at request time
+to trigger simulated error paths, with no sticky state (re-uploading
+a clean file recovers normally).
+
+#### Scenario: HTTP error codes triggered by filename
+
+- **GIVEN** mock mode is enabled
+- **WHEN** the user uploads a file whose name matches the regex
+  `/^__lfmt_mock_error_(403|413|429|500)__\.txt$/`
+- **THEN** the corresponding endpoint SHALL return that HTTP status
+  (403 → upload, 413 → upload, 429 → translate, 500 → status)
+
+#### Scenario: Network error simulated to match axios contract
+
+- **GIVEN** mock mode is enabled
+- **WHEN** the user uploads `__lfmt_mock_error_network__.txt`
+- **THEN** the relevant handler SHALL return `HttpResponse.error()`
+- **AND** axios SHALL surface the failure with `!error.response` (matching
+  the contract at `frontend/src/utils/api.ts:230-236`)
+
+#### Scenario: Slow simulation triggered by filename
+
+- **GIVEN** mock mode is enabled
+- **WHEN** the user uploads `__lfmt_mock_slow__.txt`
+- **THEN** the simulation SHALL use the 60-second wall-clock policy
+  regardless of `VITE_MOCK_SPEED`
+
+#### Scenario: Re-uploading a clean file recovers
+
+- **GIVEN** the previous upload triggered an error via reserved filename
+- **WHEN** the user uploads a normally-named file
+- **THEN** the upload SHALL succeed
+- **AND** the previous error SHALL NOT affect subsequent requests
+  (no sticky state)
+
+### Requirement: Production Safety Rails (Defense in Depth)
+
+The mock SHALL be impossible to ship to production via three independent
+mechanisms: a non-dismissible UI banner, a build-time Vite plugin
+failure, and a `closeBundle` hook that deletes the SW from `dist/`.
+
+#### Scenario: Non-dismissible UI banner is visible in mock mode
+
+- **GIVEN** the application is running with `VITE_MOCK_API=true`
+- **WHEN** the user navigates to any route
+- **THEN** a banner SHALL be rendered that:
+  - Has `z-index: 2147483647`
+  - Has `role="status"` and `aria-live="polite"`
+  - Has high-contrast colors that survive a future dark-mode flag
+  - Has no close button (cannot be dismissed)
+- **AND** the banner text SHALL clearly indicate mock mode is active
+
+#### Scenario: Mock mode build-time guard blocks production builds
+
+- **GIVEN** the developer attempts `VITE_MOCK_API=true npm run build`
+- **WHEN** Vite runs the configured plugin
+- **THEN** the build SHALL exit with a non-zero status code
+- **AND** the error message SHALL clearly explain that mock mode cannot
+  be built and SHALL point to `frontend/LOCAL-TESTING.md`
+
+#### Scenario: `mockServiceWorker.js` is removed from `dist/` after build
+
+- **GIVEN** a normal production build (`npm run build`, mock mode off)
+- **WHEN** Vite's `closeBundle` hook runs
+- **THEN** `dist/mockServiceWorker.js` SHALL be deleted if it exists
+- **AND** verifying the file's absence (`ls dist/mockServiceWorker.js`)
+  SHALL fail with "no such file"
+
+### Requirement: Shared Handlers Across Vitest and Browser Contexts
+
+The mock handler module SHALL be the single source of truth, consumed
+by both `setupServer` (Node-side, for Vitest) and `setupWorker`
+(browser-side, for dev server and Playwright), so the contract cannot
+drift between test layers.
+
+#### Scenario: Vitest unit tests use the same handlers as the browser
+
+- **GIVEN** the Vitest setup file imports `server` from `src/mocks/server.ts`
+- **WHEN** the test suite runs
+- **THEN** `server.listen({ onUnhandledRequest: 'error' })` SHALL run
+  in `beforeAll`
+- **AND** every handler invoked in tests SHALL be the exact same module
+  imported by `src/mocks/browser.ts`
+- **AND** `server.resetHandlers()` AND `resetState()` SHALL run in
+  `afterEach`
+- **AND** `server.close()` SHALL run in `afterAll`
+
+#### Scenario: Playwright fixtures reset state per test
+
+- **GIVEN** the Playwright suite is configured with `VITE_MOCK_API=true`
+- **WHEN** a test starts
+- **THEN** the per-test fixture SHALL clear `localStorage`
+- **AND** the fixture SHALL invoke `resetState()` so the next test
+  starts with a fresh job map
+
+### Requirement: Three-Layer Mock Strategy Documentation
+
+The repository SHALL document the three-tool mock strategy (axios-mock-
+adapter for unit, msw/node for component/integration, MSW Service Worker
+for E2E) so that future contributors choose the correct primitive per
+layer.
+
+#### Scenario: `frontend/LOCAL-TESTING.md` exists and documents the matrix
+
+- **GIVEN** a developer is reading project documentation
+- **WHEN** they consult `frontend/LOCAL-TESTING.md`
+- **THEN** the document SHALL include a table mapping each test layer
+  (unit / component / E2E) to its mocking tool with rationale
+- **AND** the document SHALL include known footguns
+  (`page.request.*` bypassing the SW, multi-tab `resetState`,
+  HMR + cached SW)
+
+#### Scenario: Root `CLAUDE.md` summarizes the strategy
+
+- **GIVEN** an AI assistant reads `CLAUDE.md`
+- **WHEN** it encounters the "Local Testing" section
+- **THEN** the section SHALL summarize the three-layer matrix
+- **AND** the section SHALL link to `frontend/LOCAL-TESTING.md` for
+  the full reference
+
+## MODIFIED Requirements
+
+None — this is a new capability.
+
+## REMOVED Requirements
+
+None — this is a new capability. The legacy `frontend/src/utils/mockApi.ts`
+is deleted as part of the implementation, but it was never formalized as
+a spec requirement, so there is nothing to mark REMOVED here.
+
+## RENAMED Requirements
+
+None — this is a new capability.

--- a/openspec/changes/add-local-mock-api-foundation/tasks.md
+++ b/openspec/changes/add-local-mock-api-foundation/tasks.md
@@ -1,0 +1,513 @@
+# Implementation Tasks: Local Mock API Foundation (MSW-Based)
+
+**Change ID**: `add-local-mock-api-foundation`
+**Total Estimated Effort**: ~9-11 hours of agent work
+**Phases**: 10 phases, sequential
+
+---
+
+## Phase 1: Foundation — MSW Install, Scaffold, Build Guards (1.5 hours)
+
+### 1.1 Install MSW and generate the Service Worker
+
+- [ ] 1.1.1 Add `msw` to `frontend/package.json` `devDependencies`
+      (pin exact version).
+  - **Estimated Time**: 0.1 hours
+- [ ] 1.1.2 Run `npx msw init public/` to generate
+      `frontend/public/mockServiceWorker.js`.
+  - Commit the generated file (runtime cannot fetch from npm).
+  - **Estimated Time**: 0.1 hours
+- [ ] 1.1.3 Add `postinstall` npm script that re-runs `msw init` so
+      the SW file stays in sync when the MSW package updates.
+  - **Estimated Time**: 0.1 hours
+- **Files Modified**: `frontend/package.json`
+- **Files Created**: `frontend/public/mockServiceWorker.js`
+- **Success Criteria**: `npm install` regenerates the SW file; file is
+  committed to git.
+
+### 1.2 Scaffold `src/mocks/` directory
+
+- [ ] 1.2.1 Create `frontend/src/mocks/handlers.ts` (empty handler array,
+      state-store skeleton, and `resetState()` named export).
+  - **Estimated Time**: 0.2 hours
+- [ ] 1.2.2 Create `frontend/src/mocks/browser.ts` — calls
+      `setupWorker(...handlers)`.
+  - **Estimated Time**: 0.1 hours
+- [ ] 1.2.3 Create `frontend/src/mocks/server.ts` — calls
+      `setupServer(...handlers)` (Node-side, for Vitest).
+  - **Estimated Time**: 0.1 hours
+- **Files Created**: `frontend/src/mocks/{handlers,browser,server}.ts`
+- **Success Criteria**: `tsc --noEmit` passes for the new files.
+
+### 1.3 `main.tsx` async refactor (SW startup race fix)
+
+- [ ] 1.3.1 Refactor `frontend/src/main.tsx` so that, when
+      `import.meta.env.VITE_MOCK_API === 'true'`:
+  - `await import('./mocks/browser').then(({ worker }) => worker.start())`
+  - `await import('./App')` — dynamic, **after** `worker.start()` resolves
+  - Then `ReactDOM.createRoot(...).render(<App />)`
+  - Otherwise: synchronous import + render path (today's behavior).
+  - **Estimated Time**: 0.3 hours
+- **Files Modified**: `frontend/src/main.tsx`
+- **Success Criteria**: With `VITE_MOCK_API=true npm run dev`, browser
+  console shows "MSW worker started" BEFORE the first apiClient request
+  appears in the Network tab.
+
+### 1.4 Mock-mode UI banner
+
+- [ ] 1.4.1 Create `frontend/src/components/common/MockModeBanner.tsx`:
+  - Renders only when `import.meta.env.VITE_MOCK_API === 'true'`.
+  - Non-dismissible (no close button).
+  - `z-index: 2147483647` inline style.
+  - `role="status"` `aria-live="polite"`.
+  - High-contrast colors (yellow/black) that survive dark mode.
+  - Text: "MOCK API MODE — DO NOT DEMO TO USERS".
+  - **Estimated Time**: 0.2 hours
+- [ ] 1.4.2 Mount the banner in `App.tsx` at top-level.
+  - **Estimated Time**: 0.1 hours
+- **Files Created**: `frontend/src/components/common/MockModeBanner.tsx`
+- **Files Modified**: `frontend/src/App.tsx`
+- **Success Criteria**: Banner visible on every route in mock mode;
+  invisible in normal mode.
+
+### 1.5 Vite build-time guard + `closeBundle` SW cleanup
+
+- [ ] 1.5.1 Add a Vite plugin in `frontend/vite.config.ts` that throws
+      with a clear error when `process.env.VITE_MOCK_API === 'true'` and
+      `command === 'build'` (regardless of mode).
+  - **Estimated Time**: 0.15 hours
+- [ ] 1.5.2 Add a `closeBundle` hook that deletes
+      `dist/mockServiceWorker.js` after every prod build.
+  - **Estimated Time**: 0.1 hours
+- **Files Modified**: `frontend/vite.config.ts`
+- **Success Criteria**:
+  - `VITE_MOCK_API=true npm run build` exits non-zero with the guard
+    error.
+  - After `npm run build`, `dist/mockServiceWorker.js` does NOT exist.
+
+---
+
+## Phase 2: Auth Handler Migration (1.5 hours)
+
+Port the 6 handlers from `frontend/src/utils/mockApi.ts` to MSW HTTP
+handlers, plus add the 2 NEW ones. All responses MUST type-check
+against `@lfmt/shared-types`.
+
+### 2.1 Port existing 6 auth handlers
+
+- [ ] 2.1.1 `POST /auth/register` — port from
+      `frontend/src/utils/mockApi.ts`. Same validation rules, same response
+      shape.
+  - **Estimated Time**: 0.15 hours
+- [ ] 2.1.2 `POST /auth/login` — port; reuse the same in-memory user
+      store as register.
+  - **Estimated Time**: 0.15 hours
+- [ ] 2.1.3 `POST /auth/refresh` — port; emit shape that satisfies
+      `frontend/src/utils/api.ts:230-236` error contract on failures.
+  - **Estimated Time**: 0.15 hours
+- [ ] 2.1.4 `POST /auth/logout` — port; clears the mock session.
+  - **Estimated Time**: 0.1 hours
+- [ ] 2.1.5 `GET /auth/me` — port; reads from token-derived mock user.
+  - **Estimated Time**: 0.15 hours
+- [ ] 2.1.6 `POST /auth/forgot-password` — port; returns success even
+      for unknown emails (mirrors real backend).
+  - **Estimated Time**: 0.1 hours
+- **Files Modified**: `frontend/src/mocks/handlers.ts`
+
+### 2.2 Add 2 NEW auth handlers (currently unmocked)
+
+- [ ] 2.2.1 `POST /auth/verify-email` — accept token, return success.
+  - **Estimated Time**: 0.15 hours
+- [ ] 2.2.2 `POST /auth/reset-password` — accept token + new password,
+      return success.
+  - **Estimated Time**: 0.15 hours
+- **Files Modified**: `frontend/src/mocks/handlers.ts`
+
+### 2.3 Wire & smoke-test
+
+- [ ] 2.3.1 Manual smoke: `VITE_MOCK_API=true npm run dev` →
+      register → login → see `/auth/me` succeed in DevTools Network tab.
+  - **Estimated Time**: 0.4 hours
+- **Success Criteria**: All 8 auth endpoints return correct shapes;
+  full register → login → me flow works in-browser with no real
+  backend running.
+
+---
+
+## Phase 3: Translation-Pipeline Handlers + S3 PUT Mock (2 hours)
+
+### 3.1 `POST /jobs/upload` — presigned URL handler
+
+- [ ] 3.1.1 Accept both request shapes used today:
+  - `translationService.uploadDocument`
+    (`frontend/src/services/translationService.ts:20-38`)
+  - `uploadService` upload init (`frontend/src/services/uploadService.ts:59,81`)
+  - **Estimated Time**: 0.3 hours
+- [ ] 3.1.2 Return a presigned URL pointing at same-origin
+      `http://localhost:3000/__mock-s3/<jobId>` so the SW can intercept
+      the subsequent PUT.
+  - **Estimated Time**: 0.1 hours
+- [ ] 3.1.3 Create the `JobState` entry in the in-memory store with
+      `status: 'uploaded'`.
+  - **Estimated Time**: 0.1 hours
+- **Files Modified**: `frontend/src/mocks/handlers.ts`
+
+### 3.2 `PUT /__mock-s3/:jobId` — S3 PUT interceptor
+
+- [ ] 3.2.1 Capture the request body (bytes), return 200 with empty
+      body and `ETag` header (matches real S3).
+  - **Estimated Time**: 0.3 hours
+- [ ] 3.2.2 Verify it intercepts all three transports:
+  - Raw `XMLHttpRequest` (used for upload progress)
+  - Raw `axios.put` (used by `uploadService`)
+  - `fetch` (used by other paths)
+  - Spike-validated, but re-verify post-implementation.
+  - **Estimated Time**: 0.2 hours
+- **Files Modified**: `frontend/src/mocks/handlers.ts`
+
+### 3.3 `POST /jobs/:jobId/translate`
+
+- [ ] 3.3.1 Transition job state to `'translating'`; record start
+      timestamp for wall-clock simulation.
+  - **Estimated Time**: 0.2 hours
+- **Files Modified**: `frontend/src/mocks/handlers.ts`
+
+### 3.4 `GET /jobs/:jobId/translation-status`
+
+- [ ] 3.4.1 Compute progress on-demand per the simulation policy in
+      Phase 4. NO `setInterval`/`setTimeout` in the handler.
+  - **Estimated Time**: 0.3 hours
+- **Files Modified**: `frontend/src/mocks/handlers.ts`
+
+### 3.5 `GET /jobs` — history
+
+- [ ] 3.5.1 Return all `JobState` entries from the in-memory map.
+  - **Estimated Time**: 0.15 hours
+- **Files Modified**: `frontend/src/mocks/handlers.ts`
+
+### 3.6 `GET /translation/:jobId/download`
+
+- [ ] 3.6.1 Return simulated translated text (e.g., uploaded text +
+      marker `\n\n[MOCK TRANSLATION COMPLETE]`).
+  - **Estimated Time**: 0.15 hours
+- **Files Modified**: `frontend/src/mocks/handlers.ts`
+
+### 3.7 Manual smoke
+
+- [ ] 3.7.1 `VITE_MOCK_API=true npm run dev` → upload a small file →
+      click translate → see progress tick → download.
+  - **Estimated Time**: 0.3 hours
+- **Success Criteria**: Full pipeline flows in-browser with all
+  responses against `localhost:3000` only.
+
+---
+
+## Phase 4: State Store + On-Demand Simulation + `VITE_MOCK_SPEED` (2 hours)
+
+### 4.1 `JobState` schema and closure-scoped store
+
+- [ ] 4.1.1 Define the `JobState` type:
+      `{ jobId, status, totalChunks, completedChunks, failedChunks,
+fileName, sourceLang, targetLang, createdAt, completedAt? }`.
+  - **Estimated Time**: 0.2 hours
+- [ ] 4.1.2 Closure-scoped `Map<jobId, JobState>` inside
+      `handlers.ts`. NOT a module-level export; only `resetState()` is
+      exported.
+  - **Estimated Time**: 0.2 hours
+- [ ] 4.1.3 `export function resetState(): void` — clears the map.
+  - **Estimated Time**: 0.1 hours
+- **Files Modified**: `frontend/src/mocks/handlers.ts`
+
+### 4.2 `VITE_MOCK_SPEED` branching
+
+- [ ] 4.2.1 Read `import.meta.env.VITE_MOCK_SPEED` once at module load:
+  - `'instant'` (default for tests / Vitest)
+  - `'realistic'` (default for `npm run dev`)
+  - `'slow'` (demo rehearsal)
+  - **Estimated Time**: 0.2 hours
+- [ ] 4.2.2 Implement the three progression policies:
+  - **instant**: status handler advances `completedChunks` by 25% per
+    call → 4 polls to 100%. No wall-clock dependency.
+  - **realistic**: `min(1, (now - startTs)/10s)` × `totalChunks`.
+  - **slow**: `min(1, (now - startTs)/60s)` × `totalChunks`. Also
+    triggered by reserved filename `__lfmt_mock_slow__.txt`.
+  - **Estimated Time**: 0.7 hours
+- **Files Modified**: `frontend/src/mocks/handlers.ts`
+
+### 4.3 Unit tests for state store + simulation
+
+- [ ] 4.3.1 Vitest: `instant` mode → 4 polls reach 100%.
+  - **Estimated Time**: 0.2 hours
+- [ ] 4.3.2 Vitest: `realistic` mode with mocked `Date.now()` → 10s
+      yields 100%.
+  - **Estimated Time**: 0.2 hours
+- [ ] 4.3.3 Vitest: `resetState()` clears all jobs.
+  - **Estimated Time**: 0.2 hours
+- **Files Created**: `frontend/src/mocks/__tests__/handlers.test.ts`
+- **Success Criteria**: All 3 simulation tests pass; coverage on
+  `handlers.ts` ≥ 85%.
+
+---
+
+## Phase 5: Error Injection (Reserved Filename Pattern) (0.5 hours)
+
+### 5.1 Reserved filename matcher
+
+- [ ] 5.1.1 In `POST /jobs/upload`, `POST /jobs/:jobId/translate`,
+      `GET /jobs/:jobId/translation-status`, check the file name (or job's
+      stored file name) against the regex
+      `/^__lfmt_mock_(error_(403|413|429|500|network)|slow)__\.txt$/`.
+  - Match is recomputed per request — no sticky state. Re-uploading a
+    "clean" file recovers normally.
+  - **Estimated Time**: 0.2 hours
+- [ ] 5.1.2 Map matches to responses:
+  - `__lfmt_mock_error_403__.txt` → upload returns 403
+  - `__lfmt_mock_error_413__.txt` → upload returns 413
+  - `__lfmt_mock_error_429__.txt` → translate returns 429
+  - `__lfmt_mock_error_500__.txt` → status returns 500
+  - `__lfmt_mock_error_network__.txt` → `HttpResponse.error()` (axios
+    sees `!error.response`)
+  - `__lfmt_mock_slow__.txt` → forces 60s wall-clock simulation.
+  - **Estimated Time**: 0.15 hours
+- **Files Modified**: `frontend/src/mocks/handlers.ts`
+
+### 5.2 Tests
+
+- [ ] 5.2.1 Vitest: each error code triggers correctly; especially
+      assert that `network` error matches axios `!error.response` shape
+      per `frontend/src/utils/api.ts:230-236`.
+  - **Estimated Time**: 0.15 hours
+- **Files Modified**: `frontend/src/mocks/__tests__/handlers.test.ts`
+- **Success Criteria**: All error-injection tests pass.
+
+---
+
+## Phase 6: Test Infrastructure (Vitest + Playwright) (1 hour)
+
+### 6.1 Vitest `setupTests.ts` updates
+
+- [ ] 6.1.1 In `frontend/setupTests.ts` (or equivalent), import
+      `server` from `src/mocks/server.ts`. Wire:
+  - `beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))`
+  - `afterEach(() => { server.resetHandlers(); resetState() })`
+  - `afterAll(() => server.close())`
+  - **Estimated Time**: 0.3 hours
+- **Files Modified**: `frontend/setupTests.ts` (or `vitest.config.ts`)
+- **Success Criteria**: Existing Vitest suite passes against `msw/node`
+  with no behavior change.
+
+### 6.2 Playwright global setup
+
+- [ ] 6.2.1 In `frontend/playwright.config.ts` `webServer`, set
+      `VITE_MOCK_API=true VITE_MOCK_SPEED=instant` for the dev server.
+  - **Estimated Time**: 0.2 hours
+- [ ] 6.2.2 Add a helper in `frontend/e2e/utils/`:
+      `apiCall(page, path, init)` → wraps
+      `page.evaluate(({ p, i }) => fetch(p, i).then(r => r.json()), ...)`.
+  - Document why we don't use `page.request.*` (it bypasses the SW).
+  - **Estimated Time**: 0.3 hours
+- **Files Modified**: `frontend/playwright.config.ts`
+- **Files Created**: `frontend/e2e/utils/apiCall.ts`
+- **Success Criteria**: Helper available; existing E2E suite still
+  passes.
+
+### 6.3 `beforeEach` reset hook
+
+- [ ] 6.3.1 Add `test.beforeEach(async ({ page }) => { await
+page.evaluate(() => { localStorage.clear(); }); /* and call
+resetState via test endpoint or reload */ })` pattern in a shared
+      fixture.
+  - **Estimated Time**: 0.2 hours
+- **Files Created**: `frontend/e2e/fixtures/mockReset.ts`
+
+---
+
+## Phase 7: Full-Flow Playwright Spec (0.5 hours)
+
+### 7.1 New spec — register → login → upload → translate → download
+
+- [ ] 7.1.1 Create `frontend/e2e/tests/local/full-flow-mock.spec.ts`:
+  - Navigate to `/register`.
+  - Register a new mock user.
+  - Auto-login (or login if needed).
+  - Upload a small in-memory text file.
+  - Tick legal attestation.
+  - Click translate.
+  - Wait for status to reach 100% (instant mode → ≤1s).
+  - Verify history shows the job.
+  - Click download; verify the response body contains the
+    `[MOCK TRANSLATION COMPLETE]` marker.
+  - **Estimated Time**: 0.5 hours
+- **Files Created**: `frontend/e2e/tests/local/full-flow-mock.spec.ts`
+- **Success Criteria**: Spec passes in <30s wall-clock; Network tab
+  shows zero non-localhost requests.
+
+---
+
+## Phase 8: Coordinated `mockApi.ts` Deletion (0.5 hours)
+
+**ATOMIC**: All edits in this phase land in a single commit so there
+is no broken intermediate state.
+
+### 8.1 Delete legacy mock + remove imports
+
+- [ ] 8.1.1 Delete `frontend/src/utils/mockApi.ts` (329 LOC).
+  - **Estimated Time**: 0.05 hours
+- [ ] 8.1.2 Edit `frontend/src/utils/api.ts:15` — remove
+      `import { installMockApi, isMockApiEnabled } from './mockApi'`.
+  - **Estimated Time**: 0.1 hours
+- [ ] 8.1.3 Edit `frontend/src/utils/api.ts:286-289` — remove the
+      conditional `installMockApi()` call block.
+  - **Estimated Time**: 0.1 hours
+- [ ] 8.1.4 Delete the dead `vi.stubEnv('VITE_MOCK_API', 'false')`
+      at `frontend/src/utils/__tests__/api.refresh.test.ts:42` (PR #135's
+      axios-mock-adapter rewrite already obviates it).
+  - **Estimated Time**: 0.05 hours
+- [ ] 8.1.5 Run `tsc --noEmit` and Vitest suite — both must pass with
+      zero changes to source.
+  - **Estimated Time**: 0.2 hours
+- **Files Deleted**: `frontend/src/utils/mockApi.ts`
+- **Files Modified**: `frontend/src/utils/api.ts`,
+  `frontend/src/utils/__tests__/api.refresh.test.ts`
+- **Success Criteria**: Type-check passes; all tests pass; no dangling
+  references to `mockApi`.
+
+---
+
+## Phase 9: Documentation (1 hour)
+
+### 9.1 `frontend/LOCAL-TESTING.md` (NEW)
+
+- [ ] 9.1.1 Create `frontend/LOCAL-TESTING.md` covering:
+  - Quick start: `VITE_MOCK_API=true npm run dev`.
+  - `VITE_MOCK_SPEED` matrix (`instant` / `realistic` / `slow`).
+  - Reserved filename pattern for error injection.
+  - Three-layer mock strategy table (Unit / Component / E2E).
+  - Known footguns: SW cache, multi-tab `resetState`, hard refresh,
+    `page.request.*` bypassing the SW.
+  - **Estimated Time**: 0.5 hours
+- **Files Created**: `frontend/LOCAL-TESTING.md`
+
+### 9.2 Update root `CLAUDE.md`
+
+- [ ] 9.2.1 Add a "Local Testing" subsection that summarizes the
+      three-layer matrix and links to `frontend/LOCAL-TESTING.md`.
+  - **Estimated Time**: 0.2 hours
+- **Files Modified**: `CLAUDE.md`
+
+### 9.3 Update legacy DEPLOYMENT docs
+
+- [ ] 9.3.1 `docs/DEPLOYMENT.md` — replace any `mockApi.ts` reference
+      with the MSW pointer.
+  - **Estimated Time**: 0.15 hours
+- [ ] 9.3.2 `docs/FRONTEND-DEPLOYMENT.md` — same.
+  - **Estimated Time**: 0.15 hours
+- **Files Modified**: `docs/DEPLOYMENT.md`, `docs/FRONTEND-DEPLOYMENT.md`
+
+---
+
+## Phase 10: OMC Review + Ultra QA + PR Submission (1.5 hours)
+
+### 10.1 Coverage exclusion + verification
+
+- [ ] 10.1.1 Add `'src/mocks/**'` to `vite.config.ts` coverage
+      `exclude` array. Mirror the inline-comment pattern next to the
+      existing `e2e/**` exclusion.
+  - **Estimated Time**: 0.1 hours
+- [ ] 10.1.2 Run `npm run test:coverage` and verify global ≥ 95%.
+  - **Estimated Time**: 0.2 hours
+- **Files Modified**: `frontend/vite.config.ts`
+
+### 10.2 OMC review iteration cycles (4 specialists)
+
+- [ ] 10.2.1 **code-reviewer** — request review.
+  - **Estimated Time**: 0.25 hours
+- [ ] 10.2.2 **architect-reviewer** — request review.
+  - **Estimated Time**: 0.25 hours
+- [ ] 10.2.3 **test-coverage** (test-automator) — request review.
+  - **Estimated Time**: 0.25 hours
+- [ ] 10.2.4 **security-auditor** — request review (current
+      `mockApi.ts:88-207` logs PII to `console`; same anti-pattern would
+      propagate to MSW handlers without explicit security audit).
+  - **Estimated Time**: 0.25 hours
+
+### 10.3 Ultra QA + Playwright MCP testing
+
+- [ ] 10.3.1 Drive the full demo flow via Playwright MCP against
+      `VITE_MOCK_API=true npm run dev`. Confirm Network tab is
+      100% localhost.
+  - **Estimated Time**: 0.2 hours
+
+### 10.4 Final acceptance checks
+
+- [ ] 10.4.1 `VITE_MOCK_API=true vite build` exits non-zero with the
+      guard error.
+  - **Estimated Time**: 0.05 hours
+- [ ] 10.4.2 After `npm run build`, `dist/mockServiceWorker.js` is
+      absent.
+  - **Estimated Time**: 0.05 hours
+- [ ] 10.4.3 Banner visible on every route in mock mode; invisible
+      in normal mode.
+  - **Estimated Time**: 0.05 hours
+- [ ] 10.4.4 `frontend/e2e/tests/local/full-flow-mock.spec.ts`
+      passes in <30s.
+  - **Estimated Time**: 0.05 hours
+
+### 10.5 Implementation PR submission
+
+- [ ] 10.5.1 Open implementation PR (separate from this spec PR).
+      Link to this spec PR in the body.
+  - **Estimated Time**: 0.1 hours
+
+---
+
+## Validation & Sign-off
+
+### Validation Checklist
+
+- [ ] `tsc --noEmit` passes in `frontend/`
+- [ ] `npm run test` passes (Vitest with `msw/node`)
+- [ ] `npm run test:coverage` shows global ≥ 95%
+- [ ] `frontend/e2e/tests/local/full-flow-mock.spec.ts` passes in <30s
+- [ ] `VITE_MOCK_API=true vite build` exits non-zero
+- [ ] `dist/mockServiceWorker.js` absent after prod build
+- [ ] Banner visible in mock mode, absent in normal mode
+- [ ] `mockApi.ts` deleted; no dangling imports
+
+### Acceptance Criteria
+
+1. **Local E2E**: Full demo flow runs in-browser with no real backend.
+2. **Test parity**: Vitest unit tests reuse the same MSW handlers via
+   `msw/node` (handlers shared between browser + node).
+3. **Build safety**: Mock mode cannot ship to production (3 layers of
+   defense).
+4. **Docs**: Three-layer mock strategy documented in
+   `frontend/LOCAL-TESTING.md` and `CLAUDE.md`.
+
+### Sign-off
+
+- [ ] Project Owner approval (this spec PR)
+- [ ] OMC review (4 specialists, on the implementation PR)
+- [ ] Ultra QA + Playwright MCP testing
+- [ ] Implementation PR merged
+
+---
+
+## Notes
+
+### Out-of-Scope (for clarity)
+
+- Real Gemini translation
+- Real document chunking algorithm
+- LocalStack / AWS service emulator
+- Production use of mock
+- Backend code changes
+- Refactoring real backend code
+
+### Rollback Plan
+
+If the implementation PR introduces regressions:
+
+1. Revert the implementation PR (single revert restores `mockApi.ts`).
+2. Re-run Vitest + E2E against `main` to confirm restoration.
+3. Investigate; resubmit with fix.


### PR DESCRIPTION
## Summary

Formalizes a v3-reviewed plan to replace the current 329-LOC, auth-only custom axios `mockApi.ts` with **MSW (Mock Service Worker)** handlers covering the full translation pipeline. Enables fully-local E2E testing with `VITE_MOCK_API=true npm run dev` (zero AWS, sub-100ms feedback per action).

**Spec only — no implementation in this PR.** Implementation lands via a separate PR after team approval.

## Why

Phase 10B (demo prep) requires a tight UI/UX iteration loop where translation-pipeline bugs can be reproduced and fixed inside a single browser refresh — without round-tripping through AWS deploys (~3-5 min each) or burning Gemini free-tier quota (25 RPD). Today, that loop does not exist: `mockApi.ts` covers auth only, and the upload step uses raw `axios.put` to S3 (which an axios interceptor cannot intercept).

A 45-min MSW spike confirmed MSW intercepts all three transports the codebase uses: raw `XMLHttpRequest`, raw `axios.put`, and `fetch`.

This change is the prerequisite for the Phase 10B fast-iteration workstream tracked in PR #134.

## What's in the spec

- `proposal.md` — full proposal mirroring `production-foundation/proposal.md` structure (frontmatter + Why + 12 numbered scope-IN sections + Out of Scope + Success Criteria + Risks matrix + Plan History + Approval Gate + References).
- `tasks.md` — 10 phased implementation tasks with checkboxes and time estimates (~9-11 hours total).
- `design.md` — 11 technical decisions covering MSW architecture, three-layer mock strategy, on-demand state machine + `VITE_MOCK_SPEED` branching, error injection via reserved filename pattern, SW startup race fix (dynamic import of App after `worker.start()`), build pipeline guards (Vite plugin + `closeBundle` hook), coverage carve-out rationale, and coordinated `mockApi.ts` deletion strategy.
- `specs/local-dev-tooling/spec.md` — minimal spec delta (8 ADDED requirements with 24 scenarios) so the change satisfies `openspec validate --strict`. The capability is dev-tooling, not product.

## Plan history

- **v1** (custom axios extension) — REWORK NEEDED per reviewer #1 (wrong endpoint URLs, S3 PUT bypass not addressed, MSW recommended).
- **45-min MSW spike** — STRONG GO MSW (proven all 3 transports intercepted).
- **v2** (MSW-based) — REWORK NEEDED per reviewer #2 (6 blockers + 3 should-adds: coverage cliff, prod SW leak, `mockApi.ts` import cleanup, state-machine timing, reset semantics, SW startup race, reserved-filename collision risk, security-auditor scope, three-layer mock strategy docs).
- **v3** (this proposal) — all 9 reviewer findings incorporated.

## Approval gate

**Do not start implementation until this proposal is approved by the team.** The implementation PR will land separately after approval and OMC review by 4 specialists (code, architect, test-coverage, security-auditor).

## Test plan

- [x] `npx openspec validate add-local-mock-api-foundation --strict` passes (output: `Change 'add-local-mock-api-foundation' is valid`)
- [x] `npx prettier --check 'openspec/changes/add-local-mock-api-foundation/**/*.md'` passes
- [x] Spec files reviewable in directory listing (4 files: `proposal.md` 458 LOC, `tasks.md` 513 LOC, `design.md` 681 LOC, `specs/local-dev-tooling/spec.md` 284 LOC)
- [ ] Team review of the v3 plan

## References

- PR #134 — Phase 10B demo-prep plan that depends on this foundation
- PR #135 — axios-mock-adapter for unit refresh tests (coexists, different layer)
- `frontend/src/utils/mockApi.ts` — 329 LOC custom axios interceptor being replaced
- `openspec/changes/production-foundation/` — convention model this spec mirrors