### PR TITLE
fix(ci): deploy.yml CSP/header validation false-negative — xargs strips quotes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -330,8 +330,12 @@ jobs:
 
             if echo "$HEADERS" | grep -i "^${header_name}:" > /dev/null; then
               # SC2155: declare and assign separately so command failure isn't masked.
+              # NOTE: trim with sed, NOT xargs — xargs performs shell-style
+              # tokenization that strips single quotes (e.g. `object-src 'none'`
+              # would become `object-src none`), producing false negatives in
+              # the CSP regex checks below.
               local header_value
-              header_value=$(echo "$HEADERS" | grep -i "^${header_name}:" | cut -d: -f2- | tr -d '\r\n' | xargs)
+              header_value=$(echo "$HEADERS" | grep -i "^${header_name}:" | cut -d: -f2- | tr -d '\r\n' | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')
               echo "✅ ${header_name}: ${header_value}"
 
               if [ -n "$header_pattern" ]; then
@@ -379,7 +383,12 @@ jobs:
           # grep -i is case-insensitive.
           RAW_HEADERS=$(curl -sIL "$FRONTEND_URL")
           FINAL_HEADERS=$(printf '%s' "$RAW_HEADERS" | awk 'BEGIN{RS="\r\n\r\n"} NF{last=$0} END{print last}')
-          CSP=$(echo "$FINAL_HEADERS" | grep -i "^content-security-policy:" | cut -d: -f2- | tr -d '\r\n' | xargs)
+          # Trim with sed, NOT xargs — xargs performs shell-style tokenization
+          # that strips single quotes, so `object-src 'none'` would arrive here
+          # as `object-src none` and silently fail every quoted-directive check
+          # below. (Latent bug exposed when PR #159 first routed push-to-main
+          # into deploy-dev and the CSP step actually ran.)
+          CSP=$(echo "$FINAL_HEADERS" | grep -i "^content-security-policy:" | cut -d: -f2- | tr -d '\r\n' | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')
 
           echo "CSP Policy: $CSP"
           echo ""


### PR DESCRIPTION
## Summary

- Deploy on main has been failing since PR #159 merged with `❌ FAIL: CSP missing hardening directive: object-src 'none'`. The deployed CSP itself is correct (`curl -sI` confirms `object-src 'none'` is present); the **validation script** was misparsing it.
- Root cause: `| xargs` (used to trim leading/trailing whitespace from the extracted header value) performs shell-style tokenization and **silently strips single quotes**. So `object-src 'none'` arrived at the `grep -iF` check as `object-src none` and never matched.
- Replaced `xargs` with `sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//'` in both header-extraction sites — quote-safe whitespace trim. Inline comments warn the next maintainer.

## Why this is only surfacing now

The CSP-hardening validation was added in PR #127 / PR #136, but the step lives inside `deploy-dev`. Before PR #159, neither push-to-main nor the default `workflow_dispatch=dev` actually ran `deploy-dev`, so the step had never executed against a live CloudFront response. PR #159 wired push-to-main into `deploy-dev`, exposing the latent bug on the very next merge.

## Verification

Ran the patched extraction against the live frontend:

\`\`\`
$ RAW_HEADERS=\$(curl -sIL https://d39xcun7144jgl.cloudfront.net)
$ FINAL_HEADERS=\$(printf '%s' "\$RAW_HEADERS" | awk 'BEGIN{RS="\\\r\\\n\\\r\\\n"} NF{last=\$0} END{print last}')
$ CSP=\$(echo "\$FINAL_HEADERS" | grep -i "^content-security-policy:" | cut -d: -f2- | tr -d '\\\r\\\n' | sed -E 's/^[[:space:]]+//; s/[[:space:]]+\$//')
$ echo "\$CSP"
default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; ...; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests;
\`\`\`

All 5 hardening directives now match, and the `'unsafe-eval'` regression guard still fires correctly when present.

## Test plan

- [ ] CI green (Run Tests + Build Infrastructure)
- [ ] On merge, `Deploy LFMT Infrastructure` workflow on main passes the CSP Hardening Validation step
- [ ] Pre-existing security-header validation step (Issue #62) also passes — same `xargs → sed` swap was applied there for consistency, even though that step's checks (`max-age=`, `nosniff`, `(DENY|SAMEORIGIN)`, `default-src`) don't currently include quoted directives, so it wasn't actively broken