### PR TITLE
fix(smoke): resolve 5 post-PR-#181 deploy failures (presigned-URL jobId + wizard navigation)

### DIFF
--- a/backend/functions/jobs/__tests__/uploadRequest.test.ts
+++ b/backend/functions/jobs/__tests__/uploadRequest.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Unit tests for uploadRequest Lambda function
+ *
+ * These tests verify the response shape and validation paths of the
+ * presigned-URL handler. The CORS slice is covered separately in
+ * `uploadRequest.cors.test.ts`; this file focuses on:
+ *
+ *   1. Successful response carries `jobId` in `body.data.jobId`
+ *      (the contract surface PR #184 fixed — previously the handler
+ *      built a `jobId` and silently discarded it before responding).
+ *   2. Validation errors return 400 when required fields are missing.
+ *   3. Auth context missing returns 401.
+ *
+ * The fixture is intentionally minimal: every test path must exercise the
+ * full handler so type/contract regressions are caught at the handler
+ * boundary, not buried inside helpers.
+ */
+
+// Required environment must be set BEFORE importing the handler — the
+// module reads them at load time via getRequiredEnv().
+process.env.DOCUMENT_BUCKET = 'test-bucket';
+process.env.JOBS_TABLE = 'test-jobs-table';
+process.env.ATTESTATIONS_TABLE_NAME = 'test-attestations-table';
+process.env.ALLOWED_ORIGINS = 'http://localhost:3000,https://d39xcun7144jgl.cloudfront.net';
+
+// Mock AWS SDK clients BEFORE importing the handler so the module-scoped
+// `S3Client` / `DynamoDBClient` instances pick up our test doubles.
+const mockS3Send = jest.fn();
+const mockDynamoSend = jest.fn();
+const mockGetSignedUrl = jest.fn();
+
+jest.mock('@aws-sdk/client-s3', () => ({
+  S3Client: jest.fn(() => ({ send: mockS3Send })),
+  PutObjectCommand: jest.fn(),
+}));
+
+jest.mock('@aws-sdk/client-dynamodb', () => ({
+  DynamoDBClient: jest.fn(() => ({ send: mockDynamoSend })),
+  PutItemCommand: jest.fn(),
+}));
+
+jest.mock('@aws-sdk/s3-request-presigner', () => ({
+  getSignedUrl: mockGetSignedUrl,
+}));
+
+import { handler } from '../uploadRequest';
+import { APIGatewayProxyEvent } from 'aws-lambda';
+
+/**
+ * Build a baseline mock event. Override any field via `overrides` —
+ * shallow merge is intentional so per-test assertions stay readable.
+ */
+const buildEvent = (overrides: Partial<APIGatewayProxyEvent> = {}): APIGatewayProxyEvent =>
+  ({
+    headers: {
+      origin: 'https://d39xcun7144jgl.cloudfront.net',
+      Authorization: 'Bearer mock-token',
+      'Content-Type': 'application/json',
+    },
+    requestContext: {
+      requestId: 'test-request-id',
+      authorizer: {
+        claims: {
+          sub: 'test-user-123',
+        },
+      },
+      identity: {
+        sourceIp: '127.0.0.1',
+        userAgent: 'jest-test-agent',
+      },
+    } as unknown as APIGatewayProxyEvent['requestContext'],
+    body: JSON.stringify({
+      fileName: 'test.txt',
+      fileSize: 1024,
+      contentType: 'text/plain',
+      legalAttestation: {
+        acceptCopyrightOwnership: true,
+        acceptTranslationRights: true,
+        acceptLiabilityTerms: true,
+        userIPAddress: '192.168.1.1',
+        userAgent: 'Mozilla/5.0',
+        timestamp: new Date().toISOString(),
+      },
+    }),
+    ...overrides,
+  }) as APIGatewayProxyEvent;
+
+describe('uploadRequest Lambda Function', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetSignedUrl.mockResolvedValue('https://test-bucket.s3.amazonaws.com/test-presigned-url');
+    mockDynamoSend.mockResolvedValue({});
+  });
+
+  describe('Successful response shape (PR #184 contract)', () => {
+    it('should include jobId in response body data envelope', async () => {
+      const response = await handler(buildEvent());
+
+      expect(response.statusCode).toBe(200);
+      const parsed = JSON.parse(response.body);
+
+      // The full envelope: { message, data: PresignedUrlResponse, requestId }.
+      // PR #184's fix put `jobId` on `data` — assert it survives the round-trip.
+      expect(parsed).toHaveProperty('data');
+      expect(parsed.data).toHaveProperty('jobId');
+      expect(typeof parsed.data.jobId).toBe('string');
+      expect(parsed.data.jobId.length).toBeGreaterThan(0);
+
+      // Companion fields the type contract (PresignedUrlResponse) requires.
+      expect(parsed.data).toHaveProperty('uploadUrl');
+      expect(parsed.data).toHaveProperty('fileId');
+      expect(parsed.data).toHaveProperty('expiresIn', 900);
+      expect(parsed.data).toHaveProperty('requiredHeaders');
+      expect(parsed.data.requiredHeaders).toMatchObject({
+        'Content-Type': 'text/plain',
+        'Content-Length': '1024',
+      });
+    });
+
+    it('should generate distinct jobId and fileId values', async () => {
+      // jobId addresses the *job record* (status polling, deletion).
+      // fileId addresses the *uploaded blob* (S3 key segment). They are
+      // separate UUIDs by design — collapsing them would break job-deletion
+      // semantics. Catch any future refactor that aliases them.
+      const response = await handler(buildEvent());
+      const parsed = JSON.parse(response.body);
+
+      expect(parsed.data.jobId).not.toBe(parsed.data.fileId);
+    });
+  });
+
+  describe('Validation error paths', () => {
+    it('should return 400 when fileName is missing', async () => {
+      const response = await handler(
+        buildEvent({
+          body: JSON.stringify({
+            // fileName intentionally omitted
+            fileSize: 1024,
+            contentType: 'text/plain',
+            legalAttestation: {
+              acceptCopyrightOwnership: true,
+              acceptTranslationRights: true,
+              acceptLiabilityTerms: true,
+            },
+          }),
+        })
+      );
+
+      expect(response.statusCode).toBe(400);
+      const parsed = JSON.parse(response.body);
+      expect(parsed.message).toMatch(/file validation failed/i);
+    });
+
+    it('should return 400 when legal attestation is missing', async () => {
+      // Defense-in-depth: silently dropping consent is the OWASP A09 bug
+      // closed in OpenSpec task 3.8.0. A request with no attestation MUST
+      // be rejected at the handler boundary before any S3 / DynamoDB call.
+      const response = await handler(
+        buildEvent({
+          body: JSON.stringify({
+            fileName: 'test.txt',
+            fileSize: 1024,
+            contentType: 'text/plain',
+            // legalAttestation intentionally omitted
+          }),
+        })
+      );
+
+      expect(response.statusCode).toBe(400);
+      const parsed = JSON.parse(response.body);
+      expect(parsed.message).toMatch(/legal attestation is required/i);
+      // No S3 presign / DynamoDB write should occur on validation failure.
+      expect(mockGetSignedUrl).not.toHaveBeenCalled();
+      expect(mockDynamoSend).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Auth context', () => {
+    it('should return 401 when Cognito sub claim is absent', async () => {
+      const response = await handler(
+        buildEvent({
+          requestContext: {
+            requestId: 'test-request-id',
+            authorizer: { claims: {} },
+            identity: { sourceIp: '127.0.0.1', userAgent: 'jest-test-agent' },
+          } as unknown as APIGatewayProxyEvent['requestContext'],
+        })
+      );
+
+      expect(response.statusCode).toBe(401);
+      const parsed = JSON.parse(response.body);
+      expect(parsed.message).toMatch(/unauthorized/i);
+    });
+  });
+});

--- a/backend/functions/jobs/uploadRequest.ts
+++ b/backend/functions/jobs/uploadRequest.ts
@@ -219,6 +219,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     const response: PresignedUrlResponse = {
       uploadUrl,
       fileId,
+      jobId,
       expiresIn: PRESIGNED_URL_EXPIRATION,
       requiredHeaders: {
         'Content-Type': contentType,

--- a/backend/tests/smoke/smoke.test.ts
+++ b/backend/tests/smoke/smoke.test.ts
@@ -409,18 +409,21 @@ describe('Production Smoke Tests', () => {
       );
 
       // Should succeed
+      // The backend wraps the presigned-URL payload in a `data` envelope:
+      // { message, data: { uploadUrl, fileId, jobId, ... }, requestId }
       expect(response.status).toBe(200);
-      expect(response.data).toHaveProperty('jobId');
-      expect(response.data).toHaveProperty('uploadUrl');
-      expect(response.data).toHaveProperty('uploadFields');
+      expect(response.data).toHaveProperty('data');
+      expect(response.data.data).toHaveProperty('jobId');
+      expect(response.data.data).toHaveProperty('uploadUrl');
+      expect(response.data.data).toHaveProperty('fileId');
 
       // Validate response structure
-      expect(typeof response.data.jobId).toBe('string');
-      expect(typeof response.data.uploadUrl).toBe('string');
-      expect(typeof response.data.uploadFields).toBe('object');
+      expect(typeof response.data.data.jobId).toBe('string');
+      expect(typeof response.data.data.uploadUrl).toBe('string');
+      expect(typeof response.data.data.fileId).toBe('string');
 
       console.log('✓ Upload presigned URL request successful');
-      console.log(`  Job ID: ${response.data.jobId}`);
+      console.log(`  Job ID: ${response.data.data.jobId}`);
     });
 
     it('should reject upload request without authentication', async () => {
@@ -512,7 +515,8 @@ describe('Production Smoke Tests', () => {
         authToken
       );
 
-      jobId = uploadResponse.data.jobId;
+      // Backend wraps the presigned-URL payload: { message, data: { jobId, ... } }
+      jobId = uploadResponse.data.data.jobId;
     });
 
     it('should poll job status', async () => {
@@ -646,7 +650,8 @@ describe('Production Smoke Tests', () => {
         authToken
       );
 
-      jobId = uploadResponse.data.jobId;
+      // Backend wraps the presigned-URL payload: { message, data: { jobId, ... } }
+      jobId = uploadResponse.data.data.jobId;
     });
 
     it('should delete a job', async () => {
@@ -688,7 +693,8 @@ describe('Production Smoke Tests', () => {
         authToken
       );
 
-      const testJobId = uploadResponse.data.jobId;
+      // Backend wraps the presigned-URL payload: { message, data: { jobId, ... } }
+      const testJobId = uploadResponse.data.data.jobId;
 
       const response = await makeRequest(`/jobs/${testJobId}`, 'DELETE');
 

--- a/frontend/e2e/pages/TranslationUploadPage.ts
+++ b/frontend/e2e/pages/TranslationUploadPage.ts
@@ -2,9 +2,19 @@
  * Translation Upload Page Object Model
  *
  * Represents the multi-step translation upload page.
+ *
+ * The page is a 4-step wizard:
+ *   Step 0: Legal Attestation  → Step 1: Translation Settings
+ *   Step 2: Upload Document    → Step 3: Review & Submit
+ *
+ * Both `completeUploadWorkflow()` (single-call convenience) and the
+ * `*ByRole()` granular helpers below drive the same DOM. The granular
+ * helpers exist because the production smoke test wraps each wizard
+ * step in a `test.step()` block for diagnostic tracing — see
+ * `frontend/e2e/tests/smoke/production-smoke.spec.ts`.
  */
 
-import { Page } from '@playwright/test';
+import { Page, expect } from '@playwright/test';
 import { BasePage } from './BasePage';
 
 export class TranslationUploadPage extends BasePage {
@@ -130,5 +140,90 @@ export class TranslationUploadPage extends BasePage {
    */
   async waitForNavigationToDetail() {
     await this.page.waitForURL(/\/translation\/[a-f0-9-]+/, { timeout: 10000 });
+  }
+
+  // ---------------------------------------------------------------------
+  // Role-based wizard helpers (used by production-smoke.spec.ts)
+  //
+  // These mirror the steps performed by `completeUploadWorkflow()` but use
+  // role-based locators (more resilient against CSS-class churn in deployed
+  // environments) and accept timeouts so callers can tune for prod latency.
+  // The smoke test calls each helper inside its own `test.step()` block to
+  // get per-step traces in CI.
+  // ---------------------------------------------------------------------
+
+  /**
+   * Tick the three required attestation checkboxes and advance to the
+   * Translation Settings step. Returns when the target-language control
+   * is visible (handshake that step 1 has rendered).
+   */
+  async completeLegalAttestationByRole(timeout = 10000) {
+    await this.page.getByRole('checkbox', { name: /copyright ownership/i }).check();
+    await this.page.getByRole('checkbox', { name: /translation rights/i }).check();
+    await this.page.getByRole('checkbox', { name: /liability/i }).check();
+
+    await this.page.getByRole('button', { name: /next/i }).click();
+    await expect(this.page.getByLabel(/target.*language/i)).toBeVisible({ timeout });
+  }
+
+  /**
+   * Configure source (defaults to English when present) + target language,
+   * then advance to the Upload Document step. Returns when the file input
+   * is attached to the DOM (the input has display:none — `toBeAttached` is
+   * the correct gate, not `toBeVisible`).
+   */
+  async configureLanguagesByRole(
+    targetLanguagePattern: RegExp = /spanish|español/i,
+    timeout = 10000
+  ) {
+    const sourceLanguage = this.page.getByLabel(/source.*language/i);
+    if (await sourceLanguage.isVisible()) {
+      await sourceLanguage.click();
+      await this.page.getByRole('option', { name: /english/i }).click();
+    }
+
+    const targetLanguage = this.page.getByLabel(/target.*language/i);
+    await targetLanguage.click();
+    await this.page.getByRole('option', { name: targetLanguagePattern }).click();
+
+    await this.page.getByRole('button', { name: /next/i }).click();
+    await expect(this.page.locator('input[type="file"]')).toBeAttached({ timeout });
+  }
+
+  /**
+   * Upload a file via the hidden `<input type="file">`. Asserts the file
+   * name surfaces in the UI (handshake that the wizard accepted the file).
+   */
+  async uploadFileAndAwaitDisplay(filePath: string, displayName: string, timeout = 10000) {
+    const fileInput = this.page.locator('input[type="file"]');
+    await fileInput.setInputFiles(filePath);
+
+    // Filename appears in the upload-step UI once the file is processed.
+    await expect(
+      this.page.getByText(new RegExp(displayName.replace(/\./g, '\\.'), 'i'))
+    ).toBeVisible({ timeout });
+  }
+
+  /**
+   * Advance from Upload Document to Review & Submit. The review screen
+   * re-renders the chosen filename in its summary — assert it shows up
+   * before continuing.
+   */
+  async advanceToReviewByRole(displayName: string, timeout = 10000) {
+    await this.page.getByRole('button', { name: /next/i }).click();
+    await expect(
+      this.page.getByText(new RegExp(displayName.replace(/\./g, '\\.'), 'i'))
+    ).toBeVisible({ timeout });
+  }
+
+  /**
+   * Click the final "Submit & Start Translation" button on the Review step.
+   * The regex tolerates copy variants observed in different environments.
+   */
+  async submitTranslationByRole() {
+    const translateButton = this.page.getByRole('button', {
+      name: /submit.*translation|translate|start.*translation/i,
+    });
+    await translateButton.click();
   }
 }

--- a/frontend/e2e/tests/smoke/production-smoke.spec.ts
+++ b/frontend/e2e/tests/smoke/production-smoke.spec.ts
@@ -19,6 +19,7 @@
 import * as path from 'path';
 import { fileURLToPath } from 'node:url';
 import { test, expect } from '@playwright/test';
+import { TranslationUploadPage } from '../../pages/TranslationUploadPage';
 
 // Smoke tests use a longer timeout because they run against production.
 // 3 minutes is sufficient when we use the ~1 KB smoke-test-minimal.txt
@@ -163,36 +164,21 @@ test.describe('Production Smoke Tests @smoke', () => {
     // The file input only exists in the DOM on step 2. Calling setInputFiles
     // before the wizard advances past step 1 causes a 3-minute timeout because
     // the locator never resolves (the element isn't mounted yet).
+    //
+    // Each step is delegated to TranslationUploadPage's role-based helpers
+    // (PR #184 review follow-up) so wizard navigation lives in exactly one
+    // place. The smoke test still owns its `test.step()` framing and its
+    // post-submit translation-completion polling.
+    const uploadPage = new TranslationUploadPage(page);
 
     // Step 3a: Complete legal attestation (wizard step 0)
     await test.step('Complete legal attestation step', async () => {
-      // Tick all three required checkboxes
-      await page.getByRole('checkbox', { name: /copyright ownership/i }).check();
-      await page.getByRole('checkbox', { name: /translation rights/i }).check();
-      await page.getByRole('checkbox', { name: /liability/i }).check();
-
-      // Advance to Translation Settings step
-      await page.getByRole('button', { name: /next/i }).click();
-      await expect(page.getByLabel(/target.*language/i)).toBeVisible({ timeout: 10000 });
+      await uploadPage.completeLegalAttestationByRole();
     });
 
     // Step 3b: Configure translation settings (wizard step 1)
     await test.step('User can configure translation settings', async () => {
-      // Select source language (if not already English)
-      const sourceLanguage = page.getByLabel(/source.*language/i);
-      if (await sourceLanguage.isVisible()) {
-        await sourceLanguage.click();
-        await page.getByRole('option', { name: /english/i }).click();
-      }
-
-      // Select target language (Spanish)
-      const targetLanguage = page.getByLabel(/target.*language/i);
-      await targetLanguage.click();
-      await page.getByRole('option', { name: /spanish|español/i }).click();
-
-      // Advance to Upload Document step
-      await page.getByRole('button', { name: /next/i }).click();
-      await expect(page.locator('input[type="file"]')).toBeAttached({ timeout: 10000 });
+      await uploadPage.configureLanguagesByRole();
     });
 
     // Step 3c: Upload document (wizard step 2)
@@ -201,36 +187,17 @@ test.describe('Production Smoke Tests @smoke', () => {
       // frontend/e2e/fixtures/smoke-test-minimal.txt). Using a committed
       // ~1 KB file avoids allocating large documents inside the test and
       // keeps translation time well under the 3-minute test timeout.
-      //
-      // The file input has display:none (it is triggered by a click on the
-      // drag-drop zone). setInputFiles works on hidden inputs natively in
-      // Playwright, but we still wait for the element to be attached first.
-      const fileInput = page.locator('input[type="file"]');
-      await fileInput.setInputFiles(SMOKE_FIXTURE_PATH);
-
-      // Wait for file to be processed — the filename appears in the UI
-      await expect(page.getByText(/smoke-test-minimal\.txt/i)).toBeVisible({
-        timeout: 10000,
-      });
+      await uploadPage.uploadFileAndAwaitDisplay(SMOKE_FIXTURE_PATH, 'smoke-test-minimal.txt');
     });
 
     // Step 4 (wizard step 3): Advance to review and submit
-    // After uploading the file the wizard is on step 2. Clicking Next moves to
-    // the Review & Submit step (step 3), which shows the "Submit & Start
-    // Translation" button (not a separate translate button).
     await test.step('Advance to review step', async () => {
-      await page.getByRole('button', { name: /next/i }).click();
-      // Review step renders the file name in the summary
-      await expect(page.getByText(/smoke-test-minimal\.txt/i)).toBeVisible({ timeout: 10000 });
+      await uploadPage.advanceToReviewByRole('smoke-test-minimal.txt');
     });
 
     // Step 5: Start translation
     await test.step('User can start translation', async () => {
-      // The final step button on the wizard is "Submit & Start Translation"
-      const translateButton = page.getByRole('button', {
-        name: /submit.*translation|translate|start.*translation/i,
-      });
-      await translateButton.click();
+      await uploadPage.submitTranslationByRole();
 
       // Wait for translation to start
       await expect(

--- a/frontend/e2e/tests/smoke/production-smoke.spec.ts
+++ b/frontend/e2e/tests/smoke/production-smoke.spec.ts
@@ -154,22 +154,29 @@ test.describe('Production Smoke Tests @smoke', () => {
       });
     });
 
-    // Step 3: Upload document
-    await test.step('User can upload a document', async () => {
-      // Upload the shared minimal smoke-test fixture (see
-      // frontend/e2e/fixtures/smoke-test-minimal.txt). Using a committed
-      // ~1 KB file avoids allocating large documents inside the test and
-      // keeps translation time well under the 3-minute test timeout.
-      const fileInput = page.locator('input[type="file"]');
-      await fileInput.setInputFiles(SMOKE_FIXTURE_PATH);
+    // Step 3: Complete the multi-step wizard to reach the file upload step.
+    //
+    // The upload page is a 4-step wizard:
+    //   Step 0: Legal Attestation  → Step 1: Translation Settings
+    //   Step 2: Upload Document    → Step 3: Review & Submit
+    //
+    // The file input only exists in the DOM on step 2. Calling setInputFiles
+    // before the wizard advances past step 1 causes a 3-minute timeout because
+    // the locator never resolves (the element isn't mounted yet).
 
-      // Wait for file to be processed
-      await expect(page.getByText(/smoke-test-minimal\.txt/i)).toBeVisible({
-        timeout: 10000,
-      });
+    // Step 3a: Complete legal attestation (wizard step 0)
+    await test.step('Complete legal attestation step', async () => {
+      // Tick all three required checkboxes
+      await page.getByRole('checkbox', { name: /copyright ownership/i }).check();
+      await page.getByRole('checkbox', { name: /translation rights/i }).check();
+      await page.getByRole('checkbox', { name: /liability/i }).check();
+
+      // Advance to Translation Settings step
+      await page.getByRole('button', { name: /next/i }).click();
+      await expect(page.getByLabel(/target.*language/i)).toBeVisible({ timeout: 10000 });
     });
 
-    // Step 4: Configure translation settings
+    // Step 3b: Configure translation settings (wizard step 1)
     await test.step('User can configure translation settings', async () => {
       // Select source language (if not already English)
       const sourceLanguage = page.getByLabel(/source.*language/i);
@@ -182,12 +189,47 @@ test.describe('Production Smoke Tests @smoke', () => {
       const targetLanguage = page.getByLabel(/target.*language/i);
       await targetLanguage.click();
       await page.getByRole('option', { name: /spanish|español/i }).click();
+
+      // Advance to Upload Document step
+      await page.getByRole('button', { name: /next/i }).click();
+      await expect(page.locator('input[type="file"]')).toBeAttached({ timeout: 10000 });
+    });
+
+    // Step 3c: Upload document (wizard step 2)
+    await test.step('User can upload a document', async () => {
+      // Upload the shared minimal smoke-test fixture (see
+      // frontend/e2e/fixtures/smoke-test-minimal.txt). Using a committed
+      // ~1 KB file avoids allocating large documents inside the test and
+      // keeps translation time well under the 3-minute test timeout.
+      //
+      // The file input has display:none (it is triggered by a click on the
+      // drag-drop zone). setInputFiles works on hidden inputs natively in
+      // Playwright, but we still wait for the element to be attached first.
+      const fileInput = page.locator('input[type="file"]');
+      await fileInput.setInputFiles(SMOKE_FIXTURE_PATH);
+
+      // Wait for file to be processed — the filename appears in the UI
+      await expect(page.getByText(/smoke-test-minimal\.txt/i)).toBeVisible({
+        timeout: 10000,
+      });
+    });
+
+    // Step 4 (wizard step 3): Advance to review and submit
+    // After uploading the file the wizard is on step 2. Clicking Next moves to
+    // the Review & Submit step (step 3), which shows the "Submit & Start
+    // Translation" button (not a separate translate button).
+    await test.step('Advance to review step', async () => {
+      await page.getByRole('button', { name: /next/i }).click();
+      // Review step renders the file name in the summary
+      await expect(page.getByText(/smoke-test-minimal\.txt/i)).toBeVisible({ timeout: 10000 });
     });
 
     // Step 5: Start translation
     await test.step('User can start translation', async () => {
-      // Click translate button
-      const translateButton = page.getByRole('button', { name: /translate|start.*translation/i });
+      // The final step button on the wizard is "Submit & Start Translation"
+      const translateButton = page.getByRole('button', {
+        name: /submit.*translation|translate|start.*translation/i,
+      });
       await translateButton.click();
 
       // Wait for translation to start

--- a/frontend/src/components/Translation/__tests__/FileUploadForm.test.tsx
+++ b/frontend/src/components/Translation/__tests__/FileUploadForm.test.tsx
@@ -275,6 +275,7 @@ describe('FileUploadForm', () => {
 
       vi.spyOn(uploadService.uploadService, 'uploadDocument').mockResolvedValue({
         fileId: 'test-file-id-123',
+        jobId: 'test-job-id-123',
         success: true,
       });
 
@@ -312,7 +313,7 @@ describe('FileUploadForm', () => {
             onProgress({ loaded: 50, total: 100, percentage: 50 });
             onProgress({ loaded: 100, total: 100, percentage: 100 });
           }
-          return { fileId: 'test-id', success: true };
+          return { fileId: 'test-id', jobId: 'test-job-id', success: true };
         }
       );
 
@@ -336,6 +337,7 @@ describe('FileUploadForm', () => {
 
       vi.spyOn(uploadService.uploadService, 'uploadDocument').mockResolvedValue({
         fileId: '',
+        jobId: '',
         success: false,
         error: 'Network error during upload',
       });
@@ -365,6 +367,7 @@ describe('FileUploadForm', () => {
 
       vi.spyOn(uploadService.uploadService, 'uploadDocument').mockResolvedValue({
         fileId: 'test-id',
+        jobId: 'test-job-id',
         success: true,
       });
 

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -605,6 +605,7 @@ const translationHandlers: HttpHandler[] = [
         data: {
           uploadUrl,
           fileId: jobId,
+          jobId,
           expiresIn: 900,
           requiredHeaders: {
             'Content-Type': 'text/plain',

--- a/frontend/src/services/__tests__/translationService.test.ts
+++ b/frontend/src/services/__tests__/translationService.test.ts
@@ -86,12 +86,15 @@ describe('TranslationService - uploadDocument', () => {
         timestamp: '2024-10-31T12:00:00Z',
       };
 
-      // Mock presigned URL response from backend
+      // Mock presigned URL response from backend.
+      // The backend now includes both `fileId` (the S3 object key component)
+      // and `jobId` (the DynamoDB record key) in the response envelope.
       const mockPresignedResponse = {
         data: {
           data: {
             uploadUrl: 'https://s3.amazonaws.com/bucket/presigned-url',
-            fileId: 'job-123',
+            fileId: 'file-abc',
+            jobId: 'job-123',
             requiredHeaders: {
               'x-amz-server-side-encryption': 'AES256',
             },

--- a/frontend/src/services/__tests__/uploadService.test.ts
+++ b/frontend/src/services/__tests__/uploadService.test.ts
@@ -38,6 +38,7 @@ describe('uploadService', () => {
           data: {
             uploadUrl: 'https://s3.amazonaws.com/bucket/key?signature',
             fileId: 'test-file-id-123',
+            jobId: 'test-job-id-456',
             expiresIn: 900,
             requiredHeaders: {
               'Content-Type': 'text/plain',
@@ -62,6 +63,7 @@ describe('uploadService', () => {
       expect(result).toEqual({
         uploadUrl: 'https://s3.amazonaws.com/bucket/key?signature',
         fileId: 'test-file-id-123',
+        jobId: 'test-job-id-456',
         expiresIn: 900,
         requiredHeaders: {
           'Content-Type': 'text/plain',
@@ -93,6 +95,7 @@ describe('uploadService', () => {
           data: {
             uploadUrl: 'https://s3.amazonaws.com/bucket/key',
             fileId: 'large-file-id',
+            jobId: 'large-job-id',
             expiresIn: 900,
             requiredHeaders: {
               'Content-Type': 'text/plain',
@@ -328,6 +331,7 @@ describe('uploadService', () => {
           data: {
             uploadUrl: 'https://s3.amazonaws.com/bucket/key',
             fileId: 'test-file-id',
+            jobId: 'test-job-id',
             expiresIn: 900,
             requiredHeaders: {
               'Content-Type': 'text/plain',
@@ -347,9 +351,11 @@ describe('uploadService', () => {
       // Act
       const result = await uploadService.uploadDocument(mockFile);
 
-      // Assert
+      // Assert — both fileId and jobId must be propagated end-to-end
+      // (PR #184 follow-up: jobId previously dropped silently in this seam).
       expect(result).toEqual({
         fileId: 'test-file-id',
+        jobId: 'test-job-id',
         success: true,
       });
 
@@ -372,6 +378,7 @@ describe('uploadService', () => {
           data: {
             uploadUrl: 'https://s3.amazonaws.com/bucket/key',
             fileId: 'test-file-id',
+            jobId: 'test-job-id',
             expiresIn: 900,
             requiredHeaders: {},
           },
@@ -418,6 +425,7 @@ describe('uploadService', () => {
       // Assert
       expect(result).toEqual({
         fileId: '',
+        jobId: '',
         success: false,
         error: 'Failed to get presigned URL',
       });
@@ -432,6 +440,7 @@ describe('uploadService', () => {
           data: {
             uploadUrl: 'https://s3.amazonaws.com/bucket/key',
             fileId: 'test-file-id',
+            jobId: 'test-job-id',
             expiresIn: 900,
             requiredHeaders: {},
           },
@@ -452,6 +461,7 @@ describe('uploadService', () => {
       // Assert
       expect(result).toEqual({
         fileId: '',
+        jobId: '',
         success: false,
         error: 'Network error during file upload',
       });

--- a/frontend/src/services/translationService.ts
+++ b/frontend/src/services/translationService.ts
@@ -120,6 +120,7 @@ export const uploadDocument = async (request: UploadDocumentRequest): Promise<Tr
       data: {
         uploadUrl: string;
         fileId: string;
+        jobId: string;
         expiresIn: number;
         requiredHeaders: Record<string, string>;
       };
@@ -130,7 +131,7 @@ export const uploadDocument = async (request: UploadDocumentRequest): Promise<Tr
       legalAttestation: request.legalAttestation,
     });
 
-    const { uploadUrl, fileId, requiredHeaders } = presignedResponse.data.data;
+    const { uploadUrl, jobId, requiredHeaders } = presignedResponse.data.data;
 
     // Step 2: Upload file directly to S3 using presigned URL
     // Note: We use axios directly here because S3 doesn't need our API interceptors/auth headers
@@ -145,7 +146,7 @@ export const uploadDocument = async (request: UploadDocumentRequest): Promise<Tr
     // Note: The backend creates the job record but doesn't return it immediately
     // The job will be retrieved later when starting translation
     return {
-      jobId: fileId,
+      jobId,
       userId: '', // Will be populated by backend
       fileName: request.file.name,
       fileSize: request.file.size,

--- a/frontend/src/services/uploadService.ts
+++ b/frontend/src/services/uploadService.ts
@@ -29,15 +29,26 @@ export type UploadProgressCallback = (progress: UploadProgress) => void;
 export interface UploadRequestResult {
   uploadUrl: string;
   fileId: string;
+  jobId: string;
   expiresIn: number;
   requiredHeaders: Record<string, string>;
 }
 
 /**
  * Upload completion result
+ *
+ * NOTE: `jobId` is the canonical identifier downstream services (status
+ * polling, deletion, translation start) key off — the backend creates it in
+ * `backend/functions/jobs/uploadRequest.ts` and returns it in
+ * `PresignedUrlResponse` (shared-types/src/documents.ts:83). PR #184's main
+ * fix added it to the type + service-layer plumbing for translationService;
+ * we propagate it here too so this service stays consistent and any future
+ * caller of `uploadDocument` can correlate the upload with its job record
+ * without a second round-trip.
  */
 export interface UploadResult {
   fileId: string;
+  jobId: string;
   success: boolean;
   error?: string;
 }
@@ -137,13 +148,14 @@ export async function uploadDocument(
 ): Promise<UploadResult> {
   try {
     // Step 1: Request presigned URL
-    const { uploadUrl, fileId, requiredHeaders } = await requestUploadUrl(file);
+    const { uploadUrl, fileId, jobId, requiredHeaders } = await requestUploadUrl(file);
 
     // Step 2: Upload to S3
     await uploadToS3(file, uploadUrl, requiredHeaders, onProgress);
 
     return {
       fileId,
+      jobId,
       success: true,
     };
   } catch (error) {
@@ -151,6 +163,7 @@ export async function uploadDocument(
 
     return {
       fileId: '',
+      jobId: '',
       success: false,
       error: errorMessage,
     };

--- a/shared-types/src/documents.ts
+++ b/shared-types/src/documents.ts
@@ -83,6 +83,7 @@ export interface PresignedUrlRequest {
 export interface PresignedUrlResponse {
   uploadUrl: string;
   fileId: string;
+  jobId: string;
   expiresIn: number;
   requiredHeaders: Record<string, string>;
 }


### PR DESCRIPTION
## Summary

This PR fixes the second layer of post-deploy CI failures that became visible after PR #181 was merged. All five failures share two root causes.

## Failure status table

| Failure | Root cause (file:line) | Fix |
|---------|------------------------|-----|
| `should request presigned upload URL` — `Expected path: "jobId" / Received: []` | `PresignedUrlResponse` (shared-types/src/documents.ts:83) had no `jobId` field; handler built and discarded `jobId` silently | Add `jobId` to type + handler response; update smoke test to read `response.data.data.jobId` (envelope path) |
| `should poll job status` — 403 | `smoke.test.ts` beforeAll set `jobId = uploadResponse.data.jobId` (undefined), so every subsequent call hit `GET /jobs/undefined` → 403 | Cascade from Failure 1; fixed by same `response.data.data.jobId` read |
| `should delete a job` — assertion error | Cascade from undefined jobId | Same |
| `should return 404 for deleted job` | Cascade from undefined jobId | Same |
| Production smoke `setInputFiles` 3-min timeout | Upload page is a 4-step wizard; `input[type="file"]` only exists on step 2. Test called `setInputFiles` immediately on step 0 — locator never resolved | Add legal-attestation + translation-config wizard steps before upload; wait for `toBeAttached`; add review-step navigation; fix button regex for "Submit & Start Translation" |

## Files changed

- `shared-types/src/documents.ts` — add `jobId` to `PresignedUrlResponse`
- `backend/functions/jobs/uploadRequest.ts` — include `jobId` in success response
- `backend/tests/smoke/smoke.test.ts` — fix `response.data.data.jobId` reads in assertion + 3 beforeAll blocks
- `frontend/src/services/translationService.ts` — read `jobId` from response (stop aliasing `fileId`)
- `frontend/src/mocks/handlers.ts` — add `jobId` to MSW mock response
- `frontend/src/services/__tests__/translationService.test.ts` — add `jobId` to unit-test mock
- `frontend/e2e/tests/smoke/production-smoke.spec.ts` — drive the 4-step wizard correctly

## Test plan

- [x] `backend/functions`: 442 tests pass, 0 ESLint errors, Prettier clean
- [x] `backend/infrastructure`: 45 tests pass, TypeScript build clean
- [x] `frontend`: 593 Vitest tests pass (0 failures), TypeScript strict clean, Prettier clean
- [x] `playwright test --list`: 102 specs load without parse errors
- [ ] Deploy run confirms backend smoke 22/22, production smoke passes (post-merge)

## Why the previous PR missed this

PR #181 fixed auth (`accessToken` → `idToken`) which unblocked the login/register layer. Once that layer passed, the presigned-URL response shape mismatch became the new top failure. The wizard-navigation bug was present before #181 but the test never reached it — registration was crashing first.