### PR TITLE
fix(backend): translation lifecycle cleanup (#168 + #169 + #170)

### DIFF
--- a/backend/functions/auth/__tests__/register.autoconfirm.test.ts
+++ b/backend/functions/auth/__tests__/register.autoconfirm.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Regression tests for issue #169 — auto-confirm race in the register
+ * Lambda's dev path.
+ *
+ * Bug: when AUTO_CONFIRM_USERS is on (dev environment), the User Pool's
+ * PreSignUp Lambda trigger / autoVerifiedAttributes already confirms the
+ * user as part of SignUp itself. The Lambda's redundant
+ * `AdminConfirmSignUp` call then throws
+ * `NotAuthorizedException: User cannot be confirmed. Current status is
+ * CONFIRMED`. The catch-all turned that into a 500 to the client even
+ * though the user IS successfully created — this is the same root cause
+ * as the post-deploy `Run Backend Integration Tests` failures that have
+ * tripped on every main deploy since 2026-04-29.
+ *
+ * Fix (in register.ts): catch `NotAuthorizedException` from
+ * `AdminConfirmSignUp` and treat the "already confirmed" variant as a
+ * non-error. Other variants (e.g. legitimately disabled users) MUST
+ * still propagate.
+ *
+ * This file exists separately from register.test.ts because
+ * `AUTO_CONFIRM_USERS` is computed at module load from
+ * `ENVIRONMENT.includes('Dev')`. The sibling file pre-sets
+ * `ENVIRONMENT='test'`; we need `ENVIRONMENT='LfmtPocDev'` BEFORE the
+ * handler is imported to exercise the dev branch — and module isolation
+ * hacks don't compose cleanly with aws-sdk-client-mock's
+ * middleware-level interception.
+ */
+
+// MUST be set BEFORE importing the handler — AUTO_CONFIRM_USERS is
+// computed at cold-start.
+process.env.ENVIRONMENT = 'LfmtPocDev';
+process.env.COGNITO_CLIENT_ID = 'test-client-id';
+process.env.COGNITO_USER_POOL_ID = 'test-user-pool-id';
+
+import { APIGatewayProxyEvent } from 'aws-lambda';
+import { handler } from '../register';
+import {
+  CognitoIdentityProviderClient,
+  SignUpCommand,
+  AdminConfirmSignUpCommand,
+  NotAuthorizedException,
+} from '@aws-sdk/client-cognito-identity-provider';
+import { mockClient } from 'aws-sdk-client-mock';
+
+const cognitoMock = mockClient(CognitoIdentityProviderClient);
+
+jest.mock('../../shared/logger', () => {
+  return jest.fn().mockImplementation(() => ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  }));
+});
+
+describe('register Lambda (dev / auto-confirm path) — issue #169', () => {
+  beforeEach(() => {
+    cognitoMock.reset();
+  });
+
+  it('returns 201 (NOT 500) when AdminConfirmSignUp says user already CONFIRMED', async () => {
+    cognitoMock.on(SignUpCommand).resolves({
+      UserSub: 'auto-confirmed-user-id',
+      UserConfirmed: true,
+    });
+
+    // Simulate Cognito having already auto-confirmed the user via the
+    // PreSignUp Lambda trigger — this is the EXACT message Cognito returns
+    // in production (see CloudWatch /aws/lambda/lfmt-register-LfmtPocDev).
+    cognitoMock.on(AdminConfirmSignUpCommand).rejects(
+      new NotAuthorizedException({
+        message: 'User cannot be confirmed. Current status is CONFIRMED',
+        $metadata: {},
+      })
+    );
+
+    const event = createMockEvent({
+      body: JSON.stringify({
+        email: 'autoconfirm-race@example.com',
+        password: 'Test123!@#',
+        confirmPassword: 'Test123!@#',
+        firstName: 'Auto',
+        lastName: 'Confirm',
+        acceptedTerms: true,
+        acceptedPrivacy: true,
+      }),
+    });
+
+    const response = await handler(event);
+
+    // CRITICAL: must be 201, not 500. The user IS created — the redundant
+    // confirm step's failure is benign.
+    expect(response.statusCode).toBe(201);
+    const body = JSON.parse(response.body);
+    expect(body.message).toContain('You can now log in');
+
+    // Both Cognito calls should have been attempted (redundant call is
+    // kept as defense-in-depth for older deployments).
+    expect(cognitoMock.commandCalls(SignUpCommand)).toHaveLength(1);
+    expect(cognitoMock.commandCalls(AdminConfirmSignUpCommand)).toHaveLength(1);
+  });
+
+  it('still propagates NotAuthorizedException for non-already-confirmed cases', async () => {
+    // Defense: we MUST NOT swallow every NotAuthorizedException — only
+    // the "already confirmed" variant. A legitimately disabled user must
+    // still surface as a 500 (caught by the generic handler), so the
+    // operator sees the real failure mode.
+    cognitoMock.on(SignUpCommand).resolves({
+      UserSub: 'disabled-user-id',
+    });
+
+    cognitoMock.on(AdminConfirmSignUpCommand).rejects(
+      new NotAuthorizedException({
+        message: 'User is disabled.',
+        $metadata: {},
+      })
+    );
+
+    const event = createMockEvent({
+      body: JSON.stringify({
+        email: 'disabled@example.com',
+        password: 'Test123!@#',
+        confirmPassword: 'Test123!@#',
+        firstName: 'Dis',
+        lastName: 'Abled',
+        acceptedTerms: true,
+        acceptedPrivacy: true,
+      }),
+    });
+
+    const response = await handler(event);
+
+    expect(response.statusCode).toBe(500);
+  });
+
+  it('returns 201 normally when AdminConfirmSignUp succeeds (control case)', async () => {
+    cognitoMock.on(SignUpCommand).resolves({
+      UserSub: 'happy-path-user-id',
+    });
+    cognitoMock.on(AdminConfirmSignUpCommand).resolves({});
+
+    const event = createMockEvent({
+      body: JSON.stringify({
+        email: 'happy@example.com',
+        password: 'Test123!@#',
+        confirmPassword: 'Test123!@#',
+        firstName: 'Happy',
+        lastName: 'Path',
+        acceptedTerms: true,
+        acceptedPrivacy: true,
+      }),
+    });
+
+    const response = await handler(event);
+    expect(response.statusCode).toBe(201);
+    expect(cognitoMock.commandCalls(AdminConfirmSignUpCommand)).toHaveLength(1);
+  });
+});
+
+function createMockEvent(overrides: Partial<APIGatewayProxyEvent> = {}): APIGatewayProxyEvent {
+  return {
+    body: null,
+    headers: {},
+    multiValueHeaders: {},
+    httpMethod: 'POST',
+    isBase64Encoded: false,
+    path: '/auth/register',
+    pathParameters: null,
+    queryStringParameters: null,
+    multiValueQueryStringParameters: null,
+    stageVariables: null,
+    requestContext: {
+      accountId: '123456789012',
+      apiId: 'test-api',
+      authorizer: null,
+      protocol: 'HTTP/1.1',
+      httpMethod: 'POST',
+      identity: {
+        accessKey: null,
+        accountId: null,
+        apiKey: null,
+        apiKeyId: null,
+        caller: null,
+        clientCert: null,
+        cognitoAuthenticationProvider: null,
+        cognitoAuthenticationType: null,
+        cognitoIdentityId: null,
+        cognitoIdentityPoolId: null,
+        principalOrgId: null,
+        sourceIp: '127.0.0.1',
+        user: null,
+        userAgent: 'test-agent',
+        userArn: null,
+      },
+      path: '/auth/register',
+      stage: 'test',
+      requestId: 'test-request-id',
+      requestTimeEpoch: Date.now(),
+      resourceId: 'test-resource',
+      resourcePath: '/auth/register',
+    },
+    resource: '/auth/register',
+    ...overrides,
+  } as APIGatewayProxyEvent;
+}

--- a/backend/functions/auth/__tests__/register.autoconfirm.test.ts
+++ b/backend/functions/auth/__tests__/register.autoconfirm.test.ts
@@ -133,6 +133,63 @@ describe('register Lambda (dev / auto-confirm path) — issue #169', () => {
     expect(response.statusCode).toBe(500);
   });
 
+  /**
+   * OMC-followup C4 — borderline NotAuthorizedException must propagate.
+   *
+   * The swallow predicate in register.ts uses:
+   *   /already confirmed|status is CONFIRMED/i
+   *
+   * This regex matches BOTH branches of the documented Cognito message
+   * variants, but the test suite only proved that "User is disabled."
+   * propagates. There's a class of borderline cases that should NOT
+   * match — e.g., a NotAuthorizedException whose message references a
+   * different, real authorization failure mode (account lockout, MFA
+   * pending, etc.). Without an explicit test, a future regex tightening
+   * could silently drop the propagate-on-other-NotAuthorized contract.
+   *
+   * This test asserts the negative-branch contract: a NotAuthorized whose
+   * message does NOT match the swallow regex MUST surface as a failure.
+   * (The "User is disabled." case above happens to satisfy this; this
+   * test adds a second, distinct borderline message so a single-message
+   * regex tightening can't accidentally narrow the propagate set to one.)
+   */
+  it('propagates a NotAuthorizedException with an unrelated message (OMC-followup C4)', async () => {
+    cognitoMock.on(SignUpCommand).resolves({
+      UserSub: 'borderline-user-id',
+    });
+
+    // A message that intentionally does NOT contain 'already confirmed'
+    // or 'status is CONFIRMED' — must NOT be swallowed.
+    cognitoMock.on(AdminConfirmSignUpCommand).rejects(
+      new NotAuthorizedException({
+        message: 'User account is locked due to too many failed attempts.',
+        $metadata: {},
+      })
+    );
+
+    const event = createMockEvent({
+      body: JSON.stringify({
+        email: 'locked@example.com',
+        password: 'Test123!@#',
+        confirmPassword: 'Test123!@#',
+        firstName: 'Lock',
+        lastName: 'Out',
+        acceptedTerms: true,
+        acceptedPrivacy: true,
+      }),
+    });
+
+    const response = await handler(event);
+
+    // Must NOT be 201 — silently swallowing this error would hide a real
+    // auth failure mode from the client AND from CloudWatch alarms.
+    expect(response.statusCode).not.toBe(201);
+    // Generic-handler path returns 500 (the message variants the handler
+    // recognizes — UsernameExistsException, InvalidPasswordException,
+    // InvalidParameterException — are different exception classes).
+    expect(response.statusCode).toBe(500);
+  });
+
   it('returns 201 normally when AdminConfirmSignUp succeeds (control case)', async () => {
     cognitoMock.on(SignUpCommand).resolves({
       UserSub: 'happy-path-user-id',

--- a/backend/functions/auth/__tests__/register.test.ts
+++ b/backend/functions/auth/__tests__/register.test.ts
@@ -613,6 +613,13 @@ describe('register Lambda Function', () => {
       expect(body.message).toContain('internal error');
     });
   });
+
+  // NOTE: Regression tests for issue #169 (auto-confirm race) live in a
+  // separate file (register.autoconfirm.test.ts) because AUTO_CONFIRM_USERS
+  // is computed at module load from `ENVIRONMENT.includes('Dev')`. Splitting
+  // the suite is the cleanest way to exercise both branches without
+  // module-isolation hacks that don't compose with aws-sdk-client-mock's
+  // middleware-level interception.
 });
 
 /**

--- a/backend/functions/auth/register.ts
+++ b/backend/functions/auth/register.ts
@@ -18,6 +18,7 @@ import {
   UsernameExistsException,
   InvalidPasswordException,
   InvalidParameterException,
+  NotAuthorizedException,
 } from '@aws-sdk/client-cognito-identity-provider';
 import { registerRequestSchema } from '@lfmt/shared-types';
 import { createSuccessResponse, createErrorResponse } from '../shared/api-response';
@@ -100,7 +101,22 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
 
     await cognitoClient.send(command);
 
-    // Auto-confirm user in dev environment (no email verification required)
+    // Auto-confirm user in dev environment (no email verification required).
+    //
+    // ISSUE #169: The dev User Pool is already configured with
+    // `autoVerify: { email: true }` PLUS a PreSignUp Lambda trigger that
+    // sets `autoConfirmUser = true` and `autoVerifyEmail = true`
+    // (lfmt-infrastructure-stack.ts:321 + 365-368). Cognito therefore
+    // confirms the user as part of SignUp itself, so this AdminConfirmSignUp
+    // call races with the auto-confirmation and frequently fails with
+    // `NotAuthorizedException: User cannot be confirmed. Current status is
+    // CONFIRMED`. The user IS created — only the redundant confirm step
+    // throws — but the catch-all below was turning that into a 500 to the
+    // client.
+    //
+    // Fix: keep the call (defense-in-depth for older deployments where the
+    // PreSignUp trigger may not be wired up yet) but swallow the
+    // already-confirmed NotAuthorizedException as a non-error.
     if (AUTO_CONFIRM_USERS) {
       logger.info('Auto-confirming user (dev environment)', {
         requestId,
@@ -112,12 +128,32 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
         Username: email,
       });
 
-      await cognitoClient.send(confirmCommand);
-
-      logger.info('User auto-confirmed successfully', {
-        requestId,
-        email: email.toLowerCase(),
-      });
+      try {
+        await cognitoClient.send(confirmCommand);
+        logger.info('User auto-confirmed successfully', {
+          requestId,
+          email: email.toLowerCase(),
+        });
+      } catch (confirmError) {
+        // Cognito's PreSignUp trigger / AutoVerifiedAttributes already
+        // confirmed the user — the error is benign. Match by name AND
+        // message because NotAuthorizedException is also raised for
+        // legitimately disabled users, and we MUST NOT swallow that case.
+        if (
+          confirmError instanceof NotAuthorizedException &&
+          /already confirmed|status is CONFIRMED/i.test(confirmError.message)
+        ) {
+          logger.info(
+            'User already auto-confirmed by Cognito (PreSignUp/AutoVerifiedAttributes); skipping AdminConfirmSignUp',
+            {
+              requestId,
+              email: email.toLowerCase(),
+            }
+          );
+        } else {
+          throw confirmError;
+        }
+      }
     }
 
     logger.info('User registered successfully', {

--- a/backend/functions/translation/__tests__/translateChunk.test.ts
+++ b/backend/functions/translation/__tests__/translateChunk.test.ts
@@ -20,6 +20,9 @@ import {
 } from '../translateChunk';
 import { sdkStreamMixin } from '@smithy/util-stream';
 import { RateLimitError, RateLimitType } from '../../shared/types/rateLimiting';
+// Imported alongside the jest.mock() factory below so OMC-followup C3 can
+// override the GenAI mock for a single test (see usageMetadata-undefined case).
+import { GoogleGenAI } from '@google/genai';
 
 // Create mocks
 const dynamoMock = mockClient(DynamoDBClient);
@@ -319,16 +322,23 @@ describe('translateChunk Lambda', () => {
       expect(updateCalls.length).toBe(1);
       const updateExpression = updateCalls[0].args[0].input.UpdateExpression!;
 
-      // 1. The ADD clause MUST be present for both metric attributes.
-      //    The previous (broken) implementation used SET on these fields.
-      expect(updateExpression).toMatch(/ADD\s+tokensUsed\s+:tokens(?:,\s*estimatedCost\s+:cost)?/);
+      // 1. The ADD clause MUST be present for both metric attributes AND
+      //    for translatedChunks (OMC-followup R5). The previous (broken)
+      //    implementation used SET on tokensUsed/estimatedCost; PR #176
+      //    fixed those. R5 closes the same race for translatedChunks
+      //    (parallel chunks reading the same starting value and both
+      //    writing n+1 — one chunk silently dropped from progress UI).
+      expect(updateExpression).toMatch(/ADD\s+/);
+      expect(updateExpression).toMatch(/tokensUsed\s+:tokens/);
       expect(updateExpression).toMatch(/estimatedCost\s+:cost/);
+      expect(updateExpression).toMatch(/translatedChunks\s+:one/);
 
-      // 2. Neither metric may also appear in the SET clause (would race).
+      // 2. None of the counters may also appear in the SET clause (would race).
       const setClauseMatch = updateExpression.match(/SET\s+(.+?)(?:\s+ADD|$)/);
       const setClause = setClauseMatch ? setClauseMatch[1] : '';
       expect(setClause).not.toMatch(/tokensUsed/);
       expect(setClause).not.toMatch(/estimatedCost/);
+      expect(setClause).not.toMatch(/translatedChunks/);
 
       // 3. The value passed for :tokens MUST be the per-chunk delta (150
       //    from the mocked Gemini response), NOT the running total (600
@@ -341,6 +351,99 @@ describe('translateChunk Lambda', () => {
       const costN = parseFloat((values[':cost'] as { N: string }).N);
       expect(costN).toBeGreaterThan(0);
       expect(costN).toBeLessThan(0.000045); // smaller than the pre-existing total
+      // OMC-followup R5: translatedChunks is incremented by 1 per chunk.
+      expect(values[':one']).toEqual({ N: '1' });
+    });
+
+    /**
+     * OMC-followup C3 — `usageMetadata: undefined` regression test.
+     *
+     * Bug class: Gemini API can return responses without `usageMetadata`
+     * when an upstream error is encountered (or for partial / safety-blocked
+     * responses). The previous read-modify-write SET path never touched
+     * `result.usageMetadata.totalTokenCount` directly because it pre-computed
+     * a running total OUTSIDE the marshalled value object. The new atomic
+     * ADD path passes the raw delta — and DDB's marshall() of `undefined`
+     * would cascade into a TypeError before the UpdateItem ever fires,
+     * leaving the DDB row in an inconsistent state.
+     *
+     * geminiClient.ts:159-162 already defaults each token field to `0`
+     * via `?? 0`, so this test asserts:
+     *   1. The Lambda completes without TypeError.
+     *   2. The DDB ADD value defaults to 0 (NUMBER) — race-free with ADD
+     *      arithmetic since `ADD attr 0` is a documented no-op for NUMBERs.
+     */
+    it('handles undefined usageMetadata gracefully (Gemini API error path) — OMC-followup C3', async () => {
+      // Override the default Google GenAI mock so the next translate() call
+      // returns a payload WITHOUT usageMetadata, mirroring the real Gemini
+      // upstream-error / safety-block response shape.
+      const previousImpl = (GoogleGenAI as unknown as jest.Mock).getMockImplementation();
+      (GoogleGenAI as unknown as jest.Mock).mockImplementationOnce(() => ({
+        models: {
+          generateContent: jest.fn().mockResolvedValue({
+            text: 'Texto traducido al español',
+            // usageMetadata: intentionally absent
+          }),
+        },
+      }));
+
+      try {
+        dynamoMock.on(GetItemCommand).resolves({
+          Item: createMockJob({
+            jobId: 'job-c3',
+            userId: 'user-c3',
+            status: 'CHUNKED',
+            totalChunks: 5,
+            translatedChunks: 0,
+            tokensUsed: 0,
+            estimatedCost: 0,
+            extraFields: {
+              translationStatus: { S: 'IN_PROGRESS' },
+            },
+          }),
+        } as any);
+
+        const chunkContent = JSON.stringify({
+          primaryContent: 'Chunk for OMC-followup C3 regression test.',
+          chunkId: 'chunk-0',
+          chunkIndex: 0,
+        });
+
+        s3Mock.on(GetObjectCommand).resolves({
+          Body: createMockStream(chunkContent),
+        } as any);
+
+        s3Mock.on(PutObjectCommand).resolves({} as any);
+        dynamoMock.on(UpdateItemCommand).resolves({} as any);
+
+        const event: TranslateChunkEvent = {
+          jobId: 'job-c3',
+          userId: 'user-c3',
+          chunkIndex: 0,
+          targetLanguage: 'es',
+        };
+
+        const result = await handler(event);
+
+        // 1. Must not TypeError on undefined access.
+        expect(result.success).toBe(true);
+        // tokensUsed defaults to 0 from geminiClient.ts:162 (`?? 0`).
+        expect(result.tokensUsed).toBe(0);
+
+        // 2. The DDB ADD value MUST default to 0 (not undefined) — otherwise
+        //    marshall() throws TypeError and the row is never updated.
+        const updateCalls = dynamoMock.commandCalls(UpdateItemCommand);
+        expect(updateCalls.length).toBe(1);
+        const values = updateCalls[0].args[0].input.ExpressionAttributeValues!;
+        expect(values[':tokens']).toEqual({ N: '0' });
+        expect(values[':cost']).toEqual({ N: '0' });
+      } finally {
+        // Restore the default mock for sibling tests in this file (Jest
+        // mockImplementationOnce only consumes one call, but be explicit).
+        if (previousImpl) {
+          (GoogleGenAI as unknown as jest.Mock).mockImplementation(previousImpl);
+        }
+      }
     });
   });
 

--- a/backend/functions/translation/__tests__/translateChunk.test.ts
+++ b/backend/functions/translation/__tests__/translateChunk.test.ts
@@ -255,6 +255,93 @@ describe('translateChunk Lambda', () => {
       const updateExpression = updateCalls[0].args[0].input.UpdateExpression;
       expect(updateExpression).toContain('translationStatus');
     });
+
+    /**
+     * Regression test for issue #168 — tokensUsed/estimatedCost lost under
+     * parallel execution.
+     *
+     * Bug: updateJobProgress used a `SET tokensUsed = :tokens` clause where
+     * `:tokens` was a pre-computed running total (job.tokensUsed + delta).
+     * Under maxConcurrency=10, multiple chunk Lambdas read the same starting
+     * value and last-writer-wins, so per-chunk metrics were lost (DDB ended
+     * up showing 0 even though CloudWatch confirmed real per-chunk usage).
+     *
+     * Fix: switch to atomic `ADD tokensUsed :tokens, estimatedCost :cost`
+     * and pass the per-chunk DELTA (not a running total). startTranslation
+     * initializes both attributes to 0 (NUMBER) so ADD is safe on first call.
+     *
+     * This test would have caught the bug because it asserts the
+     * UpdateExpression uses ADD on the metric attributes AND that the value
+     * passed is the per-chunk delta (150 from the mocked Gemini response),
+     * NOT a running total derived from the loaded job (which had 600).
+     */
+    it('should use atomic ADD (not SET) for tokensUsed/estimatedCost — issue #168', async () => {
+      dynamoMock.on(GetItemCommand).resolves({
+        Item: createMockJob({
+          jobId: 'job-168',
+          userId: 'user-168',
+          status: 'CHUNKED',
+          totalChunks: 5,
+          translatedChunks: 2,
+          // Pre-existing running total — must NOT leak into the SET value.
+          tokensUsed: 600,
+          estimatedCost: 0.000045,
+          extraFields: {
+            translationStatus: { S: 'IN_PROGRESS' },
+          },
+        }),
+      } as any);
+
+      const chunkContent = JSON.stringify({
+        primaryContent: 'Chunk for issue #168 regression test.',
+        chunkId: 'chunk-2',
+        chunkIndex: 2,
+      });
+
+      s3Mock.on(GetObjectCommand).resolves({
+        Body: createMockStream(chunkContent),
+      } as any);
+
+      s3Mock.on(PutObjectCommand).resolves({} as any);
+      dynamoMock.on(UpdateItemCommand).resolves({} as any);
+
+      const event: TranslateChunkEvent = {
+        jobId: 'job-168',
+        userId: 'user-168',
+        chunkIndex: 2,
+        targetLanguage: 'es',
+      };
+
+      const result = await handler(event);
+      expect(result.success).toBe(true);
+
+      const updateCalls = dynamoMock.commandCalls(UpdateItemCommand);
+      expect(updateCalls.length).toBe(1);
+      const updateExpression = updateCalls[0].args[0].input.UpdateExpression!;
+
+      // 1. The ADD clause MUST be present for both metric attributes.
+      //    The previous (broken) implementation used SET on these fields.
+      expect(updateExpression).toMatch(/ADD\s+tokensUsed\s+:tokens(?:,\s*estimatedCost\s+:cost)?/);
+      expect(updateExpression).toMatch(/estimatedCost\s+:cost/);
+
+      // 2. Neither metric may also appear in the SET clause (would race).
+      const setClauseMatch = updateExpression.match(/SET\s+(.+?)(?:\s+ADD|$)/);
+      const setClause = setClauseMatch ? setClauseMatch[1] : '';
+      expect(setClause).not.toMatch(/tokensUsed/);
+      expect(setClause).not.toMatch(/estimatedCost/);
+
+      // 3. The value passed for :tokens MUST be the per-chunk delta (150
+      //    from the mocked Gemini response), NOT the running total (600
+      //    + 150 = 750). The Gemini mock at the top of this file returns
+      //    totalTokenCount: 150.
+      const values = updateCalls[0].args[0].input.ExpressionAttributeValues!;
+      expect(values[':tokens']).toEqual({ N: '150' });
+      // estimatedCost is computed from token counts; just verify it's > 0
+      // and not the pre-existing 0.000045 running total.
+      const costN = parseFloat((values[':cost'] as { N: string }).N);
+      expect(costN).toBeGreaterThan(0);
+      expect(costN).toBeLessThan(0.000045); // smaller than the pre-existing total
+    });
   });
 
   describe('input validation', () => {

--- a/backend/functions/translation/translateChunk.ts
+++ b/backend/functions/translation/translateChunk.ts
@@ -229,12 +229,19 @@ export const handler = async (event: TranslateChunkEvent): Promise<TranslateChun
       }
     );
 
-    // Update job progress in DynamoDB
+    // Update job progress in DynamoDB.
+    // CRITICAL (issue #168): tokensUsed and estimatedCost MUST be passed as
+    // per-chunk DELTAS (not pre-computed running totals from the job we
+    // loaded above). With maxConcurrency=10, multiple chunk Lambdas run in
+    // parallel; if each Lambda reads the totals and writes a SET, the last
+    // writer wins and per-chunk metrics are lost. updateJobProgress now
+    // uses an atomic `ADD tokensUsed :tokens, estimatedCost :cost`, which
+    // is race-free under parallel execution and Step Functions retries.
     await updateJobProgress(event.jobId, event.userId, {
       translatedChunks: (job.translatedChunks || 0) + 1,
       totalChunks: job.totalChunks,
-      tokensUsed: (job.tokensUsed || 0) + result.tokensUsed.total,
-      estimatedCost: (job.estimatedCost || 0) + result.estimatedCost,
+      tokensUsedDelta: result.tokensUsed.total,
+      estimatedCostDelta: result.estimatedCost,
     });
 
     return {
@@ -464,7 +471,19 @@ async function storeTranslatedChunk(
 }
 
 /**
- * Update job progress in DynamoDB
+ * Update job progress in DynamoDB.
+ *
+ * Uses an atomic `ADD tokensUsed :tokens, ADD estimatedCost :cost` clause
+ * (issue #168) so per-chunk metrics accumulate correctly under parallel
+ * execution and Step Functions retries. The previous implementation used
+ * a pre-computed running total inside SET, which lost data under
+ * maxConcurrency > 1 (last-writer-wins). startTranslation.ts initializes
+ * both attributes to 0 (NUMBER) so ADD is always a valid operation.
+ *
+ * `translatedChunks` is still SET (not ADD) because the caller already
+ * computes the post-increment value and DDB's SET is idempotent under
+ * Step Functions retries — re-running with the same chunk index will
+ * write the same value, not double-count.
  */
 async function updateJobProgress(
   jobId: string,
@@ -472,8 +491,8 @@ async function updateJobProgress(
   progress: {
     translatedChunks: number;
     totalChunks: number;
-    tokensUsed: number;
-    estimatedCost: number;
+    tokensUsedDelta: number;
+    estimatedCostDelta: number;
   }
 ): Promise<void> {
   const translationStatus =
@@ -483,12 +502,12 @@ async function updateJobProgress(
     TableName: JOBS_TABLE,
     Key: marshall({ jobId, userId }),
     UpdateExpression:
-      'SET translationStatus = :status, translatedChunks = :translated, tokensUsed = :tokens, estimatedCost = :cost, updatedAt = :updatedAt',
+      'SET translationStatus = :status, translatedChunks = :translated, updatedAt = :updatedAt ADD tokensUsed :tokens, estimatedCost :cost',
     ExpressionAttributeValues: marshall({
       ':status': translationStatus,
       ':translated': progress.translatedChunks,
-      ':tokens': progress.tokensUsed,
-      ':cost': progress.estimatedCost,
+      ':tokens': progress.tokensUsedDelta,
+      ':cost': progress.estimatedCostDelta,
       ':updatedAt': new Date().toISOString(),
     }),
   });
@@ -500,6 +519,8 @@ async function updateJobProgress(
     userId,
     translatedChunks: progress.translatedChunks,
     totalChunks: progress.totalChunks,
+    tokensUsedDelta: progress.tokensUsedDelta,
+    estimatedCostDelta: progress.estimatedCostDelta,
     translationStatus,
   });
 }

--- a/backend/functions/translation/translateChunk.ts
+++ b/backend/functions/translation/translateChunk.ts
@@ -237,8 +237,18 @@ export const handler = async (event: TranslateChunkEvent): Promise<TranslateChun
     // writer wins and per-chunk metrics are lost. updateJobProgress now
     // uses an atomic `ADD tokensUsed :tokens, estimatedCost :cost`, which
     // is race-free under parallel execution and Step Functions retries.
+    //
+    // OMC-followup R5: same race applied to translatedChunks too — the
+    // previous SET-based update computed `(job.translatedChunks || 0) + 1`
+    // from a value loaded BEFORE the API call, so two parallel chunks
+    // could read the same starting value (e.g. 3) and both write 4 (one
+    // chunk silently dropped from the in-flight progress UI). Switched
+    // to an atomic ADD (per-chunk +1 delta) below; updateJobProgress no
+    // longer needs the pre-incremented value, so we don't compute it
+    // here. totalChunks is still passed because the helper uses it to
+    // derive translationStatus (IN_PROGRESS vs. COMPLETED).
     await updateJobProgress(event.jobId, event.userId, {
-      translatedChunks: (job.translatedChunks || 0) + 1,
+      currentTranslatedChunks: job.translatedChunks || 0, // for IN_PROGRESS-vs-COMPLETED hint only
       totalChunks: job.totalChunks,
       tokensUsedDelta: result.tokensUsed.total,
       estimatedCostDelta: result.estimatedCost,
@@ -473,39 +483,70 @@ async function storeTranslatedChunk(
 /**
  * Update job progress in DynamoDB.
  *
- * Uses an atomic `ADD tokensUsed :tokens, ADD estimatedCost :cost` clause
- * (issue #168) so per-chunk metrics accumulate correctly under parallel
- * execution and Step Functions retries. The previous implementation used
- * a pre-computed running total inside SET, which lost data under
- * maxConcurrency > 1 (last-writer-wins). startTranslation.ts initializes
- * both attributes to 0 (NUMBER) so ADD is always a valid operation.
+ * Uses an atomic `ADD translatedChunks :one, tokensUsed :tokens,
+ * estimatedCost :cost` clause so all per-chunk counters accumulate
+ * correctly under parallel execution.
  *
- * `translatedChunks` is still SET (not ADD) because the caller already
- * computes the post-increment value and DDB's SET is idempotent under
- * Step Functions retries — re-running with the same chunk index will
- * write the same value, not double-count.
+ * Issue #168 (tokensUsed / estimatedCost): the previous implementation
+ * used a pre-computed running total inside SET, which lost data under
+ * maxConcurrency > 1 (last-writer-wins). startTranslation.ts initializes
+ * all three attributes to 0 (NUMBER) so ADD is always a valid operation.
+ *
+ * OMC-followup R5 (translatedChunks): the previous SET-based update
+ * computed `(job.translatedChunks || 0) + 1` from a value loaded BEFORE
+ * the API call, so two parallel chunks could read the same starting
+ * value and both write `n+1` (one chunk silently dropped from the
+ * in-flight progress UI). Switched to atomic ADD here for the same
+ * reasons as #168.
+ *
+ * OMC-followup R7 — retry idempotency assumption (#168):
+ * Each chunk Lambda is invoked once per (jobId, chunkIndex) tuple in
+ * normal operation, so each ADD is unique. Step Functions Map retries
+ * WOULD double-count if the same chunk were retried — but the iterator
+ * task currently has NO retry policy beyond the rate-limit / service
+ * exception list (see translateChunkTask.addRetry in
+ * lfmt-infrastructure-stack.ts). For the rate-limit path the chunk
+ * Lambda returns BEFORE updateJobProgress is called, so no ADD has
+ * happened yet — re-runs are safe. For the Lambda.ServiceException
+ * path the retry happens at the SF service layer; if the Lambda
+ * actually completed (DDB ADD succeeded) but Step Functions saw the
+ * failure, the retried Lambda would re-run translation AND ADD again.
+ * This is currently accepted as best-effort. If we ever need stricter
+ * exactly-once semantics, the next step would be a per-chunk dedup
+ * key (e.g., a conditional ADD with attribute_not_exists on
+ * `chunkTokensRecorded.<chunkIndex>` or a dedicated
+ * `recordedChunks` set). NOT implemented here — documented for
+ * intentionality.
  */
 async function updateJobProgress(
   jobId: string,
   userId: string,
   progress: {
-    translatedChunks: number;
+    currentTranslatedChunks: number;
     totalChunks: number;
     tokensUsedDelta: number;
     estimatedCostDelta: number;
   }
 ): Promise<void> {
+  // Best-effort hint at the post-ADD count for the IN_PROGRESS-vs-COMPLETED
+  // status decision. Under concurrent chunks this can race (two parallel
+  // chunks may both write IN_PROGRESS even when this is the final chunk),
+  // but the terminal status is authoritatively re-set by the Step Functions
+  // UpdateJobCompleted task (see lfmt-infrastructure-stack.ts) which runs
+  // exactly once after every chunk has reported success — so a transient
+  // IN_PROGRESS here is corrected. Do NOT rely on this heuristic for
+  // terminal correctness.
   const translationStatus =
-    progress.translatedChunks >= progress.totalChunks ? 'COMPLETED' : 'IN_PROGRESS';
+    progress.currentTranslatedChunks + 1 >= progress.totalChunks ? 'COMPLETED' : 'IN_PROGRESS';
 
   const command = new UpdateItemCommand({
     TableName: JOBS_TABLE,
     Key: marshall({ jobId, userId }),
     UpdateExpression:
-      'SET translationStatus = :status, translatedChunks = :translated, updatedAt = :updatedAt ADD tokensUsed :tokens, estimatedCost :cost',
+      'SET translationStatus = :status, updatedAt = :updatedAt ADD translatedChunks :one, tokensUsed :tokens, estimatedCost :cost',
     ExpressionAttributeValues: marshall({
       ':status': translationStatus,
-      ':translated': progress.translatedChunks,
+      ':one': 1,
       ':tokens': progress.tokensUsedDelta,
       ':cost': progress.estimatedCostDelta,
       ':updatedAt': new Date().toISOString(),
@@ -517,7 +558,7 @@ async function updateJobProgress(
   logger.info('Job progress updated', {
     jobId,
     userId,
-    translatedChunks: progress.translatedChunks,
+    translatedChunksDelta: 1,
     totalChunks: progress.totalChunks,
     tokensUsedDelta: progress.tokensUsedDelta,
     estimatedCostDelta: progress.estimatedCostDelta,

--- a/backend/infrastructure/lib/__tests__/infrastructure.test.ts
+++ b/backend/infrastructure/lib/__tests__/infrastructure.test.ts
@@ -691,13 +691,21 @@ describe('LFMT Infrastructure Stack', () => {
       // The value bound to outer status MUST be 'COMPLETED' (matching
       // shared-types/src/jobs.ts JobStatus union — a drift here would
       // re-introduce the misclassification bug fixed by issue #170).
-      const valuesString = JSON.stringify(
-        updateJobCompleted.Parameters?.ExpressionAttributeValues ?? {}
-      );
-      // Two 'COMPLETED' occurrences expected: one for translationStatus, one
-      // for the outer status.
-      const completedMatches = valuesString.match(/COMPLETED/g) ?? [];
-      expect(completedMatches.length).toBeGreaterThanOrEqual(2);
+      //
+      // Round-2 OMC review (issuecomment-4364585175) — assert by KEY
+      // (`:status` and `:outerStatus`), not by counting 'COMPLETED'
+      // substring matches in the serialized JSON. Substring counts are
+      // logically sufficient here but can false-positive on contrived
+      // serialization changes (e.g., adding any other value containing
+      // 'COMPLETED'). Keyed assertions are strictly correct,
+      // self-documenting, and survive ASL serialization changes that
+      // don't affect the contract.
+      const exprValues =
+        updateJobCompleted.Parameters?.ExpressionAttributeValues ?? {};
+      expect(updateExpression).toMatch(/translationStatus\s*=\s*:status/);
+      expect(updateExpression).toMatch(/#status\s*=\s*:outerStatus/);
+      expect(exprValues[':status']).toEqual({ S: 'COMPLETED' });
+      expect(exprValues[':outerStatus']).toEqual({ S: 'COMPLETED' });
     });
 
     test('UpdateJobFailed task writes TRANSLATION_FAILED to DDB (Issue #151)', () => {
@@ -767,14 +775,18 @@ describe('LFMT Infrastructure Stack', () => {
         updateJobFailed.Parameters?.ExpressionAttributeNames ?? {};
       expect(attributeNames['#status']).toBe('status');
 
-      // Two 'TRANSLATION_FAILED' occurrences expected: one for translationStatus,
-      // one for the outer status. Mirrors the >=2 'COMPLETED' assertion in
-      // UpdateJobCompleted.
-      const valuesString = JSON.stringify(
-        updateJobFailed.Parameters?.ExpressionAttributeValues ?? {}
-      );
-      const failedMatches = valuesString.match(/TRANSLATION_FAILED/g) ?? [];
-      expect(failedMatches.length).toBeGreaterThanOrEqual(2);
+      // Round-2 OMC review (issuecomment-4364584995) — assert by KEY
+      // (`:status` and `:outerStatus`), not by counting 'TRANSLATION_FAILED'
+      // substring matches in the serialized JSON. Mirrors the keyed
+      // assertion pattern in the UpdateJobCompleted test above for
+      // symmetry. Strictly correct, self-documenting, and survives ASL
+      // serialization changes that don't affect the contract.
+      const exprValues =
+        updateJobFailed.Parameters?.ExpressionAttributeValues ?? {};
+      expect(updateExpression).toMatch(/translationStatus\s*=\s*:status/);
+      expect(updateExpression).toMatch(/#status\s*=\s*:outerStatus/);
+      expect(exprValues[':status']).toEqual({ S: 'TRANSLATION_FAILED' });
+      expect(exprValues[':outerStatus']).toEqual({ S: 'TRANSLATION_FAILED' });
     });
 
     test('Choice state gates UpdateJobCompleted on per-chunk success (OMC-followup C1)', () => {

--- a/backend/infrastructure/lib/__tests__/infrastructure.test.ts
+++ b/backend/infrastructure/lib/__tests__/infrastructure.test.ts
@@ -647,6 +647,59 @@ describe('LFMT Infrastructure Stack', () => {
       expect(startState.Catch).toBeUndefined();
     });
 
+    test('UpdateJobCompleted task ALSO writes outer status=COMPLETED (Issue #170)', () => {
+      // Regression guard: prior to this fix, updateJobCompleted only wrote
+      // `translationStatus = 'COMPLETED'` and left the OUTER `status` field
+      // alone. If a chunk Lambda failed non-retryably on attempt 1
+      // (translateChunk.ts updateJobStatus writes status='TRANSLATION_FAILED')
+      // then succeeded on a Step Functions retry, the outer status was
+      // stuck on TRANSLATION_FAILED forever — the frontend's
+      // TranslationDetail.tsx branches on `job.status === 'TRANSLATION_FAILED'`
+      // and would misclassify successful jobs as failed.
+      //
+      // Fix mirrors PR #165's pattern: Step Functions becomes the single
+      // source of truth on terminal lifecycle by updating both fields.
+      const stateMachines = template.findResources('AWS::StepFunctions::StateMachine');
+      const stateMachine = stateMachines[Object.keys(stateMachines)[0]];
+      const definition = JSON.parse(
+        stateMachine.Properties.DefinitionString['Fn::Join'][1].join('')
+      );
+
+      const states = definition.States;
+      const updateJobCompletedEntry = Object.entries(states).find(([name]) =>
+        /UpdateJobCompleted/.test(name)
+      );
+      expect(updateJobCompletedEntry).toBeDefined();
+      const [, updateJobCompleted] = updateJobCompletedEntry as [string, any];
+
+      // Must be a DDB UpdateItem task.
+      expect(updateJobCompleted.Type).toBe('Task');
+      expect(updateJobCompleted.Resource).toMatch(/dynamodb:updateItem/i);
+
+      // The UpdateExpression MUST set both `translationStatus` AND outer
+      // `status` (via #status alias because `status` is a DDB reserved word).
+      const updateExpression: string =
+        updateJobCompleted.Parameters?.UpdateExpression ?? '';
+      expect(updateExpression).toMatch(/translationStatus/);
+      expect(updateExpression).toMatch(/#status/);
+
+      // ExpressionAttributeNames must alias #status to 'status'.
+      const attributeNames =
+        updateJobCompleted.Parameters?.ExpressionAttributeNames ?? {};
+      expect(attributeNames['#status']).toBe('status');
+
+      // The value bound to outer status MUST be 'COMPLETED' (matching
+      // shared-types/src/jobs.ts JobStatus union — a drift here would
+      // re-introduce the misclassification bug fixed by issue #170).
+      const valuesString = JSON.stringify(
+        updateJobCompleted.Parameters?.ExpressionAttributeValues ?? {}
+      );
+      // Two 'COMPLETED' occurrences expected: one for translationStatus, one
+      // for the outer status.
+      const completedMatches = valuesString.match(/COMPLETED/g) ?? [];
+      expect(completedMatches.length).toBeGreaterThanOrEqual(2);
+    });
+
     test('UpdateJobFailed task writes TRANSLATION_FAILED to DDB (Issue #151)', () => {
       const stateMachines = template.findResources('AWS::StepFunctions::StateMachine');
       const stateMachine = stateMachines[Object.keys(stateMachines)[0]];

--- a/backend/infrastructure/lib/__tests__/infrastructure.test.ts
+++ b/backend/infrastructure/lib/__tests__/infrastructure.test.ts
@@ -732,6 +732,118 @@ describe('LFMT Infrastructure Stack', () => {
       expect(nextState.Type).toBe('Fail');
     });
 
+    test('UpdateJobFailed task ALSO writes outer status=TRANSLATION_FAILED (OMC-followup C2)', () => {
+      // Regression guard: PR #176 made UpdateJobCompleted dual-write both
+      // `translationStatus` AND outer `#status` (issue #170) but left
+      // UpdateJobFailed asymmetric. Same bug class applies in reverse —
+      // without this, a transient success that later fails terminally
+      // leaves the outer `status` field stuck on a stale value (e.g.,
+      // 'IN_PROGRESS' from startTranslation, or 'COMPLETED' from a
+      // hypothetical earlier write). Mirror the dual-write so Step
+      // Functions is the single source of truth on terminal lifecycle
+      // for BOTH success and failure outcomes.
+      const stateMachines = template.findResources('AWS::StepFunctions::StateMachine');
+      const stateMachine = stateMachines[Object.keys(stateMachines)[0]];
+      const definition = JSON.parse(
+        stateMachine.Properties.DefinitionString['Fn::Join'][1].join('')
+      );
+
+      const states = definition.States;
+      const updateJobFailedEntry = Object.entries(states).find(([name]) =>
+        /UpdateJobFailed/.test(name)
+      );
+      expect(updateJobFailedEntry).toBeDefined();
+      const [, updateJobFailed] = updateJobFailedEntry as [string, any];
+
+      // The UpdateExpression MUST set both `translationStatus` AND outer
+      // `status` (via #status alias because `status` is a DDB reserved word).
+      const updateExpression: string =
+        updateJobFailed.Parameters?.UpdateExpression ?? '';
+      expect(updateExpression).toMatch(/translationStatus/);
+      expect(updateExpression).toMatch(/#status/);
+
+      // ExpressionAttributeNames must alias #status to 'status'.
+      const attributeNames =
+        updateJobFailed.Parameters?.ExpressionAttributeNames ?? {};
+      expect(attributeNames['#status']).toBe('status');
+
+      // Two 'TRANSLATION_FAILED' occurrences expected: one for translationStatus,
+      // one for the outer status. Mirrors the >=2 'COMPLETED' assertion in
+      // UpdateJobCompleted.
+      const valuesString = JSON.stringify(
+        updateJobFailed.Parameters?.ExpressionAttributeValues ?? {}
+      );
+      const failedMatches = valuesString.match(/TRANSLATION_FAILED/g) ?? [];
+      expect(failedMatches.length).toBeGreaterThanOrEqual(2);
+    });
+
+    test('Choice state gates UpdateJobCompleted on per-chunk success (OMC-followup C1)', () => {
+      // Regression guard: translateChunk.ts catches every error in its
+      // outer try/catch and returns { success: false } instead of throwing.
+      // Map's addCatch only fires on THROWN errors, so without this Choice
+      // gate, UpdateJobCompleted would unconditionally run and overwrite
+      // the per-chunk Lambda's TRANSLATION_FAILED outer status with
+      // COMPLETED — the exact phantom-success bug PR #176's #170 fix was
+      // meant to prevent. The Choice state aggregates
+      // $.translationResults[*].translateResult.Payload.success via
+      // States.ArrayContains and routes to UpdateJobFailed if any chunk
+      // reported success:false.
+      const stateMachines = template.findResources('AWS::StepFunctions::StateMachine');
+      const stateMachine = stateMachines[Object.keys(stateMachines)[0]];
+      const definition = JSON.parse(
+        stateMachine.Properties.DefinitionString['Fn::Join'][1].join('')
+      );
+
+      const states = definition.States;
+
+      // 1. Map state must transition to the aggregator (Pass), NOT directly
+      //    to UpdateJobCompleted.
+      const mapEntry = Object.entries(states).find(
+        ([, state]: [string, any]) => state.Type === 'Map'
+      );
+      expect(mapEntry).toBeDefined();
+      const [, mapState] = mapEntry as [string, any];
+      expect(mapState.Next).toBeDefined();
+      const afterMap = states[mapState.Next];
+      expect(afterMap.Type).toBe('Pass');
+
+      // 2. The Pass state must compute anyChunkFailed via States.ArrayContains
+      //    on the success flag projection from each chunk's result.
+      const passParams = afterMap.Parameters ?? {};
+      const anyChunkFailedExpr = passParams['anyChunkFailed.$'];
+      expect(anyChunkFailedExpr).toBeDefined();
+      expect(anyChunkFailedExpr).toMatch(/States\.ArrayContains/);
+      // The wildcard projection must walk into translateResult.Payload.success
+      // so failures returned by translateChunk (Lambda success / app failure)
+      // are captured.
+      expect(anyChunkFailedExpr).toContain('translationResults');
+      expect(anyChunkFailedExpr).toContain('translateResult');
+      expect(anyChunkFailedExpr).toContain('Payload');
+      expect(anyChunkFailedExpr).toContain('success');
+      // ArrayContains is called against the literal `false` boolean.
+      expect(anyChunkFailedExpr).toMatch(/,\s*false\s*\)/);
+
+      // 3. The Pass state must transition to a Choice state.
+      expect(afterMap.Next).toBeDefined();
+      const choiceState = states[afterMap.Next];
+      expect(choiceState.Type).toBe('Choice');
+
+      // 4. The Choice state must have a rule that routes to UpdateJobFailed
+      //    when anyChunkFailed=true, and otherwise (Default) to UpdateJobCompleted.
+      expect(Array.isArray(choiceState.Choices)).toBe(true);
+      expect(choiceState.Choices.length).toBeGreaterThanOrEqual(1);
+      const failureBranch = choiceState.Choices.find(
+        (rule: any) =>
+          rule.Variable === '$.aggregate.anyChunkFailed' &&
+          rule.BooleanEquals === true
+      );
+      expect(failureBranch).toBeDefined();
+      expect(failureBranch.Next).toMatch(/UpdateJobFailed/);
+
+      expect(choiceState.Default).toBeDefined();
+      expect(choiceState.Default).toMatch(/UpdateJobCompleted/);
+    });
+
     test('State machine has required IAM permissions', () => {
       // State machine should have permission to invoke Lambda
       template.hasResourceProperties('AWS::IAM::Policy', {

--- a/backend/infrastructure/lib/lfmt-infrastructure-stack.ts
+++ b/backend/infrastructure/lib/lfmt-infrastructure-stack.ts
@@ -1292,33 +1292,42 @@ export class LfmtInfrastructureStack extends Stack {
       resultPath: '$.error',
     });
 
-    // OMC-followup C1 — gate UpdateJobCompleted on per-chunk success.
+    // OMC-followup C1 (Issue #170 + round-2 OMC review
+    // https://github.com/leixiaoyu/lfmt-poc/pull/176#issuecomment-4364585175):
+    // gate UpdateJobCompleted so it only runs when EVERY chunk's translateChunk
+    // Lambda returned `success: true`.
     //
     // Bug class: translateChunk.ts catches every error in its outer
-    // try/catch and RETURNS { success: false } instead of throwing
-    // (translateChunk.ts:256-293). From Step Functions' perspective the
-    // Lambda invocation is successful, so Map's `addCatch(updateJobFailed,
-    // ...)` above NEVER fires for that path. Without the Choice gate
-    // below, UpdateJobCompleted would unconditionally run and overwrite
-    // the per-chunk Lambda's TRANSLATION_FAILED outer status with
-    // COMPLETED — the exact phantom-success bug PR #176's #170 fix was
-    // meant to prevent.
+    // try/catch and RETURNS `{ success: false, retryable }` instead of
+    // throwing (translateChunk.ts:256-293). From Step Functions'
+    // perspective the Lambda invocation is successful, so Map's
+    // `addCatch(updateJobFailed, ...)` above NEVER fires on chunk-level
+    // application failures — `addCatch` (and `addRetry`) only react to
+    // THROWN errors, not to `{ success: false }` return payloads.
+    // Without this Choice, any single failed chunk would still be
+    // aggregated into a "successful" Map result, UpdateJobCompleted would
+    // run, and the per-chunk Lambda's TRANSLATION_FAILED outer status
+    // would be overwritten with COMPLETED — the exact phantom-success
+    // bug PR #176's #170 fix was meant to prevent.
     //
-    // Why a Pass + Choice (not throw-on-failure inside translateChunk):
-    // the rate-limit path also returns { success: false, retryable: true }
-    // and is intentionally kept as a soft signal so the Map state can
-    // continue iterating. Throwing in translateChunk would change retry
-    // semantics for that path AND for any future soft-failure cases.
-    // The Choice below is contained to infra and only inspects the
-    // aggregate signal; the chunk handler's contract stays unchanged.
+    // Note on `retryable`: the field is currently a dead-letter signal
+    // (no Step Functions construct reads it; addRetry only catches thrown
+    // errors). Round-2 reviewer flagged the previous "rate-limit
+    // soft-signal preserved" framing as misleading — keeping the
+    // try/catch + `{ success: false }` contract avoids changing the
+    // chunk handler's surface area, and the gate stays contained to
+    // infra. If we ever want true rate-limit retries we'll need to
+    // throw a typed error from translateChunk and add a matching
+    // `addRetry` rule on the Map iterator.
     //
-    // Why States.ArrayContains: it's the canonical ASL idiom for "did
-    // any iteration in this Map fail?" and is documented for exactly
-    // this use case in the AWS Step Functions intrinsic-functions docs.
-    // The JsonPath wildcard `$.translationResults[*].translateResult.Payload.success`
-    // returns a flat array of booleans (one per chunk); ArrayContains
-    // checks for the literal `false` value. Strict equality, no object
-    // matching needed (object matching is NOT supported by the operator).
+    // Why States.ArrayContains: it's the canonical ASL idiom — JSONPath
+    // filter expressions aren't supported in Choice states. The wildcard
+    // `$.translationResults[*].translateResult.Payload.success` projects
+    // to a flat array of booleans (one per chunk) and ArrayContains
+    // checks whether the literal `false` value appears anywhere; if it
+    // does, route to UpdateJobFailed instead. Strict equality, no
+    // object matching needed (object matching is NOT supported by the
+    // operator).
     const aggregateChunkResults = new stepfunctions.Pass(this, 'AggregateChunkResults', {
       comment:
         'Compute anyChunkFailed = ArrayContains(translationResults[*].translateResult.Payload.success, false). ' +

--- a/backend/infrastructure/lib/lfmt-infrastructure-stack.ts
+++ b/backend/infrastructure/lib/lfmt-infrastructure-stack.ts
@@ -1187,16 +1187,42 @@ export class LfmtInfrastructureStack extends Stack {
 
     processChunksMap.iterator(translateChunkTask);
 
-    // Update job status to COMPLETED (fixed translatedChunks type bug)
+    // Update job status to COMPLETED (fixed translatedChunks type bug).
+    //
+    // ISSUE #170: This task also writes the OUTER `status` field
+    // (#status = :outerStatus = 'COMPLETED'). Two attributes need the
+    // success update because they have separate lifecycles:
+    //   - `translationStatus` — driven by Step Functions; the polling
+    //     endpoint reads it for progress UI.
+    //   - `status` (outer) — initialized at upload (UPLOADED → CHUNKED)
+    //     and may be flipped to TRANSLATION_FAILED by the per-chunk
+    //     Lambda's catch-all (translateChunk.ts updateJobStatus).
+    // If a chunk Lambda fails non-retryably on attempt 1 then succeeds
+    // on a Step Functions retry, the outer status stays on
+    // TRANSLATION_FAILED forever — the frontend (TranslationDetail.tsx
+    // branches on `job.status === 'TRANSLATION_FAILED'`) then misclassifies
+    // the successful job as failed. Writing both fields here makes Step
+    // Functions the single source of truth on terminal success, mirroring
+    // PR #165's pattern for terminal failure (UpdateJobFailed below).
+    //
+    // `#status` is used because `status` is a DDB reserved word — the
+    // ExpressionAttributeNames map below aliases it.
     const updateJobCompleted = new tasks.DynamoUpdateItem(this, 'UpdateJobCompleted', {
       table: this.jobsTable,
       key: {
         jobId: tasks.DynamoAttributeValue.fromString(stepfunctions.JsonPath.stringAt('$.jobId')),
         userId: tasks.DynamoAttributeValue.fromString(stepfunctions.JsonPath.stringAt('$.userId')),
       },
-      updateExpression: 'SET translationStatus = :status, translationCompletedAt = :completedAt, translatedChunks = :totalChunks, updatedAt = :updatedAt',
+      updateExpression: 'SET translationStatus = :status, #status = :outerStatus, translationCompletedAt = :completedAt, translatedChunks = :totalChunks, updatedAt = :updatedAt',
+      expressionAttributeNames: {
+        '#status': 'status',
+      },
       expressionAttributeValues: {
         ':status': tasks.DynamoAttributeValue.fromString('COMPLETED'),
+        // 'COMPLETED' is a member of shared-types/src/jobs.ts JobStatus union
+        // and matches what frontend logic (TranslationDetail.tsx) expects on
+        // terminal success.
+        ':outerStatus': tasks.DynamoAttributeValue.fromString('COMPLETED'),
         ':completedAt': tasks.DynamoAttributeValue.fromString(stepfunctions.JsonPath.stringAt('$$.State.EnteredTime')),
         // CRITICAL FIX: DynamoDB NUMBER attributes in Step Functions MUST be provided as strings
         // Using States.Format() to convert the number result from States.ArrayLength() to a string

--- a/backend/infrastructure/lib/lfmt-infrastructure-stack.ts
+++ b/backend/infrastructure/lib/lfmt-infrastructure-stack.ts
@@ -1233,21 +1233,40 @@ export class LfmtInfrastructureStack extends Stack {
     });
 
     // Failure path (Issue #151): when the Map iterator throws after retries
-    // are exhausted, persist TRANSLATION_FAILED to DDB so the UI / polling
+    // are exhausted, OR when at least one chunk reports success=false (see
+    // OMC-followup C1 + the AggregateChunkResults / CheckAllChunksSucceeded
+    // states below), persist TRANSLATION_FAILED to DDB so the UI / polling
     // endpoints stop reporting a phantom-success. The error payload from the
     // Map's catch is stored under $.error and serialized into the DDB row for
     // post-mortem visibility.
+    //
+    // OMC-followup C2 — dual-write `#status` (outer) in addition to
+    // `translationStatus`. PR #176 added the dual-write to UpdateJobCompleted
+    // (issue #170) but left UpdateJobFailed asymmetric; the same bug class
+    // applies in reverse — without this, a transient success that later
+    // fails terminally leaves the outer `status` field stuck on a stale
+    // value (e.g., 'COMPLETED' from a hypothetical earlier write, or
+    // 'IN_PROGRESS' from startTranslation). Mirror the dual-write so Step
+    // Functions is the single source of truth on terminal lifecycle for
+    // BOTH success and failure outcomes.
     const updateJobFailed = new tasks.DynamoUpdateItem(this, 'UpdateJobFailed', {
       table: this.jobsTable,
       key: {
         jobId: tasks.DynamoAttributeValue.fromString(stepfunctions.JsonPath.stringAt('$.jobId')),
         userId: tasks.DynamoAttributeValue.fromString(stepfunctions.JsonPath.stringAt('$.userId')),
       },
-      updateExpression: 'SET translationStatus = :status, translationFailedAt = :failedAt, translationError = :error, updatedAt = :updatedAt',
+      updateExpression: 'SET translationStatus = :status, #status = :outerStatus, translationFailedAt = :failedAt, translationError = :error, updatedAt = :updatedAt',
+      expressionAttributeNames: {
+        // `status` is a DDB reserved word — alias matches UpdateJobCompleted.
+        '#status': 'status',
+      },
       expressionAttributeValues: {
         // 'TRANSLATION_FAILED' matches shared-types/src/jobs.ts (TranslationStatus union)
         // and the polling endpoint in backend/functions/jobs/getTranslationStatus.ts.
         ':status': tasks.DynamoAttributeValue.fromString('TRANSLATION_FAILED'),
+        // OMC-followup C2: outer status mirrors translationStatus on terminal
+        // failure (frontend TranslationDetail.tsx branches on `job.status`).
+        ':outerStatus': tasks.DynamoAttributeValue.fromString('TRANSLATION_FAILED'),
         ':failedAt': tasks.DynamoAttributeValue.fromString(stepfunctions.JsonPath.stringAt('$$.State.EnteredTime')),
         ':error': tasks.DynamoAttributeValue.fromString(stepfunctions.JsonPath.stringAt("States.JsonToString($.error)")),
         ':updatedAt': tasks.DynamoAttributeValue.fromString(stepfunctions.JsonPath.stringAt('$$.State.EnteredTime')),
@@ -1273,15 +1292,74 @@ export class LfmtInfrastructureStack extends Stack {
       resultPath: '$.error',
     });
 
+    // OMC-followup C1 — gate UpdateJobCompleted on per-chunk success.
+    //
+    // Bug class: translateChunk.ts catches every error in its outer
+    // try/catch and RETURNS { success: false } instead of throwing
+    // (translateChunk.ts:256-293). From Step Functions' perspective the
+    // Lambda invocation is successful, so Map's `addCatch(updateJobFailed,
+    // ...)` above NEVER fires for that path. Without the Choice gate
+    // below, UpdateJobCompleted would unconditionally run and overwrite
+    // the per-chunk Lambda's TRANSLATION_FAILED outer status with
+    // COMPLETED — the exact phantom-success bug PR #176's #170 fix was
+    // meant to prevent.
+    //
+    // Why a Pass + Choice (not throw-on-failure inside translateChunk):
+    // the rate-limit path also returns { success: false, retryable: true }
+    // and is intentionally kept as a soft signal so the Map state can
+    // continue iterating. Throwing in translateChunk would change retry
+    // semantics for that path AND for any future soft-failure cases.
+    // The Choice below is contained to infra and only inspects the
+    // aggregate signal; the chunk handler's contract stays unchanged.
+    //
+    // Why States.ArrayContains: it's the canonical ASL idiom for "did
+    // any iteration in this Map fail?" and is documented for exactly
+    // this use case in the AWS Step Functions intrinsic-functions docs.
+    // The JsonPath wildcard `$.translationResults[*].translateResult.Payload.success`
+    // returns a flat array of booleans (one per chunk); ArrayContains
+    // checks for the literal `false` value. Strict equality, no object
+    // matching needed (object matching is NOT supported by the operator).
+    const aggregateChunkResults = new stepfunctions.Pass(this, 'AggregateChunkResults', {
+      comment:
+        'Compute anyChunkFailed = ArrayContains(translationResults[*].translateResult.Payload.success, false). ' +
+        'Step Functions Map only catches THROWN errors; translateChunk returns success:false instead — without this aggregate, ' +
+        'a Lambda that reported success:false would still flow into UpdateJobCompleted and overwrite TRANSLATION_FAILED with COMPLETED.',
+      parameters: {
+        'anyChunkFailed.$':
+          'States.ArrayContains($.translationResults[*].translateResult.Payload.success, false)',
+      },
+      resultPath: '$.aggregate',
+    });
+
+    const checkAllChunksSucceeded = new stepfunctions.Choice(this, 'CheckAllChunksSucceeded', {
+      comment:
+        'If any chunk reported success:false, route to UpdateJobFailed. Otherwise proceed to UpdateJobCompleted. ' +
+        'See AggregateChunkResults above for the rationale.',
+    });
+
     // Success state
     const successState = new stepfunctions.Succeed(this, 'TranslationSuccess', {
       comment: 'All chunks translated successfully - hotfix v1',
     });
 
-    // Define the state machine workflow
+    // Wire the Choice rules. BooleanEquals against a Variable that holds
+    // the result of the intrinsic above. true → failure path; otherwise
+    // (default) → success path. This guarantees UpdateJobCompleted ONLY
+    // runs when every chunk actually succeeded.
+    checkAllChunksSucceeded
+      .when(
+        stepfunctions.Condition.booleanEquals('$.aggregate.anyChunkFailed', true),
+        updateJobFailed
+      )
+      .otherwise(updateJobCompleted.next(successState));
+
+    // Define the state machine workflow.
+    // Map → AggregateChunkResults → CheckAllChunksSucceeded
+    //   ├── (anyChunkFailed=true)  → UpdateJobFailed → TranslationFailed
+    //   └── (default)              → UpdateJobCompleted → TranslationSuccess
     const definition = processChunksMap
-      .next(updateJobCompleted)
-      .next(successState);
+      .next(aggregateChunkResults)
+      .next(checkAllChunksSucceeded);
 
     // Create the state machine
     (this as any).translationStateMachine = new stepfunctions.StateMachine(this, 'TranslationStateMachine', {


### PR DESCRIPTION
## Summary

Three backend lifecycle bugs surfaced during the **2026-05-02 Track B
capture run** — fixed together as a single bundle because all three are
surgical (~250 LOC source + ~290 LOC of regression tests) and share a
theme: Step Functions / Cognito lifecycle steps that silently drop or
mis-classify state.

Each fix is paired with a regression test that would have caught the
bug. All three slipped through previously because the existing tests
didn't assert the lifecycle/contract.

Closes #168
Closes #169
Closes #170

---

## #168 — `tokensUsed` / `estimatedCost` lost under parallel translation (HIGH)

**Symptom:** DDB job rows showed `tokensUsed: 0, estimatedCost: 0` after
a successful translation, even though CloudWatch confirmed each chunk
Lambda computed real values (~4018 tokens, ~$0.000283 per chunk).

**Root cause:** `backend/functions/translation/translateChunk.ts:233-238`
was doing a read-modify-write — load the job, compute
`(job.tokensUsed || 0) + result.tokensUsed.total`, write it as a SET.
Under Step Functions Map `maxConcurrency=10`, multiple chunk Lambdas
read the same starting value (0) in parallel and last-writer-wins, so
per-chunk metrics were lost. The Step Functions `updateJobCompleted`
task at `lfmt-infrastructure-stack.ts:1191` never aggregated them
either.

**Fix:** switch `updateJobProgress` to atomic
`SET ... ADD tokensUsed :tokens, estimatedCost :cost` and pass per-chunk
DELTAS instead of pre-computed running totals. ADD is race-free under
parallel execution and Step Functions retries.
`startTranslation.ts:312-313` already initializes both attributes to
`0` (NUMBER), so ADD is always a valid first-call operation.

**Regression test:** `translateChunk.test.ts` adds a case asserting
(a) `UpdateExpression` contains `ADD tokensUsed :tokens` and
`estimatedCost :cost`, (b) neither attribute appears in the SET clause
(would race), and (c) the value bound to `:tokens` is the per-chunk
delta (150) — NOT the loaded running total (600).

---

## #169 — Register Lambda 500 on `AdminConfirmSignUp` race (MEDIUM)

**Symptom:** `POST /v1/auth/register` for a fresh email returned HTTP 500
even though the user was successfully created. CloudWatch showed
`NotAuthorizedException: User cannot be confirmed. Current status is
CONFIRMED`. Same root cause as the post-deploy `Run Backend Integration
Tests` failures that have tripped on every main deploy since 2026-04-29.

**Root cause:** the dev User Pool is configured with both
`autoVerify: { email: true }` (`lfmt-infrastructure-stack.ts:321`) AND a
PreSignUp Lambda trigger that sets `autoConfirmUser=true` (line 365-368).
Cognito confirms the user as part of `SignUp` itself, so the Lambda's
redundant `AdminConfirmSignUp` call races and throws. The catch-all in
`backend/functions/auth/register.ts` then turned that benign error into
a 500.

**Fix:** wrap `AdminConfirmSignUp` in try/catch and treat
`NotAuthorizedException` matching `/already confirmed|status is
CONFIRMED/i` as a non-error. Other `NotAuthorizedException` variants
(e.g. legitimately disabled users) still propagate to the catch-all so
operators see real failures.

**Regression test:** new file
`backend/functions/auth/__tests__/register.autoconfirm.test.ts` —
separate from `register.test.ts` because `AUTO_CONFIRM_USERS` is
computed at module load from `ENVIRONMENT.includes('Dev')` and the
sibling pre-sets `ENVIRONMENT='test'`. Three cases: (1) the
already-confirmed race returns 201 not 500, (2) other
`NotAuthorizedException` variants still surface as 500, (3) happy path
still works.

---

## #170 — Outer `status` stuck on `TRANSLATION_FAILED` after retry-recovery (HIGH)

**Symptom:** `GET /jobs/{id}/translation-status` returned
`status: 'TRANSLATION_FAILED', translationStatus: 'COMPLETED',
progressPercentage: 100` for jobs where Step Functions execution
SUCCEEDED. Frontend logic in `TranslationDetail.tsx:166-168` branches
on `job.status === 'TRANSLATION_FAILED'` and mis-classified successful
jobs as failed.

**Root cause:** two status fields with separate lifecycles. The OUTER
`status` is initialized at upload (UPLOADED → CHUNKED) and may be
flipped to `TRANSLATION_FAILED` by the per-chunk Lambda's catch-all
(`translateChunk.ts updateJobStatus`). If a chunk Lambda fails
non-retryably on attempt 1 then succeeds on a Step Functions retry, the
outer status stays on `TRANSLATION_FAILED` forever — Step Functions'
`updateJobCompleted` task only wrote `translationStatus` and never
touched `status`.

**Fix:** extend `updateJobCompleted`'s `UpdateExpression` in
`backend/infrastructure/lib/lfmt-infrastructure-stack.ts:1191` to also
`SET #status = :outerStatus = 'COMPLETED'` (with `#status` aliased
because `status` is a DDB reserved word). Mirrors PR #165's pattern of
making Step Functions the single source of truth on terminal lifecycle.

**Regression test:** `infrastructure.test.ts` adds a case modeled on
PR #165's `UpdateJobFailed` assertion that walks the synthesized state
machine definition and asserts (a) `UpdateExpression` contains both
`translationStatus` AND `#status`, (b) `ExpressionAttributeNames`
aliases `#status` to `status`, (c) `'COMPLETED'` appears at least twice
in `ExpressionAttributeValues` (once for `translationStatus`, once for
outer `status`).

---

## Test count delta

| Suite | Before | After | Delta |
|---|---|---|---|
| `backend/functions` | 437 passed, 3 skipped | 440 passed, 3 skipped | **+3** |
| `backend/infrastructure` | 42 passed | 43 passed | **+1** |

## Verification gates

- [x] `cd backend/functions && npm test` — 440 passed, 0 failed
- [x] `cd backend/functions && npm run lint` — 0 errors (249
  pre-existing warnings)
- [x] `cd backend/functions && npm run format:check` — clean
- [x] `cd backend/infrastructure && npm test` — 43 passed, 0 failed
- [N/A] `cd backend/infrastructure && npm run lint` — pre-existing
  failure on origin/main (no eslint config; not introduced by this PR)
- [N/A] `cd backend/infrastructure && npm run format:check` —
  pre-existing failures on origin/main (same 47 files were already
  prettier-dirty before this branch). Per CLAUDE.md guidance, not
  reformatted to avoid 595-line cosmetic diffs.

## Test plan (post-merge verification)

After merge → next push redeploys → manually run a translation and
verify on the live environment:

- [ ] DDB job row shows non-zero `tokensUsed` and `estimatedCost`
  matching CloudWatch chunk Lambda totals (#168)
- [ ] Outer `status` flips from `CHUNKED` (or `TRANSLATION_FAILED` for
  retry-recovered jobs) to `COMPLETED` on successful translation (#170)
- [ ] Registering a fresh user via `POST /v1/auth/register` returns
  `201`, not `500` (#169)
- [ ] Post-deploy `Run Backend Integration Tests` job goes green (was
  failing on every main deploy since 2026-04-29 — same root cause as
  #169)