### PR TITLE
fix(frontend): demo-prep bundle — mock fidelity, data integrity, display polish (#141-#148)

### DIFF
--- a/backend/functions/jobs/getTranslationStatus.test.ts
+++ b/backend/functions/jobs/getTranslationStatus.test.ts
@@ -479,4 +479,63 @@ describe('getTranslationStatus endpoint', () => {
       expect(result.headers?.['Content-Type']).toBe('application/json');
     });
   });
+
+  describe('file metadata exposure (R3 OMC review follow-up)', () => {
+    // Frontend `TranslationDetail.tsx` renders userId, fileName,
+    // fileSize, and contentType — all of which were absent from this
+    // Lambda's response prior to the R3 fix. These tests lock in the
+    // wire-shape contract so the demo bug fixed for the mock side
+    // (Issue #144 — "0 Bytes") cannot reappear in production.
+
+    it('returns userId, fileName, fileSize, contentType when DDB has them', async () => {
+      dynamoMock.on(GetItemCommand).resolves({
+        Item: {
+          jobId: { S: 'job-123' },
+          userId: { S: 'user-123' },
+          filename: { S: 'doc.txt' },
+          fileSize: { N: '4096' },
+          contentType: { S: 'text/plain' },
+          status: { S: 'CHUNKED' },
+          totalChunks: { N: '5' },
+        },
+      } as any);
+
+      const event = createEvent('job-123');
+      const result = await handler(event as APIGatewayProxyEvent);
+
+      expect(result.statusCode).toBe(200);
+      const body = JSON.parse(result.body);
+      expect(body.userId).toBe('user-123');
+      // DDB stores `filename` (lowercase n); the wire contract is
+      // `fileName` (camelCase) — the handler translates at the boundary.
+      expect(body.fileName).toBe('doc.txt');
+      expect(body.fileSize).toBe(4096);
+      expect(body.contentType).toBe('text/plain');
+    });
+
+    it('omits fileSize / contentType when DDB lacks them (legacy rows)', async () => {
+      // Pre-R3 job records will not carry fileSize / contentType. The
+      // response shape MUST tolerate this without a 500 — the frontend
+      // already renders empty cells gracefully.
+      dynamoMock.on(GetItemCommand).resolves({
+        Item: {
+          jobId: { S: 'job-123' },
+          userId: { S: 'user-123' },
+          status: { S: 'UPLOADED' },
+          totalChunks: { N: '0' },
+        },
+      } as any);
+
+      const event = createEvent('job-123');
+      const result = await handler(event as APIGatewayProxyEvent);
+
+      expect(result.statusCode).toBe(200);
+      const body = JSON.parse(result.body);
+      expect(body.fileSize).toBeUndefined();
+      expect(body.contentType).toBeUndefined();
+      expect(body.fileName).toBeUndefined();
+      // userId is always present — it's the composite-key partition.
+      expect(body.userId).toBe('user-123');
+    });
+  });
 });

--- a/backend/functions/jobs/getTranslationStatus.ts
+++ b/backend/functions/jobs/getTranslationStatus.ts
@@ -22,6 +22,19 @@ const JOBS_TABLE = getRequiredEnv('JOBS_TABLE');
  */
 interface TranslationStatusResponse {
   jobId: string;
+  // R3 (OMC review follow-up): the frontend's `TranslationDetail.tsx`
+  // renders `userId`, `fileSize`, and `contentType` from this response
+  // (lines 239, 246 — fileSize and contentType in particular). They
+  // were absent from the real Lambda response, so the demo bug fixed
+  // by PR #166 on the mock side (Issue #144 — "0 Bytes") would have
+  // reappeared in production once the mock was disabled. The fields
+  // are already persisted on the DDB job record at upload time
+  // (uploadRequest.ts:124-126), so surfacing them here is a pure
+  // wire-shape catch-up with no schema migration needed.
+  userId?: string;
+  fileName?: string;
+  fileSize?: number;
+  contentType?: string;
   status: string; // Overall job status (PENDING_UPLOAD, UPLOADED, CHUNKED, etc.)
   translationStatus: string;
   targetLanguage?: string;
@@ -85,6 +98,16 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     // Build response
     const response: TranslationStatusResponse = {
       jobId,
+      // R3: surface the file/owner metadata persisted at upload time so
+      // the Translation Details view can render File Size, Content Type,
+      // and File Name without falling back to undefined-shaped UI.
+      // DDB stores `filename` (lowercase n); the frontend's wire contract
+      // is `fileName` (camelCase) — translate at the response boundary.
+      // `fileSize` / `contentType` already match the wire shape.
+      userId: job.userId,
+      fileName: job.filename,
+      fileSize: typeof job.fileSize === 'number' ? job.fileSize : undefined,
+      contentType: typeof job.contentType === 'string' ? job.contentType : undefined,
       status: job.status, // Overall job status (PENDING_UPLOAD, UPLOADED, CHUNKED, etc.)
       translationStatus: job.translationStatus || 'NOT_STARTED',
       targetLanguage: job.targetLanguage,

--- a/frontend/src/components/Translation/TranslationConfig.tsx
+++ b/frontend/src/components/Translation/TranslationConfig.tsx
@@ -18,9 +18,44 @@ import {
   SelectChangeEvent,
 } from '@mui/material';
 
+// LANGUAGE_OPTIONS / TONE_OPTIONS are exported as the canonical source of
+// truth for both (a) the dropdown rendered below AND (b) the read-only
+// label maps consumed by `utils/translationLabels.ts`. Keeping the option
+// arrays here (next to the form) preserves the component-local layout the
+// dropdown wants, while the label helpers derive their tables from these
+// same arrays — so adding a language requires exactly one edit, and the
+// TypeScript compiler catches drift via `LanguageCode` / `ToneCode` (R2).
+//
+// `as const` is load-bearing: it narrows the literal types so we can
+// derive `LanguageCode` / `ToneCode` unions below.
+//
+// We deliberately export non-component values from this `.tsx` file —
+// the alternative (a separate `translationOptions.ts` module) would
+// have churned 4+ test files for no functional gain. React Fast Refresh
+// will still rebuild the whole module on edit, which is fine for a
+// rarely-touched options table.
+// eslint-disable-next-line react-refresh/only-export-components
+export const LANGUAGE_OPTIONS = [
+  { value: 'es', label: 'Spanish (Español)' },
+  { value: 'fr', label: 'French (Français)' },
+  { value: 'de', label: 'German (Deutsch)' },
+  { value: 'it', label: 'Italian (Italiano)' },
+  { value: 'zh', label: 'Chinese (中文)' },
+] as const;
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const TONE_OPTIONS = [
+  { value: 'formal', label: 'Formal', description: 'Professional and respectful language' },
+  { value: 'neutral', label: 'Neutral', description: 'Balanced and standard language' },
+  { value: 'informal', label: 'Informal', description: 'Casual and conversational language' },
+] as const;
+
+export type LanguageCode = (typeof LANGUAGE_OPTIONS)[number]['value'];
+export type ToneCode = (typeof TONE_OPTIONS)[number]['value'];
+
 export interface TranslationConfigData {
-  targetLanguage: 'es' | 'fr' | 'de' | 'it' | 'zh' | '';
-  tone: 'formal' | 'informal' | 'neutral' | '';
+  targetLanguage: LanguageCode | '';
+  tone: ToneCode | '';
 }
 
 export interface TranslationConfigProps {
@@ -31,20 +66,6 @@ export interface TranslationConfigProps {
     tone?: string;
   };
 }
-
-const LANGUAGES = [
-  { value: 'es', label: 'Spanish (Español)' },
-  { value: 'fr', label: 'French (Français)' },
-  { value: 'de', label: 'German (Deutsch)' },
-  { value: 'it', label: 'Italian (Italiano)' },
-  { value: 'zh', label: 'Chinese (中文)' },
-];
-
-const TONES = [
-  { value: 'formal', label: 'Formal', description: 'Professional and respectful language' },
-  { value: 'neutral', label: 'Neutral', description: 'Balanced and standard language' },
-  { value: 'informal', label: 'Informal', description: 'Casual and conversational language' },
-];
 
 export const TranslationConfig: React.FC<TranslationConfigProps> = ({
   value,
@@ -93,7 +114,7 @@ export const TranslationConfig: React.FC<TranslationConfigProps> = ({
             <MenuItem value="">
               <em>Select a language</em>
             </MenuItem>
-            {LANGUAGES.map((lang) => (
+            {LANGUAGE_OPTIONS.map((lang) => (
               <MenuItem key={lang.value} value={lang.value}>
                 {lang.label}
               </MenuItem>
@@ -123,7 +144,7 @@ export const TranslationConfig: React.FC<TranslationConfigProps> = ({
             <MenuItem value="">
               <em>Select a tone</em>
             </MenuItem>
-            {TONES.map((tone) => (
+            {TONE_OPTIONS.map((tone) => (
               <MenuItem key={tone.value} value={tone.value}>
                 <Box>
                   <Typography>{tone.label}</Typography>

--- a/frontend/src/components/Translation/TranslationProgress.tsx
+++ b/frontend/src/components/Translation/TranslationProgress.tsx
@@ -13,6 +13,7 @@ import ErrorIcon from '@mui/icons-material/Error';
 import HourglassEmptyIcon from '@mui/icons-material/HourglassEmpty';
 import { TranslationJob } from '../../services/translationService';
 import { useTranslationJob, calculateProgress } from '../../hooks/useTranslationJob';
+import { getLanguageLabel } from '../../utils/translationLabels';
 
 export interface TranslationProgressProps {
   jobId: string;
@@ -132,7 +133,7 @@ export const TranslationProgress: React.FC<TranslationProgressProps> = ({
             <Typography variant="caption" color="text.secondary">
               Target Language
             </Typography>
-            <Typography variant="body2">{job.targetLanguage}</Typography>
+            <Typography variant="body2">{getLanguageLabel(job.targetLanguage)}</Typography>
           </Box>
         )}
 

--- a/frontend/src/components/Translation/__tests__/TranslationProgress.test.tsx
+++ b/frontend/src/components/Translation/__tests__/TranslationProgress.test.tsx
@@ -77,11 +77,12 @@ describe('TranslationProgress Component', () => {
       // Act
       render(<TranslationProgress jobId="job-123" />);
 
-      // Assert
+      // Assert — Issue #145: progress card shows the friendly language
+      // label, not the raw 'es' code.
       await waitFor(() => {
         expect(screen.getByText('Translation Progress')).toBeInTheDocument();
         expect(screen.getByText('test-document.txt')).toBeInTheDocument();
-        expect(screen.getByText('es')).toBeInTheDocument();
+        expect(screen.getByText('Spanish (Español)')).toBeInTheDocument();
       });
     });
 

--- a/frontend/src/mocks/__tests__/handlers.test.ts
+++ b/frontend/src/mocks/__tests__/handlers.test.ts
@@ -37,8 +37,11 @@ describe('computeProgress (simulation policy)', () => {
       completedChunks: 0,
       failedChunks: 0,
       fileName: 'doc.txt',
+      // Persisted on JobState for Issues #143 (tone) and #144 (fileSize).
+      fileSize: 0,
       sourceLang: 'auto',
       targetLang: 'es',
+      tone: 'neutral',
       createdAt: new Date(0).toISOString(),
       ...overrides,
     };
@@ -411,8 +414,10 @@ describe('Reserved filename error injection (Phase 5)', () => {
       completedChunks: 0,
       failedChunks: 0,
       fileName: '__lfmt_mock_slow__.txt',
+      fileSize: 0,
       sourceLang: 'auto',
       targetLang: 'es',
+      tone: 'neutral',
       createdAt: new Date(0).toISOString(),
       translateStartedAt: start,
     };

--- a/frontend/src/mocks/__tests__/handlers.test.ts
+++ b/frontend/src/mocks/__tests__/handlers.test.ts
@@ -37,7 +37,9 @@ describe('computeProgress (simulation policy)', () => {
       completedChunks: 0,
       failedChunks: 0,
       fileName: 'doc.txt',
-      // Persisted on JobState for Issues #143 (tone) and #144 (fileSize).
+      // Persisted on JobState for Issues #143 (tone), #144 (fileSize),
+      // and the R1 review follow-up (userId snapshotted at upload time).
+      userId: 'mock-user-default',
       fileSize: 0,
       sourceLang: 'auto',
       targetLang: 'es',
@@ -194,6 +196,79 @@ describe('Auth handlers (msw/node)', () => {
       body: JSON.stringify({ token: '', newPassword: '' }),
     });
     expect(r.status).toBe(400);
+  });
+
+  // ----------------------------------------------------------------
+  // R6 (OMC review follow-up) — auth-behavior coverage for #141, #142
+  // ----------------------------------------------------------------
+
+  it('Issue #141: /auth/me falls back to lastIssuedUser when token is unknown but Bearer is present', async () => {
+    // Step 1: register so `lastIssuedUser` is populated.
+    const reg = await fetch(`${API_URL}/auth/register`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        email: 'sw-restart@test.dev',
+        firstName: 'SW',
+        lastName: 'Restart',
+      }),
+    }).then((r) => r.json());
+    expect(reg.user.email).toBe('sw-restart@test.dev');
+
+    // Step 2: simulate a Service-Worker restart by passing a Bearer
+    // token the closure-scoped `sessions` Map has never seen. Pre-#141
+    // this returned a hardcoded 'Mock User'; post-#141 the recovery
+    // path should resolve to whoever was last issued tokens (i.e. the
+    // user we just registered).
+    const me = await fetch(`${API_URL}/auth/me`, {
+      headers: { Authorization: 'Bearer mock-access-fake-token-the-sw-forgot' },
+    });
+    expect(me.status).toBe(200);
+    const body = await me.json();
+    expect(body.user.email).toBe('sw-restart@test.dev');
+    expect(body.user.firstName).toBe('SW');
+    expect(body.user.lastName).toBe('Restart');
+  });
+
+  it('Issue #141: /auth/me returns 401 when no Authorization header is present', async () => {
+    // Even if `lastIssuedUser` is set, a request with NO Bearer token
+    // at all must hit the 401 branch — that is the AuthContext's
+    // signal to redirect to /login.
+    await fetch(`${API_URL}/auth/register`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'noauth@test.dev', firstName: 'No', lastName: 'Auth' }),
+    });
+
+    const r = await fetch(`${API_URL}/auth/me`); // no headers
+    expect(r.status).toBe(401);
+  });
+
+  it('Issue #142: /auth/login looks up registeredUsers and returns the registered firstName/lastName', async () => {
+    // Step 1: register with concrete identity fields.
+    const reg = await fetch(`${API_URL}/auth/register`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        email: 'foo@bar.dev',
+        firstName: 'Foo',
+        lastName: 'Bar',
+      }),
+    }).then((r) => r.json());
+    expect(reg.user.firstName).toBe('Foo');
+
+    // Step 2: log in with the same email but supply NO firstName/lastName.
+    // Pre-#142 the handler fabricated a generic 'Mock User' here; post-#142
+    // it resolves the previously-registered identity by email.
+    const login = await fetch(`${API_URL}/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'foo@bar.dev', password: 'irrelevant-in-mock' }),
+    }).then((r) => r.json());
+
+    expect(login.user.email).toBe('foo@bar.dev');
+    expect(login.user.firstName).toBe('Foo');
+    expect(login.user.lastName).toBe('Bar');
   });
 });
 
@@ -414,6 +489,7 @@ describe('Reserved filename error injection (Phase 5)', () => {
       completedChunks: 0,
       failedChunks: 0,
       fileName: '__lfmt_mock_slow__.txt',
+      userId: 'mock-user-default',
       fileSize: 0,
       sourceLang: 'auto',
       targetLang: 'es',

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -73,6 +73,14 @@ export type JobState = {
   completedChunks: number;
   failedChunks: number;
   fileName: string;
+  // Captured from the active session at upload time (R1: OMC review
+  // follow-up). Previously `toWireJob` read `lastIssuedUser?.id` directly
+  // — that broadened the `/auth/me` single-tenant escape hatch into the
+  // job-side surface AND created hidden coupling between the auth and
+  // job paths. By snapshotting the userId onto the job at creation and
+  // having `toWireJob` echo `state.userId`, `lastIssuedUser` stays
+  // strictly scoped to the `/auth/me` recovery path.
+  userId: string;
   // Persisted from the upload request so the wire shape can echo back the
   // actual size on the Translation Details / History views (Issue #144).
   // Without this, every job rendered as "File Size: 0 Bytes".
@@ -438,7 +446,10 @@ function toWireStatus(state: JobState): string {
 function toWireJob(state: JobState): Record<string, unknown> {
   return {
     jobId: state.jobId,
-    userId: lastIssuedUser?.id ?? 'mock-user-default',
+    // R1: echo the userId captured on the job at upload time. Do NOT
+    // touch `lastIssuedUser` here — it is reserved for the `/auth/me`
+    // SW-restart recovery path (Issue #141).
+    userId: state.userId,
     fileName: state.fileName,
     // Issue #144: was hardcoded to 0; now echoes the value captured from
     // the upload request body so the Job Information view shows the real
@@ -542,6 +553,18 @@ const translationHandlers: HttpHandler[] = [
     const jobId = uuid();
     const now = new Date().toISOString();
 
+    // R1: snapshot the active user's id at upload time so the job
+    // record carries its own owner. Resolution order:
+    //   1. The Bearer token on the request (real auth round-trip — the
+    //      authoritative source when the SW closure is intact).
+    //   2. `lastIssuedUser` (Issue #141 fallback — covers the SW-restart
+    //      window where `sessions` was wiped but the page still has a
+    //      valid token in localStorage).
+    //   3. A stable default — only reached when the demo is launched
+    //      without ever calling /auth/register or /auth/login first.
+    const sessionUser = userFromAuthHeader(request.headers.get('Authorization'));
+    const userId = sessionUser?.id ?? lastIssuedUser?.id ?? 'mock-user-default';
+
     jobs.set(jobId, {
       jobId,
       status: 'uploaded',
@@ -549,6 +572,7 @@ const translationHandlers: HttpHandler[] = [
       completedChunks: 0,
       failedChunks: 0,
       fileName,
+      userId,
       fileSize,
       sourceLang: 'auto',
       targetLang: 'es',

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -73,8 +73,18 @@ export type JobState = {
   completedChunks: number;
   failedChunks: number;
   fileName: string;
+  // Persisted from the upload request so the wire shape can echo back the
+  // actual size on the Translation Details / History views (Issue #144).
+  // Without this, every job rendered as "File Size: 0 Bytes".
+  fileSize: number;
   sourceLang: string;
   targetLang: string;
+  // Persisted from the translate request so all views (wizard review →
+  // job details → history) display the same tone. Defaults to 'neutral'
+  // when the request omits it, matching shared-types/src/jobs.ts default.
+  // Issue #143: previous code dropped tone on the floor and rendered
+  // 'neutral' regardless of the wizard selection.
+  tone: string;
   createdAt: string;
   completedAt?: string;
   /**
@@ -106,6 +116,19 @@ const jobs = new Map<string, JobState>();
 // Token → user lookup, populated on register/login. Mirrors the real
 // backend's "session" abstraction; cleared on resetState() / logout.
 const sessions = new Map<string, MockUser>();
+// Email (lowercased) → user lookup, populated on register and consulted
+// on login. Without this, the login handler had no way to recover the
+// firstName/lastName a user supplied at registration, so it fabricated a
+// generic 'Mock User' on every login (Issue #142). Persisted across the
+// closure lifetime; cleared on resetState() the same way `sessions` is.
+const registeredUsers = new Map<string, MockUser>();
+// Most-recently-issued user. Fallback for `GET /auth/me` when the access
+// token isn't in `sessions` — happens when the SW restarts between page
+// navigations and loses closure state, but the page still has a valid
+// access token in localStorage. Without this, /auth/me silently returned
+// `mock-user-default` ('Mock User'), breaking the perceived session
+// across direct-URL navigation (Issue #141).
+let lastIssuedUser: MockUser | null = null;
 
 /**
  * Reset the closure-scoped job store. Used by Vitest `afterEach` and
@@ -116,6 +139,8 @@ const sessions = new Map<string, MockUser>();
 export function resetState(): void {
   jobs.clear();
   sessions.clear();
+  registeredUsers.clear();
+  lastIssuedUser = null;
 }
 
 // ---------------------------------------------------------------------------
@@ -144,6 +169,10 @@ function issueTokens(user: MockUser): {
   const refreshToken = `mock-refresh-${uuid()}`;
   sessions.set(accessToken, user);
   sessions.set(refreshToken, user);
+  // Track the most-recently-issued user so /auth/me can recover identity
+  // after a Service-Worker restart wipes the `sessions` Map but the page
+  // still holds a valid access token in localStorage (Issue #141).
+  lastIssuedUser = user;
   return { accessToken, refreshToken };
 }
 
@@ -167,6 +196,10 @@ const authHandlers: HttpHandler[] = [
       firstName: typeof body.firstName === 'string' ? body.firstName : undefined,
       lastName: typeof body.lastName === 'string' ? body.lastName : undefined,
     });
+    // Persist the registered user keyed by email so a subsequent login
+    // round-trip can recover firstName/lastName instead of fabricating a
+    // generic "Mock User" (Issue #142).
+    registeredUsers.set(user.email.toLowerCase(), user);
     const tokens = issueTokens(user);
     return HttpResponse.json({ user, ...tokens }, { status: 200 });
   }),
@@ -174,9 +207,14 @@ const authHandlers: HttpHandler[] = [
   // POST /auth/login
   http.post(buildPath('/auth/login'), async ({ request }) => {
     const body = (await request.json().catch(() => ({}))) as Record<string, unknown>;
-    const user = buildMockUser({
-      email: typeof body.email === 'string' ? body.email : undefined,
-    });
+    const email = typeof body.email === 'string' ? body.email : undefined;
+    // Look up the previously-registered user by email before falling back
+    // to a synthesized one. Without this, every login returned a fresh
+    // 'Mock User' and the user's real firstName/lastName from registration
+    // was lost (Issue #142). Mock mode is single-tenant by design, so the
+    // password is intentionally not validated.
+    const existing = email ? registeredUsers.get(email.toLowerCase()) : undefined;
+    const user = existing ?? buildMockUser({ email });
     const tokens = issueTokens(user);
     return HttpResponse.json({ user, ...tokens }, { status: 200 });
   }),
@@ -209,19 +247,29 @@ const authHandlers: HttpHandler[] = [
 
   // GET /auth/me — authService expects { user: User } (NOT bare User).
   http.get(buildPath('/auth/me'), ({ request }) => {
-    const user = userFromAuthHeader(request.headers.get('Authorization'));
-    if (!user) {
-      // Default fallback so the dashboard renders even on a fresh
-      // page reload before the user has an active session.
-      const fallback: MockUser = {
-        id: 'mock-user-default',
-        email: 'demo@lfmt.dev',
-        firstName: 'Mock',
-        lastName: 'User',
-      };
-      return HttpResponse.json({ user: fallback }, { status: 200 });
+    const authHeader = request.headers.get('Authorization');
+    const user = userFromAuthHeader(authHeader);
+    if (user) {
+      return HttpResponse.json({ user }, { status: 200 });
     }
-    return HttpResponse.json({ user }, { status: 200 });
+    // Issue #141: when the SW restarts mid-session, the closure-scoped
+    // `sessions` Map is wiped but the page still has a valid access
+    // token in localStorage. The previous code returned a hardcoded
+    // 'Mock User' here, breaking the UI's perceived session on every
+    // direct-URL navigation. Recovery policy:
+    //   1. If the request bears SOME Bearer token AND we still remember
+    //      who we last issued tokens for, treat that as the active user.
+    //      Mock mode is single-tenant by design, so this matches the
+    //      demo scenario without leaking identity across sessions.
+    //   2. Otherwise (no Authorization header at all), respond 401 so
+    //      the AuthContext can route to /login deterministically — this
+    //      is closer to the real backend's contract than a hardcoded
+    //      fallback user.
+    const hasBearerToken = !!authHeader && /^Bearer\s+\S+/.test(authHeader);
+    if (hasBearerToken && lastIssuedUser) {
+      return HttpResponse.json({ user: lastIssuedUser }, { status: 200 });
+    }
+    return HttpResponse.json({ message: 'Unauthorized' }, { status: 401 });
   }),
 
   // POST /auth/forgot-password — mirrors real backend: success even
@@ -390,13 +438,18 @@ function toWireStatus(state: JobState): string {
 function toWireJob(state: JobState): Record<string, unknown> {
   return {
     jobId: state.jobId,
-    userId: 'mock-user-default',
+    userId: lastIssuedUser?.id ?? 'mock-user-default',
     fileName: state.fileName,
-    fileSize: 0,
+    // Issue #144: was hardcoded to 0; now echoes the value captured from
+    // the upload request body so the Job Information view shows the real
+    // size instead of "0 Bytes".
+    fileSize: state.fileSize,
     contentType: 'text/plain',
     status: toWireStatus(state),
     targetLanguage: state.targetLang,
-    tone: 'neutral',
+    // Issue #143: was hardcoded to 'neutral'; now echoes whatever the
+    // translate request supplied (or the wizard's neutral default).
+    tone: state.tone,
     totalChunks: state.totalChunks,
     completedChunks: state.completedChunks,
     failedChunks: state.failedChunks,
@@ -496,8 +549,12 @@ const translationHandlers: HttpHandler[] = [
       completedChunks: 0,
       failedChunks: 0,
       fileName,
+      fileSize,
       sourceLang: 'auto',
       targetLang: 'es',
+      // Default tone matches shared-types/src/jobs.ts; overwritten by
+      // the translate request when the wizard supplies a value.
+      tone: 'neutral',
       createdAt: now,
     });
 
@@ -566,6 +623,14 @@ const translationHandlers: HttpHandler[] = [
     const body = (await request.json().catch(() => ({}))) as Record<string, unknown>;
     if (typeof body.targetLanguage === 'string') {
       job.targetLang = body.targetLanguage;
+    }
+    // Issue #143: previously, `tone` from the wizard was dropped on the
+    // floor here and the job always showed 'neutral'. Persist whatever
+    // the wizard supplies; any other code path that reads back the job
+    // (status poll, history list, details page) will see the correct
+    // value via toWireJob().
+    if (typeof body.tone === 'string') {
+      job.tone = body.tone;
     }
     job.status = 'translating';
     job.translateStartedAt = Date.now();

--- a/frontend/src/pages/TranslationDetail.tsx
+++ b/frontend/src/pages/TranslationDetail.tsx
@@ -28,6 +28,7 @@ import {
   TranslationServiceError,
 } from '../services/translationService';
 import { TranslationProgress } from '../components/Translation/TranslationProgress';
+import { getLanguageLabel, getToneLabel } from '../utils/translationLabels';
 import { FEATURE_FLAGS } from '../config/constants';
 
 export const TranslationDetail: React.FC = () => {
@@ -250,7 +251,7 @@ export const TranslationDetail: React.FC = () => {
               <Typography variant="caption" color="text.secondary">
                 Target Language
               </Typography>
-              <Typography variant="body2">{job.targetLanguage}</Typography>
+              <Typography variant="body2">{getLanguageLabel(job.targetLanguage)}</Typography>
             </Box>
           )}
 
@@ -259,7 +260,7 @@ export const TranslationDetail: React.FC = () => {
               <Typography variant="caption" color="text.secondary">
                 Tone
               </Typography>
-              <Typography variant="body2">{job.tone}</Typography>
+              <Typography variant="body2">{getToneLabel(job.tone)}</Typography>
             </Box>
           )}
 

--- a/frontend/src/pages/TranslationHistory.tsx
+++ b/frontend/src/pages/TranslationHistory.tsx
@@ -36,6 +36,7 @@ import {
   translationService,
   TranslationServiceError,
 } from '../services/translationService';
+import { getLanguageLabel, getToneLabel } from '../utils/translationLabels';
 
 const STATUS_COLORS: Record<string, 'default' | 'primary' | 'success' | 'error' | 'warning'> = {
   PENDING: 'default',
@@ -245,10 +246,12 @@ export const TranslationHistory: React.FC = () => {
                   <TableCell>
                     {job.targetLanguage ? (
                       <Box>
-                        <Typography variant="body2">{job.targetLanguage}</Typography>
+                        <Typography variant="body2">
+                          {getLanguageLabel(job.targetLanguage)}
+                        </Typography>
                         {job.tone && (
                           <Typography variant="caption" color="text.secondary">
-                            {job.tone}
+                            {getToneLabel(job.tone)}
                           </Typography>
                         )}
                       </Box>

--- a/frontend/src/pages/TranslationUpload.tsx
+++ b/frontend/src/pages/TranslationUpload.tsx
@@ -25,7 +25,7 @@ import {
   TranslationConfigData,
 } from '../components/Translation/TranslationConfig';
 import { FileUpload } from '../components/Translation/FileUpload';
-import { translationService, TranslationServiceError } from '../services/translationService';
+import { translationService } from '../services/translationService';
 import { getLanguageLabel, getToneLabel } from '../utils/translationLabels';
 import { getTranslationErrorMessage } from '../utils/translationErrorMessages';
 
@@ -169,13 +169,11 @@ export const TranslationUpload: React.FC = () => {
       // Issue #147: surface a user-facing message keyed off the HTTP
       // status (or the absence of one, for network failures) rather
       // than passing through the raw backend message or a generic
-      // catch-all. TranslationServiceError carries `statusCode` from
-      // axios; getTranslationErrorMessage understands both shapes.
-      if (error instanceof TranslationServiceError) {
-        setSubmitError(getTranslationErrorMessage(error));
-      } else {
-        setSubmitError(getTranslationErrorMessage(error));
-      }
+      // catch-all. `getTranslationErrorMessage` accepts an `unknown`
+      // and handles both `TranslationServiceError` (which carries
+      // `statusCode`) and bare `Error` shapes — the previous if/else
+      // was a refactor leftover. (R4: OMC review follow-up.)
+      setSubmitError(getTranslationErrorMessage(error));
     } finally {
       setIsSubmitting(false);
     }

--- a/frontend/src/pages/TranslationUpload.tsx
+++ b/frontend/src/pages/TranslationUpload.tsx
@@ -26,6 +26,8 @@ import {
 } from '../components/Translation/TranslationConfig';
 import { FileUpload } from '../components/Translation/FileUpload';
 import { translationService, TranslationServiceError } from '../services/translationService';
+import { getLanguageLabel, getToneLabel } from '../utils/translationLabels';
+import { getTranslationErrorMessage } from '../utils/translationErrorMessages';
 
 const STEPS = ['Legal Attestation', 'Translation Settings', 'Upload Document', 'Review & Submit'];
 
@@ -164,10 +166,15 @@ export const TranslationUpload: React.FC = () => {
       // Navigate to translation detail page
       navigate(`/translation/${job.jobId}`);
     } catch (error) {
+      // Issue #147: surface a user-facing message keyed off the HTTP
+      // status (or the absence of one, for network failures) rather
+      // than passing through the raw backend message or a generic
+      // catch-all. TranslationServiceError carries `statusCode` from
+      // axios; getTranslationErrorMessage understands both shapes.
       if (error instanceof TranslationServiceError) {
-        setSubmitError(error.message);
+        setSubmitError(getTranslationErrorMessage(error));
       } else {
-        setSubmitError('An unexpected error occurred. Please try again.');
+        setSubmitError(getTranslationErrorMessage(error));
       }
     } finally {
       setIsSubmitting(false);
@@ -188,7 +195,21 @@ export const TranslationUpload: React.FC = () => {
         return (
           <TranslationConfig
             value={formData.translationConfig}
-            onChange={(data) => setFormData((prev) => ({ ...prev, translationConfig: data }))}
+            onChange={(data) => {
+              setFormData((prev) => ({ ...prev, translationConfig: data }));
+              // Issue #148: clear stale validation alerts as soon as the
+              // user fixes the offending field, instead of waiting for
+              // the next "Next" click to revalidate. We selectively clear
+              // only the fields whose values are now non-empty so an
+              // unfilled second dropdown still surfaces its error.
+              setErrors((prev) => {
+                if (!prev.translationConfig) return prev;
+                const next = { ...prev.translationConfig };
+                if (data.targetLanguage) delete next.targetLanguage;
+                if (data.tone) delete next.tone;
+                return { ...prev, translationConfig: next };
+              });
+            }}
             errors={errors.translationConfig}
           />
         );
@@ -218,14 +239,16 @@ export const TranslationUpload: React.FC = () => {
                 Target Language:
               </Typography>
               <Typography variant="body2" sx={{ mb: 2 }}>
-                {formData.translationConfig.targetLanguage}
+                {/* Issue #145: show the friendly label, not the raw 'es' code */}
+                {getLanguageLabel(formData.translationConfig.targetLanguage)}
               </Typography>
 
               <Typography variant="subtitle2" gutterBottom>
                 Tone:
               </Typography>
               <Typography variant="body2" sx={{ mb: 2 }}>
-                {formData.translationConfig.tone}
+                {/* Issue #145: 'Formal' instead of 'formal' */}
+                {getToneLabel(formData.translationConfig.tone)}
               </Typography>
 
               <Typography variant="subtitle2" gutterBottom>

--- a/frontend/src/pages/__tests__/TranslationDetail.test.tsx
+++ b/frontend/src/pages/__tests__/TranslationDetail.test.tsx
@@ -241,9 +241,11 @@ describe('TranslationDetail', () => {
 
       renderComponent();
 
+      // Issue #145: detail view now renders friendly labels rather than the
+      // raw 'es' / 'formal' codes.
       await waitFor(() => {
-        expect(screen.getByText('es')).toBeInTheDocument();
-        expect(screen.getByText('formal')).toBeInTheDocument();
+        expect(screen.getByText('Spanish (Español)')).toBeInTheDocument();
+        expect(screen.getByText('Formal')).toBeInTheDocument();
       });
     });
   });

--- a/frontend/src/pages/__tests__/TranslationHistory.test.tsx
+++ b/frontend/src/pages/__tests__/TranslationHistory.test.tsx
@@ -169,11 +169,12 @@ describe('TranslationHistory', () => {
       expect(screen.getByRole('columnheader', { name: /Created/i })).toBeInTheDocument();
       expect(screen.getByRole('columnheader', { name: /Actions/i })).toBeInTheDocument();
 
-      // Check job data
+      // Check job data — Issue #145: history table renders friendly
+      // labels rather than raw 'es' / 'formal' enum codes.
       expect(screen.getByText('document1.txt')).toBeInTheDocument();
       expect(screen.getByText('job-1')).toBeInTheDocument();
-      expect(screen.getByText('es')).toBeInTheDocument();
-      expect(screen.getByText('formal')).toBeInTheDocument();
+      expect(screen.getByText('Spanish (Español)')).toBeInTheDocument();
+      expect(screen.getByText('Formal')).toBeInTheDocument();
       expect(screen.getByText('COMPLETED')).toBeInTheDocument();
     });
 
@@ -620,13 +621,14 @@ describe('TranslationHistory', () => {
 
       renderComponent();
 
+      // Issue #145: friendly labels rather than raw enum codes.
       await waitFor(() => {
-        expect(screen.getByText('es')).toBeInTheDocument();
+        expect(screen.getByText('Spanish (Español)')).toBeInTheDocument();
       });
 
-      expect(screen.getByText('formal')).toBeInTheDocument();
-      expect(screen.getByText('fr')).toBeInTheDocument();
-      expect(screen.getByText('informal')).toBeInTheDocument();
+      expect(screen.getByText('Formal')).toBeInTheDocument();
+      expect(screen.getByText('French (Français)')).toBeInTheDocument();
+      expect(screen.getByText('Informal')).toBeInTheDocument();
     });
 
     it('should show "Not set" when language is missing', async () => {

--- a/frontend/src/pages/__tests__/TranslationUpload.test.tsx
+++ b/frontend/src/pages/__tests__/TranslationUpload.test.tsx
@@ -38,9 +38,15 @@ vi.mock('../../services/translationService', () => ({
     startTranslation: vi.fn(),
   },
   TranslationServiceError: class TranslationServiceError extends Error {
-    constructor(message: string) {
+    statusCode?: number;
+    constructor(message: string, statusCode?: number) {
       super(message);
       this.name = 'TranslationServiceError';
+      // Mirror the production constructor (translationService.ts:79-87) so
+      // tests that exercise HTTP-status-aware UX (Issue #147) get a real
+      // statusCode on the error instead of always falling through to the
+      // network-error branch of getTranslationErrorMessage.
+      this.statusCode = statusCode;
     }
   },
 }));
@@ -345,8 +351,10 @@ describe('TranslationUpload', () => {
 
       expect(screen.getByText('Review Your Submission')).toBeInTheDocument();
       expect(screen.getByText('test-document.txt')).toBeInTheDocument();
-      expect(screen.getByText('es')).toBeInTheDocument(); // language code
-      expect(screen.getByText('formal')).toBeInTheDocument();
+      // Issue #145: review step now shows friendly labels rather than
+      // raw enum codes ('es' / 'formal').
+      expect(screen.getByText('Spanish (Español)')).toBeInTheDocument();
+      expect(screen.getByText('Formal')).toBeInTheDocument();
       expect(screen.getByText(/All requirements confirmed/i)).toBeInTheDocument();
     });
 
@@ -445,11 +453,18 @@ describe('TranslationUpload', () => {
       renderComponent();
       await advanceToStep4(user);
 
-      // Mock failed service call
+      // Mock failed service call — Issue #147: errors with a known
+      // statusCode resolve to a curated user-facing phrase. With
+      // statusCode=413, the helper produces the file-too-large message;
+      // with statusCode=undefined (no response from network failure) it
+      // produces the connection-lost message. The helper falls back to
+      // the raw error.message ONLY when the status is set but unmapped,
+      // so we set statusCode=400 with a literal message to exercise the
+      // pass-through branch.
       const TranslationServiceError = (await import('../../services/translationService'))
         .TranslationServiceError;
       vi.mocked(translationService.createLegalAttestation).mockRejectedValue(
-        new TranslationServiceError('Upload failed: Network error')
+        new TranslationServiceError('Upload failed: invalid file', 400)
       );
 
       const submitButton = screen.getByRole('button', { name: /Submit & Start Translation/i });
@@ -458,16 +473,18 @@ describe('TranslationUpload', () => {
       await waitFor(() => {
         const errorAlert = screen.getByRole('alert');
         expect(errorAlert).toBeInTheDocument();
-        expect(errorAlert).toHaveTextContent(/Upload failed: Network error/i);
+        // 400 is mapped → curated phrase rather than the raw message.
+        expect(errorAlert).toHaveTextContent(/Translation could not start/i);
       });
     });
 
-    it('should display generic error message for unexpected errors', async () => {
+    it('should display network-error message for unexpected errors', async () => {
       const user = userEvent.setup();
       renderComponent();
       await advanceToStep4(user);
 
-      // Mock unexpected error
+      // Mock unexpected error — bare Error has no statusCode, which the
+      // helper treats as a network/transport failure (Issue #147).
       vi.mocked(translationService.createLegalAttestation).mockRejectedValue(
         new Error('Unexpected error')
       );
@@ -478,7 +495,7 @@ describe('TranslationUpload', () => {
       await waitFor(() => {
         const errorAlert = screen.getByRole('alert');
         expect(errorAlert).toBeInTheDocument();
-        expect(errorAlert).toHaveTextContent(/An unexpected error occurred/i);
+        expect(errorAlert).toHaveTextContent(/Connection lost/i);
       });
     });
 

--- a/frontend/src/utils/__tests__/translationErrorMessages.test.ts
+++ b/frontend/src/utils/__tests__/translationErrorMessages.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Unit tests for translationErrorMessages.ts (Issue #147, R5 OMC follow-up).
+ *
+ * Locks in the precedence rules:
+ *   1. Known HTTP status → curated phrase.
+ *   2. statusCode === undefined → NETWORK_MESSAGE (axios !response).
+ *   3. Unknown status with a usable message → pass-through.
+ *   4. null / non-object error → FALLBACK_MESSAGE.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { getTranslationErrorMessage } from '../translationErrorMessages';
+
+const NETWORK_MESSAGE = 'Connection lost — check your internet and try again.';
+const FALLBACK_MESSAGE = 'An unexpected error occurred. Please try again.';
+
+describe('getTranslationErrorMessage — mapped HTTP statuses', () => {
+  // Each row covers one entry of the STATUS_MESSAGES table. The literal
+  // text is asserted so a copy-tweak that breaks the demo phrasing
+  // surfaces here, not in a manual smoke test.
+  it.each([
+    [
+      400,
+      'Translation could not start because the request was invalid. Please review your selections and try again.',
+    ],
+    [401, 'Your session has expired — please log in again.'],
+    [403, "You don't have permission to start this translation."],
+    [413, 'File too large — the maximum supported size is 10 MB.'],
+    [429, 'Translation rate limit reached — please try again in a moment.'],
+    [500, 'Server error — our team has been notified. Please try again.'],
+    [502, 'Translation service is temporarily unavailable. Please try again shortly.'],
+    [503, 'Translation service is temporarily unavailable. Please try again shortly.'],
+    [504, 'Translation service is temporarily unavailable. Please try again shortly.'],
+  ])('maps statusCode=%i to its curated phrase', (statusCode, expected) => {
+    const error = { statusCode, message: 'irrelevant raw message' };
+    expect(getTranslationErrorMessage(error)).toBe(expected);
+  });
+});
+
+describe('getTranslationErrorMessage — network failures', () => {
+  it('returns NETWORK_MESSAGE when statusCode is undefined', () => {
+    // Axios sets `error.response = undefined` for ERR_NETWORK; the
+    // wrapper TranslationServiceError surfaces that as
+    // statusCode = undefined.
+    const error = { message: 'Network Error' };
+    expect(getTranslationErrorMessage(error)).toBe(NETWORK_MESSAGE);
+  });
+
+  it('returns NETWORK_MESSAGE when statusCode is undefined even with no message', () => {
+    expect(getTranslationErrorMessage({})).toBe(NETWORK_MESSAGE);
+  });
+});
+
+describe('getTranslationErrorMessage — unknown HTTP statuses', () => {
+  it('passes through a usable backend message when status is unmapped', () => {
+    // 418 is unmapped on purpose — the precedence check should fall
+    // through to the message pass-through branch.
+    const error = { statusCode: 418, message: 'Translation engine is on vacation' };
+    expect(getTranslationErrorMessage(error)).toBe('Translation engine is on vacation');
+  });
+
+  it('falls back when the unmapped error message is empty', () => {
+    const error = { statusCode: 418, message: '' };
+    expect(getTranslationErrorMessage(error)).toBe(FALLBACK_MESSAGE);
+  });
+
+  it('falls back when an unmapped error has no message at all', () => {
+    const error = { statusCode: 418 };
+    expect(getTranslationErrorMessage(error)).toBe(FALLBACK_MESSAGE);
+  });
+});
+
+describe('getTranslationErrorMessage — null / non-object inputs', () => {
+  it.each([null, undefined, 'string error', 42, true])(
+    'returns FALLBACK_MESSAGE for non-object input %p',
+    (input) => {
+      expect(getTranslationErrorMessage(input)).toBe(FALLBACK_MESSAGE);
+    }
+  );
+});

--- a/frontend/src/utils/__tests__/translationLabels.test.ts
+++ b/frontend/src/utils/__tests__/translationLabels.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Unit tests for translationLabels.ts (Issue #145, R5 OMC follow-up).
+ *
+ * These pure-function tests lock in:
+ *   - All entries in LANGUAGE_LABELS / TONE_LABELS are present.
+ *   - getLanguageLabel / getToneLabel handle null + undefined.
+ *   - getToneLabel capitalizes unknown codes (visual consistency).
+ *   - getLanguageLabel passes unknown codes through verbatim.
+ *
+ * They are intentionally O(ms) — no React rendering, no MSW setup.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { LANGUAGE_LABELS, TONE_LABELS, getLanguageLabel, getToneLabel } from '../translationLabels';
+
+describe('LANGUAGE_LABELS table', () => {
+  it('exposes the dropdown-derived languages', () => {
+    // The labels are derived from `LANGUAGE_OPTIONS` in
+    // `TranslationConfig.tsx` — re-asserting them here pins both the
+    // derive step AND the alias extension in one place.
+    expect(LANGUAGE_LABELS.es).toBe('Spanish (Español)');
+    expect(LANGUAGE_LABELS.fr).toBe('French (Français)');
+    expect(LANGUAGE_LABELS.de).toBe('German (Deutsch)');
+    expect(LANGUAGE_LABELS.it).toBe('Italian (Italiano)');
+    expect(LANGUAGE_LABELS.zh).toBe('Chinese (中文)');
+  });
+
+  it('includes the legacy English alias not present in the dropdown', () => {
+    // 'en' is an extension on top of the derived map — it appears in
+    // legacy DDB rows but is not selectable from the wizard.
+    expect(LANGUAGE_LABELS.en).toBe('English');
+  });
+});
+
+describe('TONE_LABELS table', () => {
+  it('exposes the dropdown-derived tones', () => {
+    expect(TONE_LABELS.formal).toBe('Formal');
+    expect(TONE_LABELS.neutral).toBe('Neutral');
+    expect(TONE_LABELS.informal).toBe('Informal');
+  });
+
+  it('includes the legacy "casual" alias for old DDB rows', () => {
+    expect(TONE_LABELS.casual).toBe('Casual');
+  });
+});
+
+describe('getLanguageLabel', () => {
+  it.each([
+    ['es', 'Spanish (Español)'],
+    ['fr', 'French (Français)'],
+    ['de', 'German (Deutsch)'],
+    ['it', 'Italian (Italiano)'],
+    ['zh', 'Chinese (中文)'],
+    ['en', 'English'],
+  ])('resolves "%s" → "%s"', (code, expected) => {
+    expect(getLanguageLabel(code)).toBe(expected);
+  });
+
+  it('returns empty string for null / undefined / empty input', () => {
+    expect(getLanguageLabel(undefined)).toBe('');
+    expect(getLanguageLabel(null)).toBe('');
+    expect(getLanguageLabel('')).toBe('');
+  });
+
+  it('passes unknown codes through verbatim (degraded display)', () => {
+    // No capitalize fallback — the language code may already be a
+    // localized name (e.g. "ja-JP") and modifying it would break
+    // legitimate values.
+    expect(getLanguageLabel('xx')).toBe('xx');
+    expect(getLanguageLabel('ja-JP')).toBe('ja-JP');
+  });
+});
+
+describe('getToneLabel', () => {
+  it.each([
+    ['formal', 'Formal'],
+    ['neutral', 'Neutral'],
+    ['informal', 'Informal'],
+    ['casual', 'Casual'],
+  ])('resolves "%s" → "%s"', (code, expected) => {
+    expect(getToneLabel(code)).toBe(expected);
+  });
+
+  it('returns empty string for null / undefined / empty input', () => {
+    expect(getToneLabel(undefined)).toBe('');
+    expect(getToneLabel(null)).toBe('');
+    expect(getToneLabel('')).toBe('');
+  });
+
+  it('capitalizes the first character of unknown codes', () => {
+    // The tone enum in DDB is small; if a new value sneaks in (e.g.
+    // 'sarcastic'), render it Title-Case for visual consistency with
+    // the known entries instead of leaving it raw lowercase.
+    expect(getToneLabel('sarcastic')).toBe('Sarcastic');
+    expect(getToneLabel('a')).toBe('A');
+  });
+
+  it('does not double-capitalize known entries', () => {
+    // Sanity check that the mapped-table branch wins over the
+    // capitalize-fallback branch.
+    expect(getToneLabel('formal')).toBe('Formal');
+  });
+});

--- a/frontend/src/utils/translationErrorMessages.ts
+++ b/frontend/src/utils/translationErrorMessages.ts
@@ -1,0 +1,69 @@
+/**
+ * Map translation-API errors to user-facing messages (Issue #147).
+ *
+ * The wizard's submit flow used to surface either a raw backend message
+ * (which can be terse, e.g. "Rate limit exceeded") or the catch-all
+ * "An unexpected error occurred. Please try again." regardless of
+ * cause. Demos kept showing the catch-all on 429 / 500, which makes the
+ * product look unfinished even when the underlying behavior is correct.
+ *
+ * We map well-known HTTP statuses to phrases the user can act on, fall
+ * back to the backend-provided message when it's specific enough, and
+ * only ever land on a generic catch-all when neither path applies.
+ *
+ * Inputs are typed loosely so this helper can be called both with a
+ * `TranslationServiceError` (carries `statusCode`) and a bare `Error`
+ * (carries only `message`). The caller doesn't need to import any axios
+ * types.
+ */
+
+export interface TranslationErrorLike {
+  message?: string;
+  statusCode?: number;
+}
+
+const STATUS_MESSAGES: Record<number, string> = {
+  400: 'Translation could not start because the request was invalid. Please review your selections and try again.',
+  401: 'Your session has expired — please log in again.',
+  403: "You don't have permission to start this translation.",
+  413: 'File too large — the maximum supported size is 10 MB.',
+  429: 'Translation rate limit reached — please try again in a moment.',
+  500: 'Server error — our team has been notified. Please try again.',
+  502: 'Translation service is temporarily unavailable. Please try again shortly.',
+  503: 'Translation service is temporarily unavailable. Please try again shortly.',
+  504: 'Translation service is temporarily unavailable. Please try again shortly.',
+};
+
+const NETWORK_MESSAGE = 'Connection lost — check your internet and try again.';
+const FALLBACK_MESSAGE = 'An unexpected error occurred. Please try again.';
+
+/**
+ * Resolve a user-facing message for a translation-submit failure.
+ *
+ * Precedence:
+ *   1. Known HTTP status → curated phrase.
+ *   2. statusCode is undefined AND we have no usable message → treat as
+ *      a network error (axios sets `error.response = undefined` for
+ *      ERR_NETWORK).
+ *   3. Backend-provided message that is non-empty and non-generic →
+ *      pass through (handles spec-driven errors we haven't enumerated).
+ *   4. Final fallback.
+ */
+export function getTranslationErrorMessage(error: unknown): string {
+  if (!error || typeof error !== 'object') {
+    return FALLBACK_MESSAGE;
+  }
+  const e = error as TranslationErrorLike;
+  if (typeof e.statusCode === 'number' && STATUS_MESSAGES[e.statusCode]) {
+    return STATUS_MESSAGES[e.statusCode];
+  }
+  if (e.statusCode === undefined) {
+    // No HTTP status reached us — almost certainly a network/transport
+    // failure (axios.isAxiosError && !error.response).
+    return NETWORK_MESSAGE;
+  }
+  if (typeof e.message === 'string' && e.message.length > 0) {
+    return e.message;
+  }
+  return FALLBACK_MESSAGE;
+}

--- a/frontend/src/utils/translationLabels.ts
+++ b/frontend/src/utils/translationLabels.ts
@@ -1,0 +1,55 @@
+/**
+ * Display-label helpers for translation enums (Issue #145).
+ *
+ * The translation pipeline persists language and tone as short codes
+ * (`es`, `formal`, …) on the wire and in DDB. The UI was rendering
+ * those raw codes in 4+ places (wizard review, job details, history,
+ * side-by-side viewer), which looked unfinished — investors don't
+ * speak ISO-639-1.
+ *
+ * Single source of truth here so a new language or tone added in
+ * `TranslationConfig.tsx` (the dropdown source) only needs to be added
+ * once for both selection and display. The selection lists themselves
+ * still live next to the form so the dropdown layout stays local; we
+ * mirror the labels here for read-only views.
+ */
+
+export const LANGUAGE_LABELS: Record<string, string> = {
+  es: 'Spanish (Español)',
+  fr: 'French (Français)',
+  de: 'German (Deutsch)',
+  it: 'Italian (Italiano)',
+  zh: 'Chinese (中文)',
+  // Common aliases just in case the wire occasionally returns these.
+  en: 'English',
+};
+
+export const TONE_LABELS: Record<string, string> = {
+  formal: 'Formal',
+  neutral: 'Neutral',
+  informal: 'Informal',
+  // Some legacy job rows used 'casual'; keep it readable rather than
+  // stripping it (the data still exists in DDB).
+  casual: 'Casual',
+};
+
+/**
+ * Resolve a language code to its display label. Returns the input
+ * unchanged when no mapping exists, so an unknown code degrades to
+ * the raw value rather than producing an empty cell.
+ */
+export function getLanguageLabel(code: string | undefined | null): string {
+  if (!code) return '';
+  return LANGUAGE_LABELS[code] ?? code;
+}
+
+/**
+ * Resolve a tone code to its display label. Same fallback policy as
+ * `getLanguageLabel`. Capitalizes the first character of unknown codes
+ * for visual consistency with the known labels.
+ */
+export function getToneLabel(code: string | undefined | null): string {
+  if (!code) return '';
+  if (TONE_LABELS[code]) return TONE_LABELS[code];
+  return code.charAt(0).toUpperCase() + code.slice(1);
+}

--- a/frontend/src/utils/translationLabels.ts
+++ b/frontend/src/utils/translationLabels.ts
@@ -9,25 +9,56 @@
  *
  * Single source of truth here so a new language or tone added in
  * `TranslationConfig.tsx` (the dropdown source) only needs to be added
- * once for both selection and display. The selection lists themselves
- * still live next to the form so the dropdown layout stays local; we
- * mirror the labels here for read-only views.
+ * once for both selection and display.
+ *
+ * R2 (OMC review follow-up): the dropdown's option arrays live in
+ * `TranslationConfig.tsx` as `LANGUAGE_OPTIONS` / `TONE_OPTIONS` (with
+ * `as const`), and the label tables here are *derived* from those same
+ * arrays. The TypeScript types `LanguageCode` and `ToneCode` are also
+ * sourced from the option arrays, so a record keyed by those unions
+ * forces a compile error if anyone adds a language to the dropdown
+ * without picking up its label here.
  */
 
+import {
+  LANGUAGE_OPTIONS,
+  TONE_OPTIONS,
+  type LanguageCode,
+  type ToneCode,
+} from '../components/Translation/TranslationConfig';
+
+/**
+ * Derive the canonical {code → label} map directly from the dropdown's
+ * option array. Typed as `Record<LanguageCode, string>` so a missing
+ * entry would fail compilation — but because we *derive* the table from
+ * the same source the dropdown uses, drift is structurally impossible.
+ */
+const DERIVED_LANGUAGE_LABELS: Record<LanguageCode, string> = Object.fromEntries(
+  LANGUAGE_OPTIONS.map((o) => [o.value, o.label])
+) as Record<LanguageCode, string>;
+
+const DERIVED_TONE_LABELS: Record<ToneCode, string> = Object.fromEntries(
+  TONE_OPTIONS.map((o) => [o.value, o.label])
+) as Record<ToneCode, string>;
+
+/**
+ * Public label maps. Typed as `Record<string, string>` so consumers can
+ * pass a wire-derived language/tone string without a cast — the wire
+ * may carry codes outside the dropdown's enum (legacy rows, future
+ * languages), and the resolver helpers below handle that gracefully.
+ *
+ * Aliases (e.g. `en`, `casual`) extend the derived map with display
+ * fallbacks for codes that exist in stored data but are NOT present in
+ * the dropdown.
+ */
 export const LANGUAGE_LABELS: Record<string, string> = {
-  es: 'Spanish (Español)',
-  fr: 'French (Français)',
-  de: 'German (Deutsch)',
-  it: 'Italian (Italiano)',
-  zh: 'Chinese (中文)',
-  // Common aliases just in case the wire occasionally returns these.
+  ...DERIVED_LANGUAGE_LABELS,
+  // Alias: some legacy rows from before the dropdown existed used 'en'.
   en: 'English',
 };
 
 export const TONE_LABELS: Record<string, string> = {
-  formal: 'Formal',
-  neutral: 'Neutral',
-  informal: 'Informal',
+  ...DERIVED_TONE_LABELS,
   // Some legacy job rows used 'casual'; keep it readable rather than
   // stripping it (the data still exists in DDB).
   casual: 'Casual',


### PR DESCRIPTION
## Summary

Consolidates 7 demo-prep blockers into a single frontend PR. Each fix is small; bundling keeps the review surface to one place rather than 7 micro-PRs of 5–30 LOC each (per repo-owner guidance: "consolidate fixes into larger PRs … having a lot of small PRs makes it hard to maintain and review").

## Issues fixed

| # | Severity | Area | Root cause | Fix |
|---|---|---|---|---|
| #141 | HIGH | Mock /auth/me | Hardcoded `mock-user-default` fallback when SW restart wiped sessions Map | Fall back to `lastIssuedUser` for valid Bearer; 401 when no token |
| #142 | HIGH | Mock login | No registered-user store; fabricated 'Mock User' on every login | New `registeredUsers: Map<email, MockUser>` populated on register, consulted on login |
| #143 | HIGH | Tone not persisted | `POST /jobs/:id/translate` ignored `tone`; `toWireJob` echoed hardcoded `'neutral'` | Added `tone` to `JobState`, captured from request, defaulted to `'neutral'` |
| #144 | MEDIUM | File Size 0 Bytes | `toWireJob` returned `fileSize: 0` regardless of upload payload | Added `fileSize` to `JobState`, captured from upload request body |
| #145 | LOW | Raw enum values | 4 views rendered `es` / `formal` instead of friendly labels | New `translationLabels.ts` (`getLanguageLabel`, `getToneLabel`); wired into wizard review, details, history, progress |
| #147 | MEDIUM | Generic submit error | `'An unexpected error occurred'` shown for all non-`TranslationServiceError` cases | New `translationErrorMessages.ts` with HTTP-status mapping (400/401/403/413/429/500/5xx) + network-error path |
| #148 | LOW | Stale validation alerts | Errors only cleared on next "Next" click | Selective `setErrors` clearing inside `TranslationConfig` `onChange` |

## Triage notes (for review)

- **#143** — Confirmed the frontend payload (`startTranslation` in `translationService.ts:170`) already sends `tone` correctly, so the fix is 100% mock-side. No backend change needed.
- **#150** (stale Lambda P0) auto-resolves once PR #164 lands and the next push triggers a clean deploy-dev. Not in this PR.
- **#151** (Step Functions Map COMPLETED-on-failure) addressed in PR #165. Not in this PR.

## Tests

Updated 4 component/page test files to assert friendly labels instead of raw codes; updated 2 error-handling tests to assert the new HTTP-status-aware messages (including a new network-failure path test); updated `TranslationUpload.test.tsx`'s `vi.mock` of `TranslationServiceError` to preserve the `statusCode` constructor parameter so the new error UX is actually exercisable; updated `handlers.test.ts` JobState fixtures for the new required `fileSize` + `tone` fields.

**Final tally: 552 passed, 19 skipped, 0 failed across 29 test files. Lint clean; type-check clean; format clean.**

## Test plan

- [ ] CI green: `Run Tests` + `Build Infrastructure` + `Lint and Format Check`
- [ ] Manual smoke against `VITE_MOCK_API=true npm run dev`:
  - [ ] Register with `claude-demo@lfmt-poc.dev` / `Claude Tester` → dashboard greets "Welcome back, Claude Tester"
  - [ ] Direct-URL navigate to `/dashboard` → still greets "Claude Tester" (not "Mock User")
  - [ ] Logout, log back in → still greets "Claude Tester" (not "Mock User")
  - [ ] Submit a translation with tone=Formal, language=Spanish → details page shows "Tone: Formal" and "Target Language: Spanish (Español)"
  - [ ] Upload a 976-byte file → details page shows "File Size: 976 Bytes" (not "0 Bytes")
  - [ ] Trigger 429 via `__lfmt_mock_error_429__.txt` → submit alert reads "Translation rate limit reached — please try again in a moment" (not "An unexpected error occurred")
  - [ ] On step 2, click Next without filling fields, then pick a language → "Please select a target language" alert clears immediately