### PR TITLE
fix(backend): Step Functions Map silently propagated COMPLETED on chunk failure (#151)

### DIFF
--- a/backend/infrastructure/lib/__tests__/infrastructure.test.ts
+++ b/backend/infrastructure/lib/__tests__/infrastructure.test.ts
@@ -594,13 +594,89 @@ describe('LFMT Infrastructure Stack', () => {
       // Verify state machine has multiple states
       const states = definition.States;
       const stateCount = Object.keys(states).length;
-      expect(stateCount).toBeGreaterThan(2); // At least: Map, DynamoDB Update, Success (Fail is inside Map iterator)
+      // Map, UpdateJobCompleted, TranslationSuccess, UpdateJobFailed, TranslationFailed
+      expect(stateCount).toBeGreaterThanOrEqual(5);
 
       // Verify there's a Succeed state for successful completion
       const successState = Object.values(states).find((state: any) => state.Type === 'Succeed');
       expect(successState).toBeDefined();
 
-      // Note: Fail state is nested inside Map iterator (TranslationFailed), not at top level
+      // Verify there's a Fail state at top level (Issue #151 — failure path
+      // must terminate the execution as FAILED, not silently succeed).
+      const failStates = Object.values(states).filter((state: any) => state.Type === 'Fail');
+      expect(failStates.length).toBeGreaterThanOrEqual(1);
+    });
+
+    test('Map state has Catch handler routing to UpdateJobFailed (Issue #151)', () => {
+      // Regression guard: the previous design attached Catch to the inner
+      // iterator task, which CDK synthesized as a per-iteration Catch that
+      // swallowed Lambda failures and made the Map state aggregate them as
+      // successful iterations. The fix moves the Catch to the Map state
+      // itself and routes it to a DDB writer that records TRANSLATION_FAILED.
+      const stateMachines = template.findResources('AWS::StepFunctions::StateMachine');
+      const stateMachine = stateMachines[Object.keys(stateMachines)[0]];
+      const definition = JSON.parse(
+        stateMachine.Properties.DefinitionString['Fn::Join'][1].join('')
+      );
+
+      const states = definition.States;
+      const mapStateEntry = Object.entries(states).find(
+        ([, state]: [string, any]) => state.Type === 'Map'
+      );
+      expect(mapStateEntry).toBeDefined();
+      const [, mapState] = mapStateEntry as [string, any];
+
+      // Map state MUST have a Catch handler at the Map-state level
+      expect(mapState.Catch).toBeDefined();
+      expect(Array.isArray(mapState.Catch)).toBe(true);
+      expect(mapState.Catch.length).toBeGreaterThanOrEqual(1);
+
+      // The Catch must cover all error types and route to UpdateJobFailed
+      const catchHandler = mapState.Catch[0];
+      expect(catchHandler.ErrorEquals).toEqual(['States.ALL']);
+      expect(catchHandler.ResultPath).toBe('$.error');
+      expect(catchHandler.Next).toMatch(/UpdateJobFailed/);
+
+      // Iterator's inner task must NOT have a Catch (would re-introduce
+      // the swallow-and-aggregate bug fixed in Issue #151).
+      const iteratorStartName = mapState.Iterator?.StartAt ?? mapState.ItemProcessor?.StartAt;
+      const iteratorStates = mapState.Iterator?.States ?? mapState.ItemProcessor?.States;
+      expect(iteratorStartName).toBeDefined();
+      expect(iteratorStates).toBeDefined();
+      const startState = iteratorStates[iteratorStartName];
+      expect(startState.Catch).toBeUndefined();
+    });
+
+    test('UpdateJobFailed task writes TRANSLATION_FAILED to DDB (Issue #151)', () => {
+      const stateMachines = template.findResources('AWS::StepFunctions::StateMachine');
+      const stateMachine = stateMachines[Object.keys(stateMachines)[0]];
+      const definition = JSON.parse(
+        stateMachine.Properties.DefinitionString['Fn::Join'][1].join('')
+      );
+
+      const states = definition.States;
+      const updateJobFailedEntry = Object.entries(states).find(([name]) =>
+        /UpdateJobFailed/.test(name)
+      );
+      expect(updateJobFailedEntry).toBeDefined();
+      const [, updateJobFailed] = updateJobFailedEntry as [string, any];
+
+      // Must be a DDB UpdateItem task
+      expect(updateJobFailed.Type).toBe('Task');
+      expect(updateJobFailed.Resource).toMatch(/dynamodb:updateItem/i);
+
+      // Status enum must match shared-types/src/jobs.ts TranslationStatus
+      // (drift here would cause the polling endpoint to misclassify the row).
+      const valuesString = JSON.stringify(
+        updateJobFailed.Parameters?.ExpressionAttributeValues ?? {}
+      );
+      expect(valuesString).toContain('TRANSLATION_FAILED');
+
+      // Must transition to a Fail terminal state (so the SF execution itself
+      // is marked FAILED, not Succeeded).
+      expect(updateJobFailed.Next).toBeDefined();
+      const nextState = states[updateJobFailed.Next];
+      expect(nextState.Type).toBe('Fail');
     });
 
     test('State machine has required IAM permissions', () => {

--- a/backend/infrastructure/lib/lfmt-infrastructure-stack.ts
+++ b/backend/infrastructure/lib/lfmt-infrastructure-stack.ts
@@ -1152,15 +1152,17 @@ export class LfmtInfrastructureStack extends Stack {
       backoffRate: 2.0, // Exponential backoff: 2s, 4s, 8s
     });
 
-    // Add catch for non-retryable errors
-    const failState = new stepfunctions.Fail(this, 'TranslationFailed', {
-      comment: 'Translation failed - non-retryable error',
-    });
-
-    translateChunkTask.addCatch(failState, {
-      errors: ['States.ALL'],
-      resultPath: '$.error',
-    });
+    // NOTE (Issue #151): Failure handling lives on the Map state, NOT on the
+    // iterator task. The previous design attached `addCatch(failState)` to the
+    // inner `translateChunkTask` with `failState` defined OUTSIDE the iterator.
+    // CDK synthesized this with the Catch handler scoped INSIDE the iteration,
+    // which made each Lambda failure behave as a "successfully caught"
+    // iteration result. The Map state then aggregated those caught failures as
+    // if every chunk had succeeded, ran updateJobCompleted, and wrote
+    // translationStatus=COMPLETED + progress=100% to DDB even when zero chunks
+    // were translated (latent for ~30 days; surfaced by Track B demo capture).
+    // The fix below catches at the Map level and routes to a real DDB writer
+    // that records TRANSLATION_FAILED, so the UI sees the truth.
 
     // Map state to process all chunks in parallel
     // maxConcurrency can be configured per environment via CDK context:
@@ -1202,6 +1204,47 @@ export class LfmtInfrastructureStack extends Stack {
         ':updatedAt': tasks.DynamoAttributeValue.fromString(stepfunctions.JsonPath.stringAt('$$.State.EnteredTime')),
       },
       resultPath: stepfunctions.JsonPath.DISCARD,
+    });
+
+    // Failure path (Issue #151): when the Map iterator throws after retries
+    // are exhausted, persist TRANSLATION_FAILED to DDB so the UI / polling
+    // endpoints stop reporting a phantom-success. The error payload from the
+    // Map's catch is stored under $.error and serialized into the DDB row for
+    // post-mortem visibility.
+    const updateJobFailed = new tasks.DynamoUpdateItem(this, 'UpdateJobFailed', {
+      table: this.jobsTable,
+      key: {
+        jobId: tasks.DynamoAttributeValue.fromString(stepfunctions.JsonPath.stringAt('$.jobId')),
+        userId: tasks.DynamoAttributeValue.fromString(stepfunctions.JsonPath.stringAt('$.userId')),
+      },
+      updateExpression: 'SET translationStatus = :status, translationFailedAt = :failedAt, translationError = :error, updatedAt = :updatedAt',
+      expressionAttributeValues: {
+        // 'TRANSLATION_FAILED' matches shared-types/src/jobs.ts (TranslationStatus union)
+        // and the polling endpoint in backend/functions/jobs/getTranslationStatus.ts.
+        ':status': tasks.DynamoAttributeValue.fromString('TRANSLATION_FAILED'),
+        ':failedAt': tasks.DynamoAttributeValue.fromString(stepfunctions.JsonPath.stringAt('$$.State.EnteredTime')),
+        ':error': tasks.DynamoAttributeValue.fromString(stepfunctions.JsonPath.stringAt("States.JsonToString($.error)")),
+        ':updatedAt': tasks.DynamoAttributeValue.fromString(stepfunctions.JsonPath.stringAt('$$.State.EnteredTime')),
+      },
+      resultPath: stepfunctions.JsonPath.DISCARD,
+    });
+
+    // Terminal failure state — must come after the DDB write so the execution
+    // is marked FAILED in the Step Functions console / CloudWatch dashboards.
+    const failedTerminal = new stepfunctions.Fail(this, 'TranslationFailed', {
+      comment: 'Translation failed - one or more chunks failed after retries',
+      cause: 'See translationError in the jobs table for the underlying error payload',
+    });
+
+    updateJobFailed.next(failedTerminal);
+
+    // Catch on the Map state itself (NOT on the inner task — see Issue #151
+    // note above). States.ALL covers Lambda errors, retries-exhausted, and
+    // Map-internal failures; resultPath='$.error' makes the error JSON
+    // available to the updateJobFailed task.
+    processChunksMap.addCatch(updateJobFailed, {
+      errors: ['States.ALL'],
+      resultPath: '$.error',
     });
 
     // Success state


### PR DESCRIPTION
## Summary

Closes #151. The translation Step Functions state machine had its Catch handler attached to the **inner iterator task** with a `failState` defined OUTSIDE the iterator. CDK synthesized that shape into ASL where each per-iteration Catch consumed the Lambda failure locally and the iteration returned a "caught" result. The Map state aggregated those as successes, ran `updateJobCompleted`, and wrote `translationStatus=COMPLETED` + `progressPercentage=100` to DynamoDB even when **zero chunks** were translated.

This bug masked Issue #150 (stale Lambda throwing on every invocation) for ~30 days — Track B demo-data capture showed jobs "completing" successfully while CloudWatch showed every chunk failing.

## Fix

Moved the Catch from the inner task to the Map state itself and routed it to a new DDB writer that records the failure:

\`\`\`
processChunksMap (Map)
  ├── iterator: translateChunkTask (with retries; NO Catch)
  └── catch (States.ALL) → updateJobFailed
                            ├── SET translationStatus = TRANSLATION_FAILED
                            ├── SET translationFailedAt, translationError
                            └── next → TranslationFailed (Fail terminal)
.next(updateJobCompleted) → SET translationStatus = COMPLETED
.next(TranslationSuccess) (Succeed terminal)
\`\`\`

\`'TRANSLATION_FAILED'\` matches the canonical enum in \`shared-types/src/jobs.ts\` and the polling logic in \`getTranslationStatus.ts\`, so the frontend needs no changes.

\`cdk synth\` confirms the corrected ASL: Catch at the Map level, \`ErrorEquals=['States.ALL']\`, \`Next=UpdateJobFailed\`, then UpdateJobFailed → TranslationFailed (Fail).

## Tests

Two new regression guards + tightened existing assertions:

1. **\`Map state has Catch handler routing to UpdateJobFailed\`** — locks the Catch at Map-state level, asserts iterator's start-state has NO Catch (would re-introduce the bug).
2. **\`UpdateJobFailed task writes TRANSLATION_FAILED to DDB\`** — asserts the enum literal matches shared-types and the next-state is a Fail terminal so the SF execution is marked FAILED.
3. Tightened \`State machine has workflow states\` from \`> 2\` (which hid the bug) to \`>= 5\` plus explicit Fail-state count check.

All 42 infrastructure tests pass; all 427 backend function tests pass.

## Test plan

- [ ] CI green: \`Run Tests\` + \`Build Infrastructure\` (lint, format, type-check, unit + cdk synth)
- [ ] On merge + redeploy, manually trigger a translation against a chunk Lambda that throws (Issue #150 currently provides the natural test case until PR #164 lands and the Lambda is redeployed)
- [ ] Verify DDB row shows \`translationStatus=TRANSLATION_FAILED\`, \`translationFailedAt=<timestamp>\`, \`translationError=<JSON>\` after the run
- [ ] Verify Step Functions execution shows FAILED (not Succeeded) in the AWS console

## Out of scope

- **Issue #150** (stale Lambda) auto-resolves once PR #164 lands → next push triggers a clean deploy-dev → Lambda rebuilds with current main code.
- Counting actual completed chunks (vs input \`ArrayLength($.chunks)\`) on the success path is a further refinement; not blocking — the success path now only runs when no chunk threw.