### PR TITLE
fix(ci): unblock post-deploy smoke + E2E + production-smoke verification jobs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -556,11 +556,24 @@ jobs:
 
       - name: Run smoke tests against deployed API
         working-directory: backend/tests/smoke
-        run: npm run test:smoke
         env:
           API_URL: ${{ needs.deploy-dev.outputs.api_url }}
-          TEST_PASSWORD: ${{ secrets.SMOKE_TEST_PASSWORD }}
           USER_POOL_ID: ${{ secrets.DEV_USER_POOL_ID }}
+        # The backend smoke test (backend/tests/smoke/smoke.test.ts) registers
+        # FRESH users each run (per its docstring) and just needs a password
+        # strong enough to satisfy Cognito's policy. We previously read this
+        # from `secrets.SMOKE_TEST_PASSWORD`, but that secret was never
+        # configured in repo settings — every post-deploy run failed with
+        # `❌ TEST_PASSWORD environment variable is required` before the suite
+        # even started. Generating per-run with openssl removes the operational
+        # dependency entirely and keeps the password ephemeral. `::add-mask::`
+        # ensures the value is redacted from the workflow log if anything
+        # downstream prints it.
+        run: |
+          GENERATED_PASS="$(openssl rand -base64 24 | tr -d '/+' | head -c 20)Aa1!"
+          echo "::add-mask::$GENERATED_PASS"
+          export TEST_PASSWORD="$GENERATED_PASS"
+          npm run test:smoke
 
       - name: Smoke Test Summary
         if: always()

--- a/frontend/e2e/tests/smoke/production-smoke.spec.ts
+++ b/frontend/e2e/tests/smoke/production-smoke.spec.ts
@@ -17,12 +17,20 @@
  */
 
 import * as path from 'path';
+import { fileURLToPath } from 'node:url';
 import { test, expect } from '@playwright/test';
 
 // Smoke tests use a longer timeout because they run against production.
 // 3 minutes is sufficient when we use the ~1 KB smoke-test-minimal.txt
 // fixture (one chunk, deterministic translation time).
 test.setTimeout(180000); // 3 minutes
+
+// __dirname is not defined in ES module scope (Node ESM). Compute it from
+// import.meta.url instead. Without this, the test file fails to load with
+// `ReferenceError: __dirname is not defined in ES module scope` and every
+// post-deploy verification job that imports it (Production Smoke Tests,
+// E2E Tests) crashes before running a single assertion.
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // Path to the tiny fixture we upload during the smoke test. Keeping this
 // ~1 KB guarantees the test completes inside the timeout regardless of


### PR DESCRIPTION
## Summary

Two pre-existing failure patterns have been blocking every deploy's post-deploy verification gates. Both fixes are minimal and surgical.

### Fix 1 — `__dirname is not defined in ES module scope`

**File**: `frontend/e2e/tests/smoke/production-smoke.spec.ts:30`

Bare `__dirname` is not defined in ES module scope. Playwright loads this spec as ESM, so the file fails to load with:

```
ReferenceError: __dirname is not defined in ES module scope
```

…before a single assertion runs. This crashes **both** `Run Production Smoke Tests` **and** `Run E2E Tests` (both jobs include this spec file).

Applied the standard ESM workaround: import `fileURLToPath` from `node:url` and derive `__dirname` from `import.meta.url`. The existing `SMOKE_FIXTURE_PATH` line is unchanged — it now resolves correctly because `__dirname` is defined.

### Fix 2 — `❌ TEST_PASSWORD environment variable is required`

**File**: `.github/workflows/deploy.yml` (the `Run smoke tests against deployed API` step, ~line 557)

The step read `TEST_PASSWORD` from `secrets.SMOKE_TEST_PASSWORD`, which was never configured in repo settings. The backend smoke test asserts the env var at startup (`backend/tests/smoke/smoke.test.ts:42-46`) and exits 1 with the error above before running anything.

Per the smoke test's own docstring it **registers fresh users each run**, so it just needs a Cognito-policy-compliant password — there's no need for a stable shared secret. The step now generates a per-run password via `openssl rand`, masks it with `::add-mask::`, and exports it inline. This removes the operational dependency on a missing secret entirely and keeps the password ephemeral.

`API_URL` and `USER_POOL_ID` env vars are preserved; only `TEST_PASSWORD: ${{ secrets.SMOKE_TEST_PASSWORD }}` was removed from the env block.

## Verification (local)

- [x] `npx tsc --noEmit -p frontend/tsconfig.json` — clean (no errors mentioning `production-smoke`)
- [x] `npx prettier --check frontend/e2e/tests/smoke/production-smoke.spec.ts` — clean
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy.yml'))"` — YAML parses

## Out of scope / follow-up

After Fix 1 unblocks them, frontend `Run Production Smoke Tests` and `Run E2E Tests` may surface a **new** failure pattern: they read `SMOKE_TEST_EMAIL` and `SMOKE_TEST_PASSWORD` to log in to a known account, and those secrets are also unset in repo settings. That is a larger refactor (it requires either a seeded test account or refactoring the frontend smoke flow to register a fresh user the way the backend smoke test does) and is intentionally **not** addressed here. Tracking as a follow-up.

## Notes

This is a clean re-do of an earlier attempt that was lost when a previous working tree was reset by a colliding agent edit. This PR was prepared in an isolated git worktree on a fresh branch off main, so the diff contains only the two intended files and nothing else.

## Test plan

- [ ] Verify `Run Tests` and `Build Infrastructure` (the two required checks) pass on this PR
- [ ] After merge, monitor the next deploy run and confirm `Run smoke tests against deployed API`, `Run Production Smoke Tests`, and `Run E2E Tests` no longer fail with the two patterns above (they may surface the documented follow-up failure for the frontend smoke jobs — that's expected)