### PR TITLE
fix(ci): add frontend/** to deploy.yml paths filter (companion to #152, #154)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - 'backend/**'
       - 'shared-types/**'
+      - 'frontend/**'
       - '.github/workflows/deploy.yml'
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## Summary

One-line fix: adds `frontend/**` to `.github/workflows/deploy.yml`'s `push.paths` filter. Frontend-only PRs now auto-trigger the deploy pipeline instead of silently skipping it.

## Why

PR #154's architect-reviewer audit ([comment](https://github.com/leixiaoyu/lfmt-poc/pull/154#issuecomment-4322920423)) flagged the gap as a non-blocking follow-up:

> **Trigger paths.** `deploy.yml` runs on `push to main` with paths filter `[backend/**, shared-types/**, .github/workflows/deploy.yml]`. **Frontend changes do not trigger deploy.yml.** Today this works because deploy.yml's deploy-dev rebuilds the frontend with the merged main HEAD anyway, BUT: if the only change in a PR is `frontend/**`, deploy.yml never runs and the frontend on the dev environment goes stale.

The hidden cost: frontend code changes only reach the deployed CloudFront/S3 bundle when an unrelated backend/shared-types/workflow PR happens to land afterward. Could be hours or weeks of staleness.

## The fix

```diff
 paths:
   - 'backend/**'
   - 'shared-types/**'
+  - 'frontend/**'
   - '.github/workflows/deploy.yml'
```

That's the entire diff. One line. YAML validated via `python3 -c "import yaml; yaml.safe_load(...)"`.

## Verification — retroactive check

Confirmed the gap was real by checking `gh run list --commit <sha> --workflow deploy.yml` for three known frontend-only merges:

| PR | Files touched | deploy.yml runs triggered |
|---|---|---|
| #134 | `PROGRESS.md` + `demo/*` (docs only — should NOT trigger; included as control) | 0 ✓ correct |
| #135 | `frontend/package*.json`, `frontend/src/utils/__tests__/api.refresh.test.ts`, `frontend/vite.config.ts` (frontend-only) | **0** ✗ MISSED |
| #140 | 28 files: `frontend/**` (MSW implementation) + `.gitignore`, `CLAUDE.md`, `FRONTEND-DEPLOYMENT.md`, `docs/DEPLOYMENT.md` | **0** ✗ MISSED |

PRs #135 and #140 contained real deployable frontend changes that never reached dev. With this fix, both would have triggered.

PR #134 was docs-only and correctly stayed out — note that `frontend/**` does NOT broaden to docs/, demo/, or root markdown.

## Trigger semantics after fix

| Change scope | Before | After |
|---|---|---|
| backend-only | triggers ✓ | triggers ✓ |
| shared-types-only | triggers ✓ | triggers ✓ |
| deploy.yml-only | triggers ✓ | triggers ✓ |
| frontend-only | **skipped** ✗ | **triggers** ✓ |
| docs/, demo/, openspec/, root *.md | skipped ✓ | skipped ✓ |
| `frontend/*.md` (e.g. README, LOCAL-TESTING.md) | skipped | triggers (acceptable: deploy is a no-op rebuild; frontend markdown edits are rare) |

## OMC review

- code-reviewer: pending
- architect-reviewer: pending

(Comments will be posted on this PR; consolidated verdict to follow.)

## Test plan

- [ ] CI green on this branch (workflow self-triggers because `.github/workflows/deploy.yml` is already in paths filter — the filter applies to pushes to main, but PR-time `ci.yml` will gate the merge as usual)
- [ ] After merge, the next frontend-only PR pushed to main triggers a deploy run
- [ ] Documentation-only PRs (docs/, demo/, openspec/, root *.md) continue to NOT trigger deploys

## Stop conditions checked

- ✓ One-line fix; no multi-line restructuring needed
- ✓ Nothing under `frontend/` should be excluded from deploys (a few markdown files exist, but they're rare and a no-op rebuild is a safe trade-off vs. silent staleness)

**Do NOT merge** until OMC verdicts post and `gh pr checks` is green.