### PR TITLE
fix(translation): root-cause + fix two runtime failures blocking demo (Sherlock/Pride 2026-05-02)

### DIFF
--- a/backend/functions/translation/__tests__/geminiClient.test.ts
+++ b/backend/functions/translation/__tests__/geminiClient.test.ts
@@ -4,7 +4,7 @@
 
 import { mockClient } from 'aws-sdk-client-mock';
 import { SecretsManagerClient, GetSecretValueCommand } from '@aws-sdk/client-secrets-manager';
-import { GeminiClient, createGeminiClient } from '../geminiClient';
+import { GeminiClient, createGeminiClient, isFinishReasonRetryable } from '../geminiClient';
 import { GeminiApiError, RateLimitError, AuthenticationError, TranslationOptions } from '../types';
 
 // Mock the Google GenAI SDK
@@ -507,6 +507,160 @@ describe('GeminiClient', () => {
 
       // Cost = (10000 / 1,000,000) * $0.075 = $0.00075
       expect(result.estimatedCost).toBeCloseTo(0.00075, 6);
+    });
+  });
+
+  /**
+   * OMC-followup R4 — EMPTY_RESPONSE retryable mapping.
+   *
+   * Background: Gemini's GenerateContentResponse exposes a per-candidate
+   * `finishReason` (FinishReason enum from @google/genai). The previous
+   * empty-text guard always set retryable=false, which was wrong: OTHER
+   * and FINISH_REASON_UNSPECIFIED outcomes are transient and SHOULD be
+   * retried by Step Functions. Conversely, deterministic outcomes
+   * (SAFETY, RECITATION, MAX_TOKENS, BLOCKLIST, PROHIBITED_CONTENT, ...)
+   * MUST NOT be retried — retrying produces the same outcome and burns
+   * the rate-limit budget.
+   *
+   * This block has two parts:
+   *   1. Direct tests of the pure helper `isFinishReasonRetryable()`
+   *      (one assertion per FinishReason enum variant).
+   *   2. End-to-end tests through `GeminiClient.translate()` that verify
+   *      the helper's output is correctly threaded into the thrown
+   *      GeminiApiError's `retryable` flag and that the message surfaces
+   *      the finishReason for triage.
+   */
+  describe('EMPTY_RESPONSE finishReason → retryable mapping (OMC-followup R4)', () => {
+    describe('isFinishReasonRetryable() pure helper', () => {
+      it.each([
+        ['SAFETY'],
+        ['RECITATION'],
+        ['BLOCKLIST'],
+        ['PROHIBITED_CONTENT'],
+        ['SPII'],
+        ['MAX_TOKENS'],
+        ['LANGUAGE'],
+        ['MALFORMED_FUNCTION_CALL'],
+        ['UNEXPECTED_TOOL_CALL'],
+        ['IMAGE_SAFETY'],
+        ['IMAGE_PROHIBITED_CONTENT'],
+        ['IMAGE_RECITATION'],
+        ['NO_IMAGE'],
+      ])('%s → NOT retryable (deterministic / content-policy outcome)', (reason) => {
+        expect(isFinishReasonRetryable(reason)).toBe(false);
+      });
+
+      it.each([
+        ['OTHER'],
+        ['IMAGE_OTHER'],
+        ['FINISH_REASON_UNSPECIFIED'],
+        ['SOMETHING_NEW_FROM_FUTURE_SDK_VERSION'],
+      ])('%s → retryable (transient / unknown — benefit of the doubt)', (reason) => {
+        expect(isFinishReasonRetryable(reason)).toBe(true);
+      });
+
+      it.each([[undefined], [null], ['']])(
+        'absent finishReason (%p) → retryable (benefit of the doubt)',
+        (reason) => {
+          expect(isFinishReasonRetryable(reason as undefined | null | string)).toBe(true);
+        }
+      );
+    });
+
+    describe('GeminiApiError.retryable threaded from finishReason', () => {
+      let client: GeminiClient;
+      let mockGenerateContent: jest.Mock;
+
+      beforeEach(async () => {
+        secretsMock.on(GetSecretValueCommand).resolves({
+          SecretString: mockApiKey,
+        } as any);
+
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const { GoogleGenAI } = require('@google/genai');
+        mockGenerateContent = jest.fn();
+
+        (GoogleGenAI as jest.Mock).mockImplementation(() => ({
+          models: { generateContent: mockGenerateContent },
+        }));
+
+        client = new GeminiClient(mockConfig);
+        await client.initialize();
+      });
+
+      it.each([
+        ['SAFETY', false],
+        ['RECITATION', false],
+        ['MAX_TOKENS', false],
+        ['BLOCKLIST', false],
+        ['OTHER', true],
+        ['FINISH_REASON_UNSPECIFIED', true],
+      ])(
+        'empty text + finishReason=%s → throws GeminiApiError with retryable=%s and EMPTY_RESPONSE code',
+        async (finishReason, expectedRetryable) => {
+          mockGenerateContent.mockResolvedValue({
+            text: undefined,
+            candidates: [{ finishReason }],
+            usageMetadata: {
+              promptTokenCount: 50,
+              candidatesTokenCount: 0,
+              totalTokenCount: 50,
+            },
+          });
+
+          const options: TranslationOptions = { targetLanguage: 'es' };
+
+          await expect(client.translate('Text', options)).rejects.toMatchObject({
+            name: 'GeminiApiError',
+            errorCode: 'EMPTY_RESPONSE',
+            retryable: expectedRetryable,
+            // Triage-friendly: the message surfaces the finishReason verbatim.
+            message: expect.stringContaining(finishReason),
+          });
+        }
+      );
+
+      it('empty text + missing candidates array → retryable=true (benefit of the doubt)', async () => {
+        mockGenerateContent.mockResolvedValue({
+          text: '',
+          // candidates intentionally absent
+          usageMetadata: {
+            promptTokenCount: 50,
+            candidatesTokenCount: 0,
+            totalTokenCount: 50,
+          },
+        });
+
+        const options: TranslationOptions = { targetLanguage: 'es' };
+
+        await expect(client.translate('Text', options)).rejects.toMatchObject({
+          name: 'GeminiApiError',
+          errorCode: 'EMPTY_RESPONSE',
+          retryable: true,
+          message: expect.stringContaining('unknown'),
+        });
+      });
+
+      it.each([
+        ['null', null],
+        ['empty string', ''],
+      ])(
+        'empty text shape "%s" still triggers the EMPTY_RESPONSE guard',
+        async (_label, textValue) => {
+          mockGenerateContent.mockResolvedValue({
+            text: textValue,
+            candidates: [{ finishReason: 'SAFETY' }],
+          });
+
+          const options: TranslationOptions = { targetLanguage: 'es' };
+
+          await expect(client.translate('Text', options)).rejects.toMatchObject({
+            name: 'GeminiApiError',
+            errorCode: 'EMPTY_RESPONSE',
+            retryable: false,
+          });
+        }
+      );
     });
   });
 });

--- a/backend/functions/translation/__tests__/translateChunk.test.ts
+++ b/backend/functions/translation/__tests__/translateChunk.test.ts
@@ -445,6 +445,84 @@ describe('translateChunk Lambda', () => {
         }
       }
     });
+
+    /**
+     * Bug A regression test — Gemini returns response with text=undefined.
+     *
+     * Observed: Sherlock job 2026-05-02, chunk 0, after a 54-second generation
+     * the Gemini response had no text candidate. The SDK's .text getter returns
+     * string | undefined, so storeTranslatedChunk received undefined as the S3
+     * PutObjectCommand Body. AWS SDK v3 (SigV4 signer) calls .trim() on the
+     * Body when treating it as a string, causing:
+     *   "Cannot read properties of undefined (reading 'length')"
+     * The fix (geminiClient.ts) throws a GeminiApiError('EMPTY_RESPONSE') so
+     * translateChunk returns { success: false, retryable: false } instead.
+     */
+    it('returns success:false when Gemini response has undefined text — Bug A regression', async () => {
+      const previousImpl = (GoogleGenAI as unknown as jest.Mock).getMockImplementation();
+      (GoogleGenAI as unknown as jest.Mock).mockImplementationOnce(() => ({
+        models: {
+          generateContent: jest.fn().mockResolvedValue({
+            text: undefined, // safety filter / empty candidate
+            usageMetadata: {
+              promptTokenCount: 50,
+              candidatesTokenCount: 0,
+              totalTokenCount: 50,
+            },
+          }),
+        },
+      }));
+
+      try {
+        dynamoMock.on(GetItemCommand).resolves({
+          Item: createMockJob({
+            jobId: 'job-bug-a',
+            userId: 'user-bug-a',
+            status: 'CHUNKED',
+            totalChunks: 4,
+            translatedChunks: 0,
+            tokensUsed: 0,
+            estimatedCost: 0,
+            extraFields: {
+              translationStatus: { S: 'IN_PROGRESS' },
+            },
+          }),
+        } as any);
+
+        const chunkContent = JSON.stringify({
+          primaryContent: 'Sherlock Holmes text for Bug A regression.',
+          chunkId: 'chunk-0',
+          chunkIndex: 0,
+        });
+
+        s3Mock.on(GetObjectCommand).resolves({
+          Body: createMockStream(chunkContent),
+        } as any);
+        dynamoMock.on(UpdateItemCommand).resolves({} as any);
+
+        const event: TranslateChunkEvent = {
+          jobId: 'job-bug-a',
+          userId: 'user-bug-a',
+          chunkIndex: 0,
+          targetLanguage: 'es',
+        };
+
+        const result = await handler(event);
+
+        // Must return success:false without TypeError — not crash.
+        expect(result.success).toBe(false);
+        expect(result.retryable).toBe(false);
+        expect(result.error).toContain('empty response');
+
+        // S3 PutObject must NOT have been called (no translatedText to store).
+        const putCalls = s3Mock.commandCalls(PutObjectCommand);
+        expect(putCalls).toHaveLength(0);
+      } finally {
+        if (previousImpl) {
+          (GoogleGenAI as unknown as jest.Mock).mockImplementation(previousImpl);
+        }
+      }
+    });
   });
 
   describe('input validation', () => {

--- a/backend/functions/translation/__tests__/translateChunk.test.ts
+++ b/backend/functions/translation/__tests__/translateChunk.test.ts
@@ -456,33 +456,118 @@ describe('translateChunk Lambda', () => {
      * Body when treating it as a string, causing:
      *   "Cannot read properties of undefined (reading 'length')"
      * The fix (geminiClient.ts) throws a GeminiApiError('EMPTY_RESPONSE') so
-     * translateChunk returns { success: false, retryable: false } instead.
+     * translateChunk returns { success: false, retryable } instead.
+     *
+     * OMC-followup R3 + R4: extended to cover three empty-response shapes
+     * (undefined / null / '') and a representative non-retryable finishReason
+     * (SAFETY) so we lock down both the defensive guard AND the retryable
+     * mapping introduced in geminiClient.isFinishReasonRetryable().
      */
-    it('returns success:false when Gemini response has undefined text — Bug A regression', async () => {
+    it.each([
+      { label: 'undefined text', text: undefined },
+      { label: 'null text', text: null },
+      { label: 'empty string text', text: '' },
+      { label: 'completely undefined result.text via missing field', text: undefined },
+    ])(
+      'returns success:false when Gemini response has $label (finishReason=SAFETY → non-retryable) — Bug A regression',
+      async ({ text }) => {
+        const previousImpl = (GoogleGenAI as unknown as jest.Mock).getMockImplementation();
+        (GoogleGenAI as unknown as jest.Mock).mockImplementationOnce(() => ({
+          models: {
+            generateContent: jest.fn().mockResolvedValue({
+              text, // undefined / null / '' — all three must hit the empty guard
+              candidates: [{ finishReason: 'SAFETY' }], // R4: non-retryable mapping
+              usageMetadata: {
+                promptTokenCount: 50,
+                candidatesTokenCount: 0,
+                totalTokenCount: 50,
+              },
+            }),
+          },
+        }));
+
+        try {
+          dynamoMock.on(GetItemCommand).resolves({
+            Item: createMockJob({
+              jobId: 'job-bug-a',
+              userId: 'user-bug-a',
+              status: 'CHUNKED',
+              totalChunks: 4,
+              translatedChunks: 0,
+              tokensUsed: 0,
+              estimatedCost: 0,
+              extraFields: {
+                translationStatus: { S: 'IN_PROGRESS' },
+              },
+            }),
+          } as any);
+
+          const chunkContent = JSON.stringify({
+            primaryContent: 'Sherlock Holmes text for Bug A regression.',
+            chunkId: 'chunk-0',
+            chunkIndex: 0,
+          });
+
+          s3Mock.on(GetObjectCommand).resolves({
+            Body: createMockStream(chunkContent),
+          } as any);
+          dynamoMock.on(UpdateItemCommand).resolves({} as any);
+
+          const event: TranslateChunkEvent = {
+            jobId: 'job-bug-a',
+            userId: 'user-bug-a',
+            chunkIndex: 0,
+            targetLanguage: 'es',
+          };
+
+          const result = await handler(event);
+
+          // Must return success:false without TypeError — not crash.
+          expect(result.success).toBe(false);
+          // SAFETY is in the non-retryable set → retryable must be false.
+          expect(result.retryable).toBe(false);
+          expect(result.error).toContain('empty response');
+          // R4: the error message MUST surface the finishReason for triage.
+          expect(result.error).toContain('SAFETY');
+
+          // S3 PutObject must NOT have been called (no translatedText to store).
+          const putCalls = s3Mock.commandCalls(PutObjectCommand);
+          expect(putCalls).toHaveLength(0);
+        } finally {
+          if (previousImpl) {
+            (GoogleGenAI as unknown as jest.Mock).mockImplementation(previousImpl);
+          }
+        }
+      }
+    );
+
+    /**
+     * OMC-followup R3 — entirely undefined `result` shape.
+     *
+     * Belt-and-suspenders: the SDK could (in principle) return undefined for
+     * the whole result object on an unexpected upstream failure. Verify the
+     * client surfaces the same EMPTY_RESPONSE GeminiApiError contract instead
+     * of throwing an uncaught TypeError on `result.text`.
+     *
+     * Note: in practice the SDK throws (rejects the promise) before this code
+     * path is reached. This test pins the contract anyway so a future SDK
+     * change that returns undefined silently still degrades gracefully.
+     */
+    it('returns success:false when Gemini result is undefined — OMC-followup R3 defensive guard', async () => {
       const previousImpl = (GoogleGenAI as unknown as jest.Mock).getMockImplementation();
       (GoogleGenAI as unknown as jest.Mock).mockImplementationOnce(() => ({
         models: {
-          generateContent: jest.fn().mockResolvedValue({
-            text: undefined, // safety filter / empty candidate
-            usageMetadata: {
-              promptTokenCount: 50,
-              candidatesTokenCount: 0,
-              totalTokenCount: 50,
-            },
-          }),
+          generateContent: jest.fn().mockResolvedValue(undefined),
         },
       }));
 
       try {
         dynamoMock.on(GetItemCommand).resolves({
           Item: createMockJob({
-            jobId: 'job-bug-a',
-            userId: 'user-bug-a',
+            jobId: 'job-r3',
+            userId: 'user-r3',
             status: 'CHUNKED',
-            totalChunks: 4,
-            translatedChunks: 0,
-            tokensUsed: 0,
-            estimatedCost: 0,
+            totalChunks: 1,
             extraFields: {
               translationStatus: { S: 'IN_PROGRESS' },
             },
@@ -490,7 +575,7 @@ describe('translateChunk Lambda', () => {
         } as any);
 
         const chunkContent = JSON.stringify({
-          primaryContent: 'Sherlock Holmes text for Bug A regression.',
+          primaryContent: 'R3 defensive test.',
           chunkId: 'chunk-0',
           chunkIndex: 0,
         });
@@ -501,20 +586,18 @@ describe('translateChunk Lambda', () => {
         dynamoMock.on(UpdateItemCommand).resolves({} as any);
 
         const event: TranslateChunkEvent = {
-          jobId: 'job-bug-a',
-          userId: 'user-bug-a',
+          jobId: 'job-r3',
+          userId: 'user-r3',
           chunkIndex: 0,
           targetLanguage: 'es',
         };
 
         const result = await handler(event);
 
-        // Must return success:false without TypeError — not crash.
+        // Must NOT throw; must return a structured failure.
         expect(result.success).toBe(false);
         expect(result.retryable).toBe(false);
-        expect(result.error).toContain('empty response');
-
-        // S3 PutObject must NOT have been called (no translatedText to store).
+        // S3 PutObject must NOT have been called.
         const putCalls = s3Mock.commandCalls(PutObjectCommand);
         expect(putCalls).toHaveLength(0);
       } finally {

--- a/backend/functions/translation/geminiClient.ts
+++ b/backend/functions/translation/geminiClient.ts
@@ -152,8 +152,24 @@ export class GeminiClient {
 
       const processingTimeMs = Date.now() - startTime;
 
-      // Extract translated text from response
+      // Extract translated text from response.
+      // result.text is typed string | undefined by the @google/genai SDK.
+      // It can be undefined when Gemini returns a safety-filtered or empty
+      // response (observed: chunk 0 Sherlock job 2026-05-02, after a 54s
+      // generation the response body had no text candidate). Treat this as
+      // a non-retryable GeminiApiError so translateChunk returns success:false
+      // with a clear message instead of crashing in storeTranslatedChunk with
+      // "Cannot read properties of undefined (reading 'length')".
       const translatedText = result.text;
+      if (translatedText === undefined || translatedText === null) {
+        throw new GeminiApiError(
+          'Gemini returned an empty response (no text candidate). ' +
+            'This may indicate a safety filter, content policy block, or upstream model error.',
+          200,
+          'EMPTY_RESPONSE',
+          false
+        );
+      }
 
       // Calculate token usage and cost
       const tokensUsed = {

--- a/backend/functions/translation/geminiClient.ts
+++ b/backend/functions/translation/geminiClient.ts
@@ -4,6 +4,16 @@
  */
 
 import { GoogleGenAI } from '@google/genai';
+// FinishReason is intentionally imported as a TYPE-ONLY symbol below (see
+// `geminiClient.test.ts` jest.mock at file top — that factory replaces the
+// `@google/genai` module wholesale and does NOT re-export the FinishReason
+// enum, so `import { FinishReason }` (value-form) would crash any test
+// suite that mocks the module). Using `import type` keeps the type
+// information at compile time and emits no JS reference at runtime, while
+// the constants below use plain string literals (which are exactly the
+// FinishReason enum's runtime values per @google/genai/dist/node/node.d.ts).
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { FinishReason } from '@google/genai';
 import {
   SecretsManagerClient,
   GetSecretValueCommand,
@@ -154,20 +164,33 @@ export class GeminiClient {
 
       // Extract translated text from response.
       // result.text is typed string | undefined by the @google/genai SDK.
-      // It can be undefined when Gemini returns a safety-filtered or empty
-      // response (observed: chunk 0 Sherlock job 2026-05-02, after a 54s
-      // generation the response body had no text candidate). Treat this as
-      // a non-retryable GeminiApiError so translateChunk returns success:false
-      // with a clear message instead of crashing in storeTranslatedChunk with
+      // It can be undefined / null / '' when Gemini returns a safety-filtered
+      // or empty response (observed: chunk 0 Sherlock job 2026-05-02, after a
+      // 54s generation the response body had no text candidate). Treat this
+      // as a GeminiApiError so translateChunk returns success:false with a
+      // clear message instead of crashing in storeTranslatedChunk with
       // "Cannot read properties of undefined (reading 'length')".
+      //
+      // OMC-followup R4: branch `retryable` on candidates[0].finishReason.
+      // Gemini's GenerateContentResponse exposes a per-candidate finishReason
+      // (FinishReason enum from @google/genai). Some reasons are deterministic
+      // and MUST NOT be retried (SAFETY / RECITATION / BLOCKLIST / PROHIBITED_CONTENT
+      // / SPII / IMAGE_SAFETY / IMAGE_PROHIBITED_CONTENT / IMAGE_RECITATION are all
+      // content-policy outcomes; MAX_TOKENS / LANGUAGE / MALFORMED_FUNCTION_CALL /
+      // UNEXPECTED_TOOL_CALL / NO_IMAGE are structural mismatches a retry can't
+      // fix). OTHER and FINISH_REASON_UNSPECIFIED (or any unknown / undefined
+      // value) are treated as transient and retryable so Step Functions can
+      // schedule a retry.
       const translatedText = result.text;
-      if (translatedText === undefined || translatedText === null) {
+      if (translatedText === undefined || translatedText === null || translatedText === '') {
+        const finishReason = result.candidates?.[0]?.finishReason;
+        const retryable = isFinishReasonRetryable(finishReason);
         throw new GeminiApiError(
-          'Gemini returned an empty response (no text candidate). ' +
+          `Gemini returned an empty response (finishReason: ${finishReason ?? 'unknown'}). ` +
             'This may indicate a safety filter, content policy block, or upstream model error.',
           200,
           'EMPTY_RESPONSE',
-          false
+          retryable
         );
       }
 
@@ -391,6 +414,59 @@ export class GeminiClient {
     // Unknown errors
     return new GeminiApiError(`Translation failed: ${message}`, status, 'UNKNOWN_ERROR', false);
   }
+}
+
+/**
+ * OMC-followup R4 — finishReason → retryable mapping.
+ *
+ * Determines whether an EMPTY_RESPONSE from Gemini should be retried by
+ * Step Functions, based on the candidate's finishReason. Deterministic
+ * outcomes (content-policy blocks, structural mismatches) are NOT retryable;
+ * unknown / OTHER / unspecified are treated as transient.
+ *
+ * Exported for testability.
+ *
+ * Mapping rationale:
+ *   - SAFETY, RECITATION, BLOCKLIST, PROHIBITED_CONTENT, SPII,
+ *     IMAGE_SAFETY, IMAGE_PROHIBITED_CONTENT, IMAGE_RECITATION
+ *       → content-policy block, retry will produce the same outcome
+ *   - MAX_TOKENS → chunk too big; retrying with the same input is futile
+ *   - LANGUAGE → unsupported language; deterministic
+ *   - MALFORMED_FUNCTION_CALL, UNEXPECTED_TOOL_CALL, NO_IMAGE
+ *       → structural mismatch with the request; deterministic
+ *   - OTHER, IMAGE_OTHER → unspecified upstream issue, likely transient
+ *   - FINISH_REASON_UNSPECIFIED, undefined, unknown enum value
+ *       → benefit of the doubt — assume transient
+ */
+// String literals match the FinishReason enum values declared in
+// node_modules/@google/genai/dist/node/node.d.ts (e.g. SAFETY = "SAFETY").
+// Using literals (instead of importing the enum as a value) avoids runtime
+// crashes in test suites that mock the entire @google/genai module — see
+// the type-only import note at the top of this file.
+const NON_RETRYABLE_FINISH_REASONS: ReadonlySet<string> = new Set<string>([
+  'SAFETY',
+  'RECITATION',
+  'BLOCKLIST',
+  'PROHIBITED_CONTENT',
+  'SPII',
+  'MAX_TOKENS',
+  'LANGUAGE',
+  'MALFORMED_FUNCTION_CALL',
+  'UNEXPECTED_TOOL_CALL',
+  'IMAGE_SAFETY',
+  'IMAGE_PROHIBITED_CONTENT',
+  'IMAGE_RECITATION',
+  'NO_IMAGE',
+]);
+
+export function isFinishReasonRetryable(
+  finishReason: FinishReason | string | undefined | null
+): boolean {
+  if (finishReason === undefined || finishReason === null || finishReason === '') {
+    // Unknown / unspecified → benefit of the doubt → retryable
+    return true;
+  }
+  return !NON_RETRYABLE_FINISH_REASONS.has(finishReason);
 }
 
 /**

--- a/backend/infrastructure/lib/__tests__/infrastructure.test.ts
+++ b/backend/infrastructure/lib/__tests__/infrastructure.test.ts
@@ -435,9 +435,7 @@ describe('LFMT Infrastructure Stack', () => {
               Resource: Match.arrayWith([
                 // The attestations table ARN appears as a Fn::GetAtt reference.
                 Match.objectLike({
-                  'Fn::GetAtt': Match.arrayWith([
-                    Match.stringLikeRegexp('^AttestationsTable'),
-                  ]),
+                  'Fn::GetAtt': Match.arrayWith([Match.stringLikeRegexp('^AttestationsTable')]),
                 }),
               ]),
             }),
@@ -496,7 +494,9 @@ describe('LFMT Infrastructure Stack', () => {
         if (policyDoc?.Statement) {
           policyDoc.Statement.forEach((statement: any) => {
             if (statement.Action) {
-              const actions = Array.isArray(statement.Action) ? statement.Action : [statement.Action];
+              const actions = Array.isArray(statement.Action)
+                ? statement.Action
+                : [statement.Action];
               actions.forEach((action: any) => {
                 // Fail if we find dynamodb:* wildcard
                 expect(action).not.toBe('dynamodb:*');
@@ -540,7 +540,9 @@ describe('LFMT Infrastructure Stack', () => {
         if (policyDoc?.Statement) {
           policyDoc.Statement.forEach((statement: any) => {
             if (statement.Action) {
-              const actions = Array.isArray(statement.Action) ? statement.Action : [statement.Action];
+              const actions = Array.isArray(statement.Action)
+                ? statement.Action
+                : [statement.Action];
               actions.forEach((action: any) => {
                 // Fail if we find global wildcard '*'
                 expect(action).not.toBe('*');
@@ -678,14 +680,12 @@ describe('LFMT Infrastructure Stack', () => {
 
       // The UpdateExpression MUST set both `translationStatus` AND outer
       // `status` (via #status alias because `status` is a DDB reserved word).
-      const updateExpression: string =
-        updateJobCompleted.Parameters?.UpdateExpression ?? '';
+      const updateExpression: string = updateJobCompleted.Parameters?.UpdateExpression ?? '';
       expect(updateExpression).toMatch(/translationStatus/);
       expect(updateExpression).toMatch(/#status/);
 
       // ExpressionAttributeNames must alias #status to 'status'.
-      const attributeNames =
-        updateJobCompleted.Parameters?.ExpressionAttributeNames ?? {};
+      const attributeNames = updateJobCompleted.Parameters?.ExpressionAttributeNames ?? {};
       expect(attributeNames['#status']).toBe('status');
 
       // The value bound to outer status MUST be 'COMPLETED' (matching
@@ -700,8 +700,7 @@ describe('LFMT Infrastructure Stack', () => {
       // 'COMPLETED'). Keyed assertions are strictly correct,
       // self-documenting, and survive ASL serialization changes that
       // don't affect the contract.
-      const exprValues =
-        updateJobCompleted.Parameters?.ExpressionAttributeValues ?? {};
+      const exprValues = updateJobCompleted.Parameters?.ExpressionAttributeValues ?? {};
       expect(updateExpression).toMatch(/translationStatus\s*=\s*:status/);
       expect(updateExpression).toMatch(/#status\s*=\s*:outerStatus/);
       expect(exprValues[':status']).toEqual({ S: 'COMPLETED' });
@@ -765,14 +764,12 @@ describe('LFMT Infrastructure Stack', () => {
 
       // The UpdateExpression MUST set both `translationStatus` AND outer
       // `status` (via #status alias because `status` is a DDB reserved word).
-      const updateExpression: string =
-        updateJobFailed.Parameters?.UpdateExpression ?? '';
+      const updateExpression: string = updateJobFailed.Parameters?.UpdateExpression ?? '';
       expect(updateExpression).toMatch(/translationStatus/);
       expect(updateExpression).toMatch(/#status/);
 
       // ExpressionAttributeNames must alias #status to 'status'.
-      const attributeNames =
-        updateJobFailed.Parameters?.ExpressionAttributeNames ?? {};
+      const attributeNames = updateJobFailed.Parameters?.ExpressionAttributeNames ?? {};
       expect(attributeNames['#status']).toBe('status');
 
       // Round-2 OMC review (issuecomment-4364584995) — assert by KEY
@@ -781,8 +778,7 @@ describe('LFMT Infrastructure Stack', () => {
       // assertion pattern in the UpdateJobCompleted test above for
       // symmetry. Strictly correct, self-documenting, and survives ASL
       // serialization changes that don't affect the contract.
-      const exprValues =
-        updateJobFailed.Parameters?.ExpressionAttributeValues ?? {};
+      const exprValues = updateJobFailed.Parameters?.ExpressionAttributeValues ?? {};
       expect(updateExpression).toMatch(/translationStatus\s*=\s*:status/);
       expect(updateExpression).toMatch(/#status\s*=\s*:outerStatus/);
       expect(exprValues[':status']).toEqual({ S: 'TRANSLATION_FAILED' });
@@ -846,9 +842,7 @@ describe('LFMT Infrastructure Stack', () => {
       expect(Array.isArray(choiceState.Choices)).toBe(true);
       expect(choiceState.Choices.length).toBeGreaterThanOrEqual(1);
       const failureBranch = choiceState.Choices.find(
-        (rule: any) =>
-          rule.Variable === '$.aggregate.anyChunkFailed' &&
-          rule.BooleanEquals === true
+        (rule: any) => rule.Variable === '$.aggregate.anyChunkFailed' && rule.BooleanEquals === true
       );
       expect(failureBranch).toBeDefined();
       // Bug B fix: Choice now routes through NormalizeFailureContext before UpdateJobFailed.
@@ -889,8 +883,7 @@ describe('LFMT Infrastructure Stack', () => {
       const [, choiceState] = choiceEntry as [string, any];
 
       const failureBranch = choiceState.Choices.find(
-        (rule: any) =>
-          rule.Variable === '$.aggregate.anyChunkFailed' && rule.BooleanEquals === true
+        (rule: any) => rule.Variable === '$.aggregate.anyChunkFailed' && rule.BooleanEquals === true
       );
       expect(failureBranch).toBeDefined();
       // Must route to the normalizer, not directly to the DDB task.
@@ -898,6 +891,20 @@ describe('LFMT Infrastructure Stack', () => {
 
       // 2. NormalizeFailureContext must be a Pass state that sets $.error
       //    from $.translationResults (which is present in the success:false path).
+      //
+      // OMC-followup R2 + R5: the payload was originally a single
+      //   error.$ = States.JsonToString($.translationResults)
+      // (a stringified raw dump of every chunk's result). It is now a
+      // STRUCTURED envelope:
+      //   {
+      //     reason: 'CHUNK_FAILURE',         // stable discriminator
+      //     failedCountUpperBound.$: ArrayLength,
+      //     totalChunks.$: ArrayLength,
+      //     translationResults.$: <raw forensic detail>
+      //   }
+      // Tighten the assertions to the new shape so a future refactor that
+      // accidentally drops `reason` or reverts to the unstructured dump
+      // fails this test loudly.
       const normEntry = Object.entries(states).find(([name]) =>
         /NormalizeFailureContext/.test(name)
       );
@@ -907,9 +914,30 @@ describe('LFMT Infrastructure Stack', () => {
       expect(normState.Type).toBe('Pass');
       // Must write into $.error via ResultPath so UpdateJobFailed can read it.
       expect(normState.ResultPath).toBe('$.error');
-      // Parameters must derive the error value from $.translationResults.
-      const errorParam: string = normState.Parameters?.['error.$'] ?? '';
-      expect(errorParam).toContain('translationResults');
+
+      // R5: assert structured payload shape (NOT the legacy `error.$` raw dump).
+      const params = normState.Parameters ?? {};
+
+      // Discriminator: stable `reason` literal so downstream alerting can
+      // branch on the failure mode without parsing the array.
+      expect(params['reason']).toBe('CHUNK_FAILURE');
+
+      // Counts: ASL has no native filter intrinsic, so we surface the upper
+      // bound (== totalChunks). Both fields are derived via States.ArrayLength
+      // on $.translationResults.
+      expect(params['failedCountUpperBound.$']).toMatch(/States\.ArrayLength/);
+      expect(params['failedCountUpperBound.$']).toContain('translationResults');
+      expect(params['totalChunks.$']).toMatch(/States\.ArrayLength/);
+      expect(params['totalChunks.$']).toContain('translationResults');
+
+      // Forensic detail preserved verbatim under a NAMED key (NOT the legacy
+      // `error.$` raw dump — that would be a regression to the unstructured
+      // payload).
+      expect(params['translationResults.$']).toBe('$.translationResults');
+
+      // Negative guard: the legacy raw-dump shape (single `error.$` key
+      // pointing at States.JsonToString of the whole array) MUST be gone.
+      expect(params['error.$']).toBeUndefined();
 
       // 3. NormalizeFailureContext must transition to UpdateJobFailed.
       expect(normState.Next).toMatch(/UpdateJobFailed/);
@@ -917,16 +945,14 @@ describe('LFMT Infrastructure Stack', () => {
       // 4. The Map Catch handler must STILL route directly to UpdateJobFailed
       //    (bypassing NormalizeFailureContext) so we don't clobber the real
       //    $.error payload from the Catch.
-      const mapEntry = Object.entries(states).find(
-        ([, s]: [string, any]) => s.Type === 'Map'
-      );
+      const mapEntry = Object.entries(states).find(([, s]: [string, any]) => s.Type === 'Map');
       expect(mapEntry).toBeDefined();
       const [, mapState] = mapEntry as [string, any];
 
       const catchHandlers: any[] = mapState.Catch ?? [];
       expect(catchHandlers.length).toBeGreaterThanOrEqual(1);
-      const catchAll = catchHandlers.find((c: any) =>
-        Array.isArray(c.ErrorEquals) && c.ErrorEquals.includes('States.ALL')
+      const catchAll = catchHandlers.find(
+        (c: any) => Array.isArray(c.ErrorEquals) && c.ErrorEquals.includes('States.ALL')
       );
       expect(catchAll).toBeDefined();
       // Catch goes DIRECTLY to UpdateJobFailed (no normalizer needed —
@@ -1177,9 +1203,7 @@ describe('LFMT Infrastructure Stack', () => {
         if (csp && typeof csp === 'object' && 'Fn::Join' in (csp as object)) {
           const join = (csp as { 'Fn::Join': [string, unknown[]] })['Fn::Join'];
           const parts = join[1];
-          return parts
-            .map((p) => (typeof p === 'string' ? p : JSON.stringify(p)))
-            .join('');
+          return parts.map((p) => (typeof p === 'string' ? p : JSON.stringify(p))).join('');
         }
         return JSON.stringify(csp);
       };
@@ -1198,8 +1222,9 @@ describe('LFMT Infrastructure Stack', () => {
       expect(cspCarryingPolicies.length).toBeGreaterThanOrEqual(2);
 
       cspCarryingPolicies.forEach((policy: any) => {
-        const csp = policy.Properties.ResponseHeadersPolicyConfig.SecurityHeadersConfig
-          .ContentSecurityPolicy.ContentSecurityPolicy;
+        const csp =
+          policy.Properties.ResponseHeadersPolicyConfig.SecurityHeadersConfig.ContentSecurityPolicy
+            .ContentSecurityPolicy;
         const flat = flattenCsp(csp);
         requiredDirectives.forEach((directive) => {
           expect(flat).toContain(directive);
@@ -1220,9 +1245,7 @@ describe('LFMT Infrastructure Stack', () => {
         if (csp && typeof csp === 'object' && 'Fn::Join' in (csp as object)) {
           const join = (csp as { 'Fn::Join': [string, unknown[]] })['Fn::Join'];
           const parts = join[1];
-          return parts
-            .map((p) => (typeof p === 'string' ? p : JSON.stringify(p)))
-            .join('');
+          return parts.map((p) => (typeof p === 'string' ? p : JSON.stringify(p))).join('');
         }
         return JSON.stringify(csp);
       };
@@ -1235,8 +1258,9 @@ describe('LFMT Infrastructure Stack', () => {
       expect(cspCarryingPolicies.length).toBeGreaterThanOrEqual(2);
 
       cspCarryingPolicies.forEach((policy: any) => {
-        const csp = policy.Properties.ResponseHeadersPolicyConfig.SecurityHeadersConfig
-          .ContentSecurityPolicy.ContentSecurityPolicy;
+        const csp =
+          policy.Properties.ResponseHeadersPolicyConfig.SecurityHeadersConfig.ContentSecurityPolicy
+            .ContentSecurityPolicy;
         const flat = flattenCsp(csp);
         expect(flat).not.toContain("'unsafe-eval'");
       });

--- a/backend/infrastructure/lib/__tests__/infrastructure.test.ts
+++ b/backend/infrastructure/lib/__tests__/infrastructure.test.ts
@@ -840,8 +840,9 @@ describe('LFMT Infrastructure Stack', () => {
       const choiceState = states[afterMap.Next];
       expect(choiceState.Type).toBe('Choice');
 
-      // 4. The Choice state must have a rule that routes to UpdateJobFailed
-      //    when anyChunkFailed=true, and otherwise (Default) to UpdateJobCompleted.
+      // 4. The Choice state must have a rule that routes to NormalizeFailureContext
+      //    (Bug B fix: NormalizeFailureContext then → UpdateJobFailed) when
+      //    anyChunkFailed=true, and otherwise (Default) to UpdateJobCompleted.
       expect(Array.isArray(choiceState.Choices)).toBe(true);
       expect(choiceState.Choices.length).toBeGreaterThanOrEqual(1);
       const failureBranch = choiceState.Choices.find(
@@ -850,10 +851,88 @@ describe('LFMT Infrastructure Stack', () => {
           rule.BooleanEquals === true
       );
       expect(failureBranch).toBeDefined();
-      expect(failureBranch.Next).toMatch(/UpdateJobFailed/);
+      // Bug B fix: Choice now routes through NormalizeFailureContext before UpdateJobFailed.
+      expect(failureBranch.Next).toMatch(/NormalizeFailureContext/);
 
       expect(choiceState.Default).toBeDefined();
       expect(choiceState.Default).toMatch(/UpdateJobCompleted/);
+    });
+
+    test('Choice failure branch routes through NormalizeFailureContext before UpdateJobFailed — Bug B regression', () => {
+      // Regression guard for the Bug B fix (post-PR-#176):
+      //
+      // UpdateJobFailed uses States.JsonToString($.error) to write the error
+      // detail to DDB. $.error is set by the Map Catch handler (resultPath='$.error'),
+      // but when chunks return success:false and the Choice gate fires,
+      // $.error does NOT exist — only $.translationResults does.
+      // This caused a States.Runtime JsonPath-not-found error that prevented
+      // the DDB write, leaving translationStatus stuck on IN_PROGRESS.
+      //
+      // Fix: insert NormalizeFailureContext (a Pass state) between the Choice
+      // gate and UpdateJobFailed on the success:false path. It synthesises
+      // $.error from $.translationResults, so UpdateJobFailed always has it.
+      // The Map Catch path bypasses NormalizeFailureContext (goes directly to
+      // UpdateJobFailed) because the Catch already sets $.error via resultPath.
+      const stateMachines = template.findResources('AWS::StepFunctions::StateMachine');
+      const stateMachine = stateMachines[Object.keys(stateMachines)[0]];
+      const definition = JSON.parse(
+        stateMachine.Properties.DefinitionString['Fn::Join'][1].join('')
+      );
+      const states = definition.States;
+
+      // 1. The Choice state's failure branch must point to NormalizeFailureContext,
+      //    NOT directly to UpdateJobFailed.
+      const choiceEntry = Object.entries(states).find(
+        ([, s]: [string, any]) => s.Type === 'Choice'
+      );
+      expect(choiceEntry).toBeDefined();
+      const [, choiceState] = choiceEntry as [string, any];
+
+      const failureBranch = choiceState.Choices.find(
+        (rule: any) =>
+          rule.Variable === '$.aggregate.anyChunkFailed' && rule.BooleanEquals === true
+      );
+      expect(failureBranch).toBeDefined();
+      // Must route to the normalizer, not directly to the DDB task.
+      expect(failureBranch.Next).toMatch(/NormalizeFailureContext/);
+
+      // 2. NormalizeFailureContext must be a Pass state that sets $.error
+      //    from $.translationResults (which is present in the success:false path).
+      const normEntry = Object.entries(states).find(([name]) =>
+        /NormalizeFailureContext/.test(name)
+      );
+      expect(normEntry).toBeDefined();
+      const [, normState] = normEntry as [string, any];
+
+      expect(normState.Type).toBe('Pass');
+      // Must write into $.error via ResultPath so UpdateJobFailed can read it.
+      expect(normState.ResultPath).toBe('$.error');
+      // Parameters must derive the error value from $.translationResults.
+      const errorParam: string = normState.Parameters?.['error.$'] ?? '';
+      expect(errorParam).toContain('translationResults');
+
+      // 3. NormalizeFailureContext must transition to UpdateJobFailed.
+      expect(normState.Next).toMatch(/UpdateJobFailed/);
+
+      // 4. The Map Catch handler must STILL route directly to UpdateJobFailed
+      //    (bypassing NormalizeFailureContext) so we don't clobber the real
+      //    $.error payload from the Catch.
+      const mapEntry = Object.entries(states).find(
+        ([, s]: [string, any]) => s.Type === 'Map'
+      );
+      expect(mapEntry).toBeDefined();
+      const [, mapState] = mapEntry as [string, any];
+
+      const catchHandlers: any[] = mapState.Catch ?? [];
+      expect(catchHandlers.length).toBeGreaterThanOrEqual(1);
+      const catchAll = catchHandlers.find((c: any) =>
+        Array.isArray(c.ErrorEquals) && c.ErrorEquals.includes('States.ALL')
+      );
+      expect(catchAll).toBeDefined();
+      // Catch goes DIRECTLY to UpdateJobFailed (no normalizer needed —
+      // resultPath='$.error' on the Catch already provides $.error).
+      expect(catchAll.Next).toMatch(/UpdateJobFailed/);
+      expect(catchAll.Next).not.toMatch(/NormalizeFailureContext/);
     });
 
     test('State machine has required IAM permissions', () => {

--- a/backend/infrastructure/lib/lfmt-infrastructure-stack.ts
+++ b/backend/infrastructure/lib/lfmt-infrastructure-stack.ts
@@ -1236,9 +1236,17 @@ export class LfmtInfrastructureStack extends Stack {
     // are exhausted, OR when at least one chunk reports success=false (see
     // OMC-followup C1 + the AggregateChunkResults / CheckAllChunksSucceeded
     // states below), persist TRANSLATION_FAILED to DDB so the UI / polling
-    // endpoints stop reporting a phantom-success. The error payload from the
-    // Map's catch is stored under $.error and serialized into the DDB row for
-    // post-mortem visibility.
+    // endpoints stop reporting a phantom-success.
+    //
+    // Bug B fix (post-PR-#176): UpdateJobFailed previously read $.error via
+    // States.JsonToString($.error). That field only exists when the Map Catch
+    // fires (resultPath='$.error'). When chunks return success:false and the
+    // Choice gate routes here, $.error is absent — causing a States.Runtime
+    // JsonPath-not-found error that prevents the DDB write entirely and leaves
+    // translationStatus stuck on IN_PROGRESS in DDB. Fix: insert a
+    // NormalizeFailureContext Pass state on the Choice path that synthesises
+    // $.error from $.translationResults so UpdateJobFailed always has it.
+    // The Map Catch path bypasses NormalizeFailureContext and already has $.error.
     //
     // OMC-followup C2 — dual-write `#status` (outer) in addition to
     // `translationStatus`. PR #176 added the dual-write to UpdateJobCompleted
@@ -1268,10 +1276,30 @@ export class LfmtInfrastructureStack extends Stack {
         // failure (frontend TranslationDetail.tsx branches on `job.status`).
         ':outerStatus': tasks.DynamoAttributeValue.fromString('TRANSLATION_FAILED'),
         ':failedAt': tasks.DynamoAttributeValue.fromString(stepfunctions.JsonPath.stringAt('$$.State.EnteredTime')),
+        // $.error is guaranteed to exist here — both entry paths set it:
+        // 1. Map Catch path: resultPath='$.error' on processChunksMap.addCatch().
+        // 2. Choice path (success:false): NormalizeFailureContext Pass state below
+        //    synthesises $.error from $.translationResults before entering this task.
         ':error': tasks.DynamoAttributeValue.fromString(stepfunctions.JsonPath.stringAt("States.JsonToString($.error)")),
         ':updatedAt': tasks.DynamoAttributeValue.fromString(stepfunctions.JsonPath.stringAt('$$.State.EnteredTime')),
       },
       resultPath: stepfunctions.JsonPath.DISCARD,
+    });
+
+    // NormalizeFailureContext: inserted between the Choice gate and UpdateJobFailed
+    // on the success:false path. Synthesises $.error from $.translationResults
+    // so UpdateJobFailed's States.JsonToString($.error) always resolves.
+    // The Map Catch path goes DIRECTLY to updateJobFailed (bypassing this state)
+    // because the Catch already sets $.error via resultPath.
+    const normalizeFailureContext = new stepfunctions.Pass(this, 'NormalizeFailureContext', {
+      comment:
+        'Bug B fix: when Choice gate routes here (success:false path), $.error is absent. ' +
+        'Synthesise it from $.translationResults so UpdateJobFailed can always read $.error. ' +
+        'Map Catch path bypasses this state because resultPath="$.error" already sets $.error.',
+      parameters: {
+        'error.$': 'States.JsonToString($.translationResults)',
+      },
+      resultPath: '$.error',
     });
 
     // Terminal failure state — must come after the DDB write so the execution
@@ -1355,17 +1383,22 @@ export class LfmtInfrastructureStack extends Stack {
     // the result of the intrinsic above. true → failure path; otherwise
     // (default) → success path. This guarantees UpdateJobCompleted ONLY
     // runs when every chunk actually succeeded.
+    //
+    // Bug B fix: route anyChunkFailed=true through NormalizeFailureContext
+    // BEFORE UpdateJobFailed so $.error is always populated (see comment above).
+    normalizeFailureContext.next(updateJobFailed);
     checkAllChunksSucceeded
       .when(
         stepfunctions.Condition.booleanEquals('$.aggregate.anyChunkFailed', true),
-        updateJobFailed
+        normalizeFailureContext
       )
       .otherwise(updateJobCompleted.next(successState));
 
     // Define the state machine workflow.
     // Map → AggregateChunkResults → CheckAllChunksSucceeded
-    //   ├── (anyChunkFailed=true)  → UpdateJobFailed → TranslationFailed
+    //   ├── (anyChunkFailed=true)  → NormalizeFailureContext → UpdateJobFailed → TranslationFailed
     //   └── (default)              → UpdateJobCompleted → TranslationSuccess
+    // Map Catch (States.ALL) → UpdateJobFailed (directly; $.error set by Catch resultPath)
     const definition = processChunksMap
       .next(aggregateChunkResults)
       .next(checkAllChunksSucceeded);

--- a/backend/infrastructure/lib/lfmt-infrastructure-stack.ts
+++ b/backend/infrastructure/lib/lfmt-infrastructure-stack.ts
@@ -1291,13 +1291,58 @@ export class LfmtInfrastructureStack extends Stack {
     // so UpdateJobFailed's States.JsonToString($.error) always resolves.
     // The Map Catch path goes DIRECTLY to updateJobFailed (bypassing this state)
     // because the Catch already sets $.error via resultPath.
+    //
+    // OMC-followup R2 — structured payload (was: raw translationResults dump).
+    //
+    // Previously this state set `error.$` = States.JsonToString($.translationResults),
+    // which produced a stringified array of every chunk's full result as the
+    // DDB `translationError` column value. That is semantically wrong: the
+    // column is supposed to hold a *description of the failure*, not the
+    // success/failure data of every chunk. It also bloats DDB rows
+    // unnecessarily (each result includes tokensUsed, estimatedCost,
+    // processingTimeMs, etc. — KB per chunk × N chunks).
+    //
+    // Step Functions ASL has NO native filter intrinsic
+    // (States.ArrayFilter does not exist; only ArrayContains/ArrayLength/
+    // ArrayPartition/ArrayUnique/ArrayGetItem/ArrayRange/Array are available).
+    // To filter to "only failed chunks" we would need a Map substate, which
+    // is too heavy for a normalizer that only runs once on the failure path.
+    //
+    // Pragmatic fix: produce a structured envelope with a `reason` discriminator,
+    // a count, and the full `translationResults` (preserving forensic detail).
+    // The DDB column type is now `{reason: string, failedCountUpperBound: number,
+    // totalChunks: number, translationResults: Array<...>}` — readable,
+    // queryable by reason, and explicit about the failure mode.
+    //
+    // Why keep `translationResults` rather than slim it down: ASL filtering
+    // would require a substate (rejected as too heavy per the OMC review).
+    // The forensic value of the per-chunk results outweighs the DDB row size
+    // for the failure path (failures are rare; this is dead-letter queue
+    // territory). Future work: if/when ASL adds States.ArrayFilter, replace
+    // `translationResults.$` with a filtered subset (only failed chunks).
     const normalizeFailureContext = new stepfunctions.Pass(this, 'NormalizeFailureContext', {
       comment:
-        'Bug B fix: when Choice gate routes here (success:false path), $.error is absent. ' +
-        'Synthesise it from $.translationResults so UpdateJobFailed can always read $.error. ' +
-        'Map Catch path bypasses this state because resultPath="$.error" already sets $.error.',
+        'Bug B fix (R2 structured payload): when Choice gate routes here (success:false path), ' +
+        '$.error is absent. Synthesise a structured failure envelope so UpdateJobFailed can always ' +
+        'read $.error AND so the DDB translationError column holds a typed payload (reason + counts + ' +
+        'forensic detail) rather than a raw dump of translationResults. Map Catch path bypasses ' +
+        'this state because resultPath="$.error" already sets $.error.',
       parameters: {
-        'error.$': 'States.JsonToString($.translationResults)',
+        // R2: structured envelope.
+        // - `reason`: stable discriminator (CHUNK_FAILURE) for downstream
+        //   alerting / dashboards.
+        // - `failedCountUpperBound` / `totalChunks`: counts derived via
+        //   States.ArrayLength (the only quantitative ASL intrinsic we have
+        //   without filter support). The exact failed count cannot be
+        //   computed without filter support; we surface the upper bound and
+        //   annotate intent in the field name so future readers don't
+        //   misinterpret it as the exact failure count.
+        // - `translationResults.$`: raw forensic detail, preserved verbatim
+        //   so we don't lose information for triage.
+        'reason': 'CHUNK_FAILURE',
+        'failedCountUpperBound.$': 'States.ArrayLength($.translationResults)',
+        'totalChunks.$': 'States.ArrayLength($.translationResults)',
+        'translationResults.$': '$.translationResults',
       },
       resultPath: '$.error',
     });

--- a/docs/cdk-best-practices.md
+++ b/docs/cdk-best-practices.md
@@ -324,6 +324,93 @@ Before every CDK deployment:
 
 ---
 
+## Multi-Input-Path Contract Tests (OMC-followup R1)
+
+### The Rule
+
+> **Every Step Functions task or Lambda that can be reached from MORE than one
+> upstream state MUST have a contract test for EACH upstream entry path.**
+
+A "contract test" verifies the _payload shape_ the downstream task reads from
+the state machine context — not just that the task is wired into the graph.
+
+### Why It Matters: PR #176 Bug B
+
+PR #176 went through TWO rounds of OMC review and was approved. In production,
+it still failed: when chunks returned `success: false` (instead of throwing),
+the state machine routed through the Choice gate to `UpdateJobFailed`, which
+crashed with a `States.Runtime` JsonPath-not-found error trying to read
+`$.error`. The DDB write never happened, leaving `translationStatus` stuck on
+`IN_PROGRESS` forever.
+
+Root cause:
+
+- `UpdateJobFailed` has **two upstream entry paths**:
+  1. The Map state's Catch handler (sets `$.error` via `resultPath: '$.error'`)
+  2. The Choice gate's failure branch (does NOT set `$.error`)
+- Existing tests asserted **topology** only:
+  - "Pass + Choice + UpdateJobFailed all exist" ✅
+  - "Choice routes to UpdateJobFailed" ✅
+- They did NOT assert that `$.error` was populated **on both paths**.
+
+The two reviewers (and the author) both reasoned about the graph and missed
+that the Choice path lacked the field the downstream task required.
+
+### The Reviewer Checklist
+
+When reviewing a PR that adds or modifies a Step Functions task / Lambda:
+
+1. **List every upstream state that can reach this task.** Walk the state
+   machine definition; don't just look at the most-recently-added entry.
+2. **Document the input payload contract.** What fields does this task read?
+   What types? Required vs. optional?
+3. **For each upstream entry path, verify the contract holds.** Either:
+   - The upstream state explicitly produces the required fields (assert in a
+     test), or
+   - There's a normalizer state in between that synthesizes them (assert the
+     normalizer's output shape AND that the upstream routes through it).
+4. **Add a contract test per path.** Tests must inspect the SYNTHESIZED ASL
+   JSON, not the CDK construct surface, so they survive ASL serialization
+   changes that don't affect the contract.
+
+### Example Anti-Pattern
+
+```typescript
+// ❌ Topology-only assertion (PR #176's gap)
+expect(failureBranch.Next).toMatch(/UpdateJobFailed/);
+```
+
+### Example Fix
+
+```typescript
+// ✅ Contract assertion: the failure branch MUST go through a normalizer
+//    that synthesizes $.error before reaching UpdateJobFailed.
+expect(failureBranch.Next).toMatch(/NormalizeFailureContext/);
+
+const normState = states['NormalizeFailureContext'];
+expect(normState.ResultPath).toBe('$.error');
+expect(normState.Parameters['reason']).toBe('CHUNK_FAILURE');
+expect(normState.Next).toMatch(/UpdateJobFailed/);
+
+// AND the OTHER entry path (Map Catch) sets $.error directly:
+expect(catchAll.Next).toMatch(/UpdateJobFailed/);
+expect(catchAll.ResultPath).toBe('$.error');
+```
+
+See `backend/infrastructure/lib/__tests__/infrastructure.test.ts` —
+"Choice failure branch routes through NormalizeFailureContext before
+UpdateJobFailed — Bug B regression" for the canonical example in this
+codebase.
+
+### When This Rule Applies
+
+- Step Functions tasks that have multiple `.next()` predecessors
+- Step Functions tasks reached via both a Choice rule AND a Catch handler
+- Lambdas invoked from multiple Step Functions tasks
+- Lambdas invoked from both Step Functions AND API Gateway
+
+---
+
 ## Additional Resources
 
 - [AWS CDK Best Practices](https://docs.aws.amazon.com/cdk/v2/guide/best-practices.html)


### PR DESCRIPTION
## Investigation

Capture script ran 2026-05-02 ~19:52 UTC against the post-PR-#176 Lambda. Both Sherlock (4 chunks) and Pride (1 chunk) Step Functions executions ended FAILED but DDB `translationStatus` stayed `IN_PROGRESS`. Two independent bugs found.

## Bug A — `geminiClient.ts:156` crashes with `TypeError: Cannot read properties of undefined (reading 'length')`

**Root cause:** The `@google/genai` SDK types `.text` as `string | undefined` (confirmed at `genai.d.ts` line 4535 in the installed package). Sherlock chunk 0 ran for 54 seconds, then Gemini returned a response with no text candidate (safety-filter or empty-candidate). `geminiClient.ts:156` assigned `result.text` (→ `undefined`) to `translatedText`, then `storeTranslatedChunk` passed it as the S3 `PutObjectCommand` `Body`. The SigV4 signer called `.trim()` on it, crashing with the `'length'` TypeError. The CW log confirms the sequence: `"Translation completed"` → `"Are you using a Stream of unknown length"` → `ERROR: Cannot read properties of undefined (reading 'length')`.

**Fix (`backend/functions/translation/geminiClient.ts:156`):** Guard `result.text`. If `undefined`/`null`, throw `GeminiApiError('EMPTY_RESPONSE', ..., retryable: false)` so the outer `catch` in `translateChunk.ts` returns `{ success: false, retryable: false }` cleanly instead of crashing.

## Bug B — `UpdateJobFailed` DDB write never executes; `translationStatus` stuck on `IN_PROGRESS`

**Root cause:** PR #176 added `UpdateJobFailed` DDB task that reads `States.JsonToString($.error)`. That `$.error` key is injected by the Map Catch handler (`resultPath: '$.error'`). When chunks return `success:false` and the `CheckAllChunksSucceeded` Choice gate routes to `UpdateJobFailed`, `$.error` does **not** exist — the input only has `$.translationResults` and `$.aggregate`. SF throws `States.Runtime` / JsonPath-not-found, aborting the DDB write before it executes. DDB is never updated; both jobs stayed `IN_PROGRESS` forever. Confirmed via the SF execution's `ExecutionFailed` event: `"The JsonPath argument for the field '$.error' could not be found in the input '{"jobId":...,"aggregate":{"anyChunkFailed":true}}'"`

**Fix (`backend/infrastructure/lib/lfmt-infrastructure-stack.ts`):** Insert `NormalizeFailureContext` Pass state between the Choice gate and `UpdateJobFailed` **on the success:false path only**. It synthesises `$.error` from `$.translationResults` (always present on that path) via `States.JsonToString($.translationResults)` so `UpdateJobFailed`'s `$.error` reference always resolves. The Map Catch path goes **directly** to `UpdateJobFailed` (bypasses `NormalizeFailureContext`) because the Catch already sets `$.error` via `resultPath`.

New state machine topology:
```
Map → AggregateChunkResults → CheckAllChunksSucceeded
  ├── anyChunkFailed=true → NormalizeFailureContext → UpdateJobFailed → TranslationFailed  ← NEW
  └── default             → UpdateJobCompleted → TranslationSuccess
Map Catch (States.ALL) → UpdateJobFailed (directly; $.error set by Catch resultPath)
```

## Regression tests added

- `translateChunk.test.ts`: "returns success:false when Gemini response has undefined text — Bug A regression" — mocks `result.text = undefined`, asserts `success:false`, `retryable:false`, error contains `'empty response'`, and S3 `PutObject` is never called.
- `infrastructure.test.ts`: "Choice failure branch routes through NormalizeFailureContext before UpdateJobFailed — Bug B regression" — parses synthesised ASL, asserts Choice failure branch → `NormalizeFailureContext`, normalizer sets `$.error` from `$.translationResults`, Map Catch goes **directly** to `UpdateJobFailed` (not through normalizer).
- Updated existing `OMC-followup C1` test: Choice failure branch assertion updated from `UpdateJobFailed` to `NormalizeFailureContext` to match new topology.

## Verification

- `backend/functions npm test`: 443 passed, 3 skipped, 0 errors
- `backend/infrastructure npm test`: 46 passed, 0 errors
- `backend/functions npm run lint`: 0 errors (256 pre-existing warnings, unchanged)
- `backend/functions npm run format:check`: all files match Prettier style
- `backend/infrastructure npm run build`: clean TypeScript compile
- `cdk synth --context environment=dev --context skipLambdaBundling=true`: clean

## Verification plan (post-merge)

1. Merge triggers CI — `Run Tests` + `Build Infrastructure` must be green.
2. Next deploy push redeploys Lambda + updates SF state machine ASL.
3. Re-run capture script. Expected: both Sherlock + Pride jobs complete fully with `translationStatus=COMPLETED` in DDB. If a chunk hits the Gemini rate limit, it should return `{ success: false }` → Choice routes through `NormalizeFailureContext` → `UpdateJobFailed` writes `TRANSLATION_FAILED` to DDB within seconds (not stuck on `IN_PROGRESS`).