### PR TITLE
fix(demo-script): use --no-scan-index-forward (boolean flag) for DDB Query

### DIFF
--- a/demo/scripts/capture-chapter-metrics.mjs
+++ b/demo/scripts/capture-chapter-metrics.mjs
@@ -826,8 +826,12 @@ async function discoverJobIdViaQuery(fileId, userId) {
     JSON.stringify({ ':u': { S: userId }, ':d': { S: fileId } }),
     '--projection-expression',
     'jobId',
-    '--scan-index-forward',
-    'false', // newest first
+    // AWS CLI v2 quirk: scan-index-forward is a boolean flag — pass
+    // `--no-scan-index-forward` to sort newest-first (descending on the
+    // sort key). The intuitive `--scan-index-forward false` is rejected
+    // with "Unknown options: false". Discovered during the 2026-05-02
+    // capture run.
+    '--no-scan-index-forward',
     '--limit',
     '50',
   ]);


### PR DESCRIPTION
## Summary

Fixes a 4-line bug in `demo/scripts/capture-chapter-metrics.mjs` where `discoverJobIdViaQuery` invoked `aws dynamodb query` with the wrong flag syntax, causing it to fail silently on every call and forcing the paginated-Scan fallback to do all the work.

Closes #174

## The bug (AWS CLI v2 quirk)

AWS CLI v2 treats `scan-index-forward` as a **boolean flag**, not a key/value option. The previous code passed it as two separate args:

```js
'--scan-index-forward',
'false', // newest first
```

AWS CLI v2 rejects this with `"Unknown options: false"`. The correct form is the single boolean flag `--no-scan-index-forward` (sort newest-first / descending on the sort key).

## Diff (4 lines of code, plus a 4-line inline comment)

```diff
-    '--scan-index-forward',
-    'false', // newest first
+    // AWS CLI v2 quirk: scan-index-forward is a boolean flag — pass
+    // `--no-scan-index-forward` to sort newest-first (descending on the
+    // sort key). The intuitive `--scan-index-forward false` is rejected
+    // with "Unknown options: false". Discovered during the 2026-05-02
+    // capture run.
+    '--no-scan-index-forward',
```

## How it was discovered

During the **2026-05-02 Track B capture run**, every chapter produced AWS CLI stderr warnings before each successful Scan fallback. The script never crashed (because `discoverJobIdViaPaginatedScan` is a silent fallback), but:

1. Every chapter capture produced noisy `aws cli stderr` warnings.
2. The architect's R2 intent from PR #146's OMC review (efficient bounded GSI Query as the **primary** discovery path) was never actually exercised.

## Test plan

- [x] `node -c demo/scripts/capture-chapter-metrics.mjs` — syntax check passes
- [x] `node --test demo/scripts/__tests__/capture-chapter-metrics.test.mjs` — all 13 tests pass

This is a **runtime-only flag fix** — no test changes. The bug was misuse of the AWS CLI v2 flag syntax (a shell-out behavior), which is not testable in the existing unit suite that mocks `aws-sdk-client-mock` rather than the AWS CLI subprocess. The fix will be exercised by the next live capture run.