### PR TITLE
fix(ci): allow workflow_dispatch=dev to trigger deploy-dev (manual escape hatch)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,66 @@ jobs:
         working-directory: backend/infrastructure
         run: npx cdk synth --context environment=dev --context skipLambdaBundling=true
 
+  workflow-lint:
+    name: Workflow Lint
+    runs-on: ubuntu-latest
+    # Catches the class of drift that caused Issues #149, #152, #154 — broken
+    # workflow files merging green because nothing parsed them for semantic
+    # correctness. Two checks:
+    #   1. actionlint: validates GitHub Actions expression syntax, needs:
+    #      references, action input names, shellcheck on run: blocks.
+    #   2. deploy.yml gated-job parity: deploy-dev and the 4 trailing test
+    #      jobs (production-smoke-tests, smoke-tests, integration-tests,
+    #      e2e-tests) MUST share an identical if: expression so they run as a
+    #      unit. Drift here would silently skip post-deploy verification on
+    #      manual dispatch (the exact bug PR #159 fixed for the inverse case).
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install actionlint (pinned)
+        run: |
+          # Pin to 1.7.12 — same version verified locally during PR #159 audit.
+          # Bump deliberately when adopting new actionlint features.
+          bash <(curl -sf https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) 1.7.12 /usr/local/bin
+          actionlint --version
+
+      - name: Run actionlint on all workflow files
+        run: actionlint -color
+
+      - name: Verify deploy.yml gated-job condition parity
+        run: |
+          python3 <<'PYEOF'
+          import sys
+          import yaml
+
+          with open('.github/workflows/deploy.yml') as f:
+              wf = yaml.safe_load(f)
+
+          # These 5 jobs are the "deploy-dev cascade" — deploy-dev plus its
+          # 4 verification jobs that needs: deploy-dev. They must share an
+          # identical if: expression or the cascade will partially skip.
+          gated_jobs = [
+              'deploy-dev',
+              'production-smoke-tests',
+              'smoke-tests',
+              'integration-tests',
+              'e2e-tests',
+          ]
+          conditions = {job: wf['jobs'][job].get('if', '') for job in gated_jobs}
+          unique = set(conditions.values())
+
+          if len(unique) != 1:
+              print('::error file=.github/workflows/deploy.yml::deploy.yml gated jobs have divergent if: expressions — cascade will silently partial-skip')
+              for job, cond in conditions.items():
+                  print(f'  {job}: {cond}', file=sys.stderr)
+              sys.exit(1)
+
+          print(f'OK: all {len(gated_jobs)} gated jobs share an identical if: expression')
+          print(f'Condition: {next(iter(unique))}')
+          PYEOF
+
   lint-and-format:
     name: Lint and Format Check
     runs-on: ubuntu-latest
@@ -294,7 +354,7 @@ jobs:
   ci-summary:
     name: CI Summary
     runs-on: ubuntu-latest
-    needs: [test, build-infrastructure, lint-and-format, security-scan, test-frontend] # test-e2e temporarily disabled
+    needs: [test, build-infrastructure, lint-and-format, security-scan, test-frontend, workflow-lint] # test-e2e temporarily disabled
     if: always()
 
     steps:
@@ -308,12 +368,16 @@ jobs:
           echo "Lint and Format: ${{ needs.lint-and-format.result }}"
           echo "Security Scan: ${{ needs.security-scan.result }}"
           echo "Frontend Tests: ${{ needs.test-frontend.result }}"
+          echo "Workflow Lint: ${{ needs.workflow-lint.result }}"
           echo "E2E Tests: temporarily disabled"
           echo "========================================="
 
-          # lint-and-format is now required (Issue #149): deploy.yml fails on
-          # any lint or format violation, so PRs must surface those before merge.
-          if [ "${{ needs.test.result }}" != "success" ] || [ "${{ needs.build-infrastructure.result }}" != "success" ] || [ "${{ needs.test-frontend.result }}" != "success" ] || [ "${{ needs.lint-and-format.result }}" != "success" ]; then
+          # lint-and-format is required (Issue #149): deploy.yml fails on any
+          # lint or format violation, so PRs must surface those before merge.
+          # workflow-lint is required (Issue #162 / PR #159): catches GH Actions
+          # expression syntax errors and deploy.yml gated-job condition drift
+          # at PR time, before the broken workflow merges to main.
+          if [ "${{ needs.test.result }}" != "success" ] || [ "${{ needs.build-infrastructure.result }}" != "success" ] || [ "${{ needs.test-frontend.result }}" != "success" ] || [ "${{ needs.lint-and-format.result }}" != "success" ] || [ "${{ needs.workflow-lint.result }}" != "success" ]; then
             echo "❌ CI pipeline failed - required jobs did not pass"
             exit 1
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,15 @@ jobs:
           actionlint --version
 
       - name: Run actionlint on all workflow files
-        run: actionlint -color
+        # `-shellcheck "shellcheck -S warning"` keeps warning + error severity
+        # but suppresses info-level findings. The Ubuntu runner has shellcheck
+        # preinstalled, so actionlint invokes it on every `run:` block. Most
+        # info-level findings on these workflows are SC2086 false positives —
+        # shellcheck flags `${{ steps.X.outputs.Y }}` as un-quoted bash
+        # interpolation, but those are GH Actions expressions substituted at
+        # YAML-processing time, not bash variables. Real bash quoting bugs
+        # would still fire as warnings/errors and be caught.
+        run: actionlint -color -shellcheck "shellcheck -S warning"
 
       - name: Verify deploy.yml gated-job condition parity
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -146,8 +146,15 @@ jobs:
     # The manual path was added after Issue #158 (cdk import for
     # TranslationApiKeySecret) when we needed to verify a hand-fix without
     # piggy-backing on an unrelated commit. staging/prod are dispatchable via
-    # dedicated jobs below; do NOT collapse this back to `event_name == 'push'`
-    # without re-adding a manual dev-redeploy path elsewhere.
+    # dedicated jobs below (note: those lack a main-branch guard — tracked
+    # in Issue #160 as a follow-up).
+    #
+    # Drift-prevention history: this file has had three trigger-related
+    # incidents in one quarter (Issue #149 backend lint regression, PR #152
+    # shared-types build, PR #154 frontend trigger gap). Do NOT collapse this
+    # condition back to `event_name == 'push'` without re-adding a manual
+    # dev-redeploy path elsewhere — the next person to "simplify" this away
+    # will trigger the next incident.
     if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'dev'))
     environment:
       name: development

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -329,7 +329,9 @@ jobs:
             local required="$3"
 
             if echo "$HEADERS" | grep -i "^${header_name}:" > /dev/null; then
-              local header_value=$(echo "$HEADERS" | grep -i "^${header_name}:" | cut -d: -f2- | tr -d '\r\n' | xargs)
+              # SC2155: declare and assign separately so command failure isn't masked.
+              local header_value
+              header_value=$(echo "$HEADERS" | grep -i "^${header_name}:" | cut -d: -f2- | tr -d '\r\n' | xargs)
               echo "✅ ${header_name}: ${header_value}"
 
               if [ -n "$header_pattern" ]; then

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,11 @@ on:
   workflow_dispatch:
     inputs:
       environment:
-        description: 'Environment to deploy'
+        # NOTE: default is 'dev' — running `gh workflow run deploy.yml --ref main`
+        # with no `-f environment=...` flag triggers a real deploy to LfmtPocDev
+        # (CDK + S3 sync + CloudFront invalidation + smoke + integration + e2e).
+        # Pick `staging` or `prod` explicitly to target those stacks instead.
+        description: 'Environment to deploy (dev triggers a real deploy to LfmtPocDev)'
         required: true
         default: 'dev'
         type: choice
@@ -136,7 +140,15 @@ jobs:
     name: Deploy to Development
     runs-on: ubuntu-latest
     needs: test
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    # Trigger conditions:
+    #   - push to main → automatic deploy
+    #   - workflow_dispatch with environment=dev → manual deploy (escape hatch)
+    # The manual path was added after Issue #158 (cdk import for
+    # TranslationApiKeySecret) when we needed to verify a hand-fix without
+    # piggy-backing on an unrelated commit. staging/prod are dispatchable via
+    # dedicated jobs below; do NOT collapse this back to `event_name == 'push'`
+    # without re-adding a manual dev-redeploy path elsewhere.
+    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'dev'))
     environment:
       name: development
       url: ${{ steps.get-frontend-url.outputs.frontend_url }}
@@ -432,7 +444,7 @@ jobs:
     name: Run Production Smoke Tests
     runs-on: ubuntu-latest
     needs: deploy-dev
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'dev'))
 
     steps:
       - name: Checkout code
@@ -507,7 +519,7 @@ jobs:
     name: Run Smoke Tests
     runs-on: ubuntu-latest
     needs: deploy-dev
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'dev'))
 
     steps:
       - name: Checkout code
@@ -546,7 +558,7 @@ jobs:
     name: Run Backend Integration Tests
     runs-on: ubuntu-latest
     needs: deploy-dev
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'dev'))
 
     permissions:
       id-token: write
@@ -643,7 +655,7 @@ jobs:
     name: Run E2E Tests
     runs-on: ubuntu-latest
     needs: deploy-dev
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'dev'))
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Why

After the user ran `cdk import` to fix Issue #158 (TranslationApiKeySecret adoption), they tried to verify the import worked by running `gh workflow run deploy.yml --ref main`. **The deploy never ran** — only `Run Tests` executed. Cause:

`deploy.yml`'s `deploy-dev` is gated on `event_name == 'push'`, and the workflow_dispatch path only routes to `staging`/`prod` (via per-environment input checks). There is currently **no manual escape hatch for dev**.

This forced the user to either:
1. Push a no-op commit just to verify a hand-fix, OR
2. Wait for an unrelated commit and piggyback verification

Both are footguns. Every time we recover from drift (cdk import, manual stack edits, etc.), we'd hit this.

## What this PR does

Adds the missing manual escape hatch by extending the `if:` condition in 5 jobs:

| Job | Old condition | New condition |
|---|---|---|
| `deploy-dev` (line 139) | `push only` | `push OR (workflow_dispatch AND env=dev)` |
| `production-smoke-tests` (line 435) | `push only` | `push OR (workflow_dispatch AND env=dev)` |
| `smoke-tests` (line 510) | `push only` | `push OR (workflow_dispatch AND env=dev)` |
| `integration-tests` (line 549) | `push only` | `push OR (workflow_dispatch AND env=dev)` |
| `e2e-tests` (line 646) | `push only` | `push OR (workflow_dispatch AND env=dev)` |

All 5 jobs `needs: deploy-dev` (or are deploy-dev itself), so they fire as a unit.

Push-to-main behavior is **unchanged**.

## Trigger matrix after this change

| Trigger | What runs |
|---|---|
| Push to main (any backend/frontend/shared-types/.github) | test → deploy-dev → smoke + integration + e2e |
| `gh workflow run deploy.yml --ref main` (default env=dev) | test → **deploy-dev → smoke + integration + e2e** ⬅ NEW |
| `gh workflow run deploy.yml --ref main -f environment=staging` | test → deploy-staging |
| `gh workflow run deploy.yml --ref main -f environment=prod` | test → deploy-prod |

No double-deploy possible — `deploy-dev`/`deploy-staging`/`deploy-prod` check mutually-exclusive environment values.

## Documentation added (per Issue #156 codification convention)

1. **7-line comment above `deploy-dev`'s `if:`** explaining the dual trigger and warning future contributors not to revert it.
2. **4-line comment above `workflow_dispatch.inputs.environment`** warning that `default: 'dev'` means a no-flag `gh workflow run deploy.yml` triggers a real dev deploy + smoke/integration/e2e.
3. **Description updated** on the input itself for the GitHub UI.

## Self-review (OMC)

Ran both specialists on the worktree before push:

- **architect-reviewer**: APPROVE WITH NITS (no critical) — flagged comment-as-codification + default-env warning + asymmetric branch guard. First two addressed in commit; third filed as follow-up issue.
- **code-reviewer**: APPROVE WITH NITS (no critical) — verified boolean logic correctness across all 4 trigger cases, YAML syntax, and trailing-test-cascade semantics. Same pre-existing nits flagged.

## Follow-up issues to file (out of scope here)

1. **Branch-guard asymmetry**: deploy-dev requires `github.ref == 'refs/heads/main'`, but deploy-staging/deploy-prod do not. A workflow_dispatch from any branch could currently deploy to staging/prod.
2. **Missing `concurrency:` group**: a manual dispatch can race a push-triggered deploy against the same stack. CDK will fail the second one but it's a noisy failure.

Both are pre-existing gaps that this PR makes more visible without introducing new risk.

## Test plan

- [x] YAML validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] OMC self-review (both APPROVE WITH NITS, no critical)
- [ ] CI on this PR passes (auto-triggered)
- [ ] **After merge**: user can run `gh workflow run deploy.yml --ref main` to verify the cdk import for Issue #158, without needing a sentinel commit.

## Closes-prep

Enables manual verification of Issue #158 (cdk import for `TranslationApiKeySecret`) without piggy-backing on an unrelated commit.