### PR TITLE
chore(ci): split deploy.yml into backend + frontend workflows (#157)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
       - develop
   push:
     branches-ignore:
-      - main # Main branch uses deploy.yml workflow
+      - main # Main branch uses deploy-backend.yml + deploy-frontend.yml workflows (Issue #157)
 
 env:
   AWS_REGION: us-east-1
@@ -101,11 +101,13 @@ jobs:
     # correctness. Two checks:
     #   1. actionlint: validates GitHub Actions expression syntax, needs:
     #      references, action input names, shellcheck on run: blocks.
-    #   2. deploy.yml gated-job parity: deploy-dev and the 4 trailing test
-    #      jobs (production-smoke-tests, smoke-tests, integration-tests,
-    #      e2e-tests) MUST share an identical if: expression so they run as a
-    #      unit. Drift here would silently skip post-deploy verification on
-    #      manual dispatch (the exact bug PR #159 fixed for the inverse case).
+    #   2. deploy-{backend,frontend}.yml gated-job parity: in EACH deploy
+    #      workflow, the deploy-dev job and its trailing verification jobs
+    #      (the "cascade") MUST share an identical if: expression so they
+    #      run as a unit. Drift here would silently skip post-deploy
+    #      verification on manual dispatch (the exact bug PR #159 fixed for
+    #      the inverse case). Updated for Issue #157 split: previously
+    #      checked a single deploy.yml; now checks both halves separately.
 
     steps:
       - name: Checkout code
@@ -129,36 +131,51 @@ jobs:
         # would still fire as warnings/errors and be caught.
         run: actionlint -color -shellcheck "shellcheck -S warning"
 
-      - name: Verify deploy.yml gated-job condition parity
+      - name: Verify deploy workflow gated-job condition parity
         run: |
           python3 <<'PYEOF'
           import sys
           import yaml
 
-          with open('.github/workflows/deploy.yml') as f:
-              wf = yaml.safe_load(f)
+          # Issue #157 split: one parity check per deploy workflow. Each
+          # workflow's "deploy-dev cascade" (deploy job + verification jobs
+          # that need: it) must share an identical if: expression so the
+          # cascade runs as a unit. The two cascades are independent —
+          # backend and frontend can have different conditions across files,
+          # but the jobs WITHIN a file must agree.
+          DEPLOY_WORKFLOWS = {
+              '.github/workflows/deploy-backend.yml': [
+                  'deploy-dev',
+                  'smoke-tests',
+                  'integration-tests',
+              ],
+              '.github/workflows/deploy-frontend.yml': [
+                  'deploy-dev-frontend',
+                  'production-smoke-tests',
+                  'e2e-tests',
+              ],
+          }
 
-          # These 5 jobs are the "deploy-dev cascade" — deploy-dev plus its
-          # 4 verification jobs that needs: deploy-dev. They must share an
-          # identical if: expression or the cascade will partially skip.
-          gated_jobs = [
-              'deploy-dev',
-              'production-smoke-tests',
-              'smoke-tests',
-              'integration-tests',
-              'e2e-tests',
-          ]
-          conditions = {job: wf['jobs'][job].get('if', '') for job in gated_jobs}
-          unique = set(conditions.values())
+          had_error = False
+          for wf_path, gated_jobs in DEPLOY_WORKFLOWS.items():
+              with open(wf_path) as f:
+                  wf = yaml.safe_load(f)
 
-          if len(unique) != 1:
-              print('::error file=.github/workflows/deploy.yml::deploy.yml gated jobs have divergent if: expressions — cascade will silently partial-skip')
-              for job, cond in conditions.items():
-                  print(f'  {job}: {cond}', file=sys.stderr)
+              conditions = {job: wf['jobs'][job].get('if', '') for job in gated_jobs}
+              unique = set(conditions.values())
+
+              if len(unique) != 1:
+                  print(f'::error file={wf_path}::{wf_path} gated jobs have divergent if: expressions — cascade will silently partial-skip')
+                  for job, cond in conditions.items():
+                      print(f'  {job}: {cond}', file=sys.stderr)
+                  had_error = True
+                  continue
+
+              print(f'OK ({wf_path}): all {len(gated_jobs)} gated jobs share an identical if: expression')
+              print(f'  Condition: {next(iter(unique))}')
+
+          if had_error:
               sys.exit(1)
-
-          print(f'OK: all {len(gated_jobs)} gated jobs share an identical if: expression')
-          print(f'Condition: {next(iter(unique))}')
           PYEOF
 
   lint-and-format:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,14 @@ jobs:
               sys.exit(1)
           PYEOF
 
+      - name: Verify deploy workflow path-filter contracts
+        # OMC test-automator follow-up (PR #185 R2): asserts each deploy
+        # workflow's on.push.paths contains the EXPECTED globs (and excludes
+        # forbidden globs that would over-trigger across the split). Adding a
+        # 3rd deploy workflow in the future requires updating the EXPECTED /
+        # FORBIDDEN dicts in the script. See tracking issue for auto-discovery.
+        run: python3 tests/workflows/test_deploy_path_filters.py
+
   lint-and-format:
     name: Lint and Format Check
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -44,6 +44,25 @@ env:
   AWS_REGION: us-east-1
   NODE_VERSION: '20'
 
+# Concurrency group (OMC perf + architect review, PR #185 follow-up):
+#
+# `shared-types/**` triggers BOTH deploy-backend.yml AND deploy-frontend.yml.
+# Without coordination, the two workflows race: deploy-frontend.yml can read
+# stale CloudFormation outputs (and therefore the old API URL) and S3-sync a
+# stale bundle to CloudFront BEFORE deploy-backend.yml's own frontend rebuild
+# step finishes pushing the fresh URL.
+#
+# Both workflows share the SAME group name (`deploy-${ref}`) so GitHub Actions
+# serializes them per ref. The frontend pipeline waits for the backend pipeline
+# (or vice versa) instead of racing.
+#
+# `cancel-in-progress: false` — never abort an in-flight deploy. Aborting an
+# active CDK or S3 sync risks partial state. Trade-off: occasional short queue
+# wait when shared-types lands; acceptable.
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   test:
     name: Run Tests (Backend)

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -1,6 +1,21 @@
-name: Deploy LFMT Infrastructure
+name: Deploy LFMT Backend
 
-# Automated CI/CD pipeline with secure OIDC authentication
+# Backend deployment pipeline (Issue #157 split):
+#
+# This workflow handles the BACKEND half of what used to be the monolithic
+# deploy.yml. It triggers on backend or shared-types changes and runs the
+# full CDK deploy + API-level verification cascade. The frontend half lives
+# in `.github/workflows/deploy-frontend.yml`.
+#
+# Why the split? Pre-split, every frontend-only commit (CSS tweak, copy
+# change) ran the full ~15-20 min backend pipeline including a noop CDK
+# deploy and backend integration tests against an unchanged API. After the
+# split, frontend commits run only the frontend pipeline (~5-7 min) and
+# backend commits run only this one. shared-types/** triggers BOTH, since
+# both halves depend on the shared types package.
+#
+# See `docs/CI-CD-ARCHITECTURE.md` for the full rationale and operational
+# coordination requirements (branch-protection rule names, parity checks).
 on:
   push:
     branches:
@@ -8,15 +23,14 @@ on:
     paths:
       - 'backend/**'
       - 'shared-types/**'
-      - 'frontend/**'
-      - '.github/workflows/deploy.yml'
+      - '.github/workflows/deploy-backend.yml'
   workflow_dispatch:
     inputs:
       environment:
-        # NOTE: default is 'dev' — running `gh workflow run deploy.yml --ref main`
+        # NOTE: default is 'dev' — running `gh workflow run deploy-backend.yml --ref main`
         # with no `-f environment=...` flag triggers a real deploy to LfmtPocDev
-        # (CDK + S3 sync + CloudFront invalidation + smoke + integration + e2e).
-        # Pick `staging` or `prod` explicitly to target those stacks instead.
+        # (CDK + smoke + integration). Pick `staging` or `prod` explicitly to
+        # target those stacks instead.
         description: 'Environment to deploy (dev triggers a real deploy to LfmtPocDev)'
         required: true
         default: 'dev'
@@ -32,37 +46,34 @@ env:
 
 jobs:
   test:
-    name: Run Tests
+    name: Run Tests (Backend)
     runs-on: ubuntu-latest
-    # ci.yml ↔ deploy.yml parity (Phase 1.1 audit, 2026-04-18):
+    # ci.yml ↔ deploy-backend.yml parity (Phase 1.1 audit, 2026-04-18;
+    # split out of monolithic deploy.yml in Issue #157):
     #
-    # This job is the deploy-time gate for main. It is intentionally a
-    # SUBSET of ci.yml's PR-time gates. ci.yml runs on every PR and covers
-    # the full matrix (test, lint-and-format, build-infrastructure,
-    # security-scan, test-frontend). The contract is: any code that
-    # reaches main has already passed the full ci.yml suite, so this job
-    # only re-verifies the deploy-blocking subset (lint, format, type-check,
-    # backend tests + coverage) against the merged main commit. This applies
-    # equally to backend, shared-types, AND frontend pushes — the trigger
-    # `paths` above include `frontend/**`, and the steps below cover frontend
-    # lint/format/type-check; full vitest coverage and the production build
-    # remain ci.yml-only because deploy-dev rebuilds with the live VITE_API_URL.
+    # This job is the deploy-time gate for backend changes on main. It is
+    # intentionally a SUBSET of ci.yml's PR-time gates. ci.yml runs on every
+    # PR and covers the full matrix (test, lint-and-format, build-infrastructure,
+    # security-scan, test-frontend). The contract is: any code that reaches
+    # main has already passed the full ci.yml suite, so this job only
+    # re-verifies the deploy-blocking subset (lint, format, type-check,
+    # backend tests + coverage) against the merged main commit. Frontend
+    # lint/format/type-check is handled by the parallel `Run Tests (Frontend)`
+    # job in deploy-frontend.yml.
     #
     # Steps that ci.yml runs but this job intentionally does NOT:
     #   - shared-types `npm test` (ci.yml `test` job)        [PR-gate only]
     #   - backend `npx tsc --noEmit`  (ci.yml lint-and-format)[PR-gate only;
     #     checks every .ts file, not just tests — narrower than `npm test`]
-    #   - frontend `npm run test:coverage` (ci.yml test-frontend)[PR-gate only]
-    #   - frontend `npm run build`    (ci.yml test-frontend) [done in deploy-dev]
     #   - infrastructure build/test/cdk-synth (ci.yml build-infrastructure)
     #     [the `cdk deploy` below implicitly re-synths; PR gate is authoritative]
     #   - npm audit                   (ci.yml security-scan) [PR-gate only]
     #
-    # If you add a new deploy-blocking step to deploy.yml, also add it to
-    # ci.yml so PRs surface failures BEFORE merge. Do NOT remove the
-    # primary lint/format/type-check steps below — those are the ones
-    # that historically failed at deploy-time after merging green PRs
-    # (Issue #149 backend lint, Issue #152 follow-on shared-types build).
+    # If you add a new deploy-blocking step to deploy-backend.yml, also add
+    # it to ci.yml so PRs surface failures BEFORE merge. Do NOT remove the
+    # primary lint/format steps below — those are the ones that historically
+    # failed at deploy-time after merging green PRs (Issue #149 backend lint,
+    # Issue #152 follow-on shared-types build).
 
     steps:
       - name: Checkout code
@@ -73,29 +84,20 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
-          # Cache all three lockfiles touched by this job (shared-types,
-          # backend/functions, frontend). Listing only one guarantees cache
-          # misses on the other two `npm ci` steps below — actions/setup-node
-          # accepts a multi-line list and hashes them together for a single
-          # composite cache key. Aligns with ci.yml lint-and-format which also
-          # caches all three (PR #154 audit fix).
+          # Cache both lockfiles touched by this job (shared-types,
+          # backend/functions). actions/setup-node accepts a multi-line list
+          # and hashes them together for a single composite cache key.
           cache-dependency-path: |
             shared-types/package-lock.json
             backend/functions/package-lock.json
-            frontend/package-lock.json
 
       - name: Install shared-types dependencies
         working-directory: shared-types
         run: npm ci
 
-      # Build shared-types BEFORE the frontend type-check below. The frontend
-      # imports from '@lfmt/shared-types', which resolves through the package's
-      # main/types entry to shared-types/dist/. Without this build step, the
-      # Type-check frontend step fails with TS2307 "Cannot find module
-      # '@lfmt/shared-types'". Mirrors ci.yml lint-and-format (line ~118) and
-      # the deploy-dev/staging/prod jobs below, which already build shared-types
-      # before the frontend rebuild. Closes the parity gap that allowed PR #152
-      # to merge green while deploy.yml still failed at type-check.
+      # Build shared-types so backend's tsc/test runs can resolve the
+      # '@lfmt/shared-types' package entry (dist/). Mirrors ci.yml
+      # lint-and-format and the deploy-dev job below.
       - name: Build shared-types
         working-directory: shared-types
         run: npm run build
@@ -120,24 +122,8 @@ jobs:
         working-directory: backend/functions
         run: npm run test:coverage
 
-      - name: Install frontend dependencies
-        working-directory: frontend
-        run: npm ci
-
-      - name: Lint frontend
-        working-directory: frontend
-        run: npm run lint
-
-      - name: Check frontend formatting
-        working-directory: frontend
-        run: npm run format:check
-
-      - name: Type-check frontend
-        working-directory: frontend
-        run: npm run type-check
-
   deploy-dev:
-    name: Deploy to Development
+    name: Deploy Backend to Development
     runs-on: ubuntu-latest
     needs: test
     # Trigger conditions:
@@ -145,16 +131,13 @@ jobs:
     #   - workflow_dispatch with environment=dev → manual deploy (escape hatch)
     # The manual path was added after Issue #158 (cdk import for
     # TranslationApiKeySecret) when we needed to verify a hand-fix without
-    # piggy-backing on an unrelated commit. staging/prod are dispatchable via
-    # dedicated jobs below (note: those lack a main-branch guard — tracked
-    # in Issue #160 as a follow-up).
+    # piggy-backing on an unrelated commit.
     #
-    # Drift-prevention history: this file has had three trigger-related
-    # incidents in one quarter (Issue #149 backend lint regression, PR #152
-    # shared-types build, PR #154 frontend trigger gap). Do NOT collapse this
-    # condition back to `event_name == 'push'` without re-adding a manual
-    # dev-redeploy path elsewhere — the next person to "simplify" this away
-    # will trigger the next incident.
+    # Drift-prevention history: this file's predecessor (deploy.yml) had
+    # three trigger-related incidents in one quarter (Issue #149 backend
+    # lint regression, PR #152 shared-types build, PR #154 frontend trigger
+    # gap). Do NOT collapse this condition back to `event_name == 'push'`
+    # without re-adding a manual dev-redeploy path elsewhere.
     if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'dev'))
     environment:
       name: development
@@ -177,9 +160,12 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
           # deploy-dev runs `npm ci` in four directories below: shared-types,
-          # backend/functions, backend/infrastructure, and frontend. List all
-          # four lockfiles so the cache key is computed across the full set
-          # (same multi-lockfile pattern as the Run Tests job above and ci.yml).
+          # backend/functions, backend/infrastructure, and frontend. The
+          # frontend rebuild is required to pick up the freshly-deployed
+          # API URL via VITE_API_URL — backend infra changes can rotate the
+          # API Gateway URL, so the frontend bundle must be rebuilt and
+          # pushed to S3 to stay in sync. (Frontend-only commits do NOT
+          # trigger this workflow; deploy-frontend.yml handles those.)
           cache-dependency-path: |
             shared-types/package-lock.json
             backend/functions/package-lock.json
@@ -238,6 +224,11 @@ jobs:
         run: |
           curl -f ${{ steps.get-url.outputs.api_url }}/v1/auth || echo "API not yet ready, may need warm-up"
 
+      # Backend deploys still rebuild + sync the frontend because the
+      # newly-deployed API URL must be baked into the frontend bundle
+      # (VITE_API_URL is build-time, not runtime). Frontend-only commits
+      # take the lighter `deploy-frontend.yml` path which reads the existing
+      # API URL from CFN outputs without a CDK deploy.
       - name: Install shared-types for frontend rebuild
         working-directory: shared-types
         run: npm ci
@@ -305,152 +296,10 @@ jobs:
           echo "Waiting for CloudFront invalidation to complete..."
           sleep 30
 
-      - name: Validate Security Headers (Issue #62)
+      - name: Backend Deployment Summary
         run: |
           echo "========================================="
-          echo "Live Security Header Validation"
-          echo "========================================="
-          FRONTEND_URL="${{ steps.get-frontend-url.outputs.frontend_url }}"
-          echo "Testing URL: $FRONTEND_URL"
-          echo ""
-
-          # Fetch headers using -L to follow redirects. curl -sIL prints headers
-          # for every hop; keep only the FINAL response block (the one a browser
-          # actually sees). Splitting on blank lines (\r\n\r\n) with awk keeps
-          # the last non-empty block.
-          RAW_HEADERS=$(curl -sIL "$FRONTEND_URL")
-          HEADERS=$(printf '%s' "$RAW_HEADERS" | awk 'BEGIN{RS="\r\n\r\n"} NF{last=$0} END{print last}')
-
-          # Function to check header (case-insensitive grep so 301/302 variants
-          # and differently-cased servers don't produce false negatives).
-          check_header() {
-            local header_name="$1"
-            local header_pattern="$2"
-            local required="$3"
-
-            if echo "$HEADERS" | grep -i "^${header_name}:" > /dev/null; then
-              # SC2155: declare and assign separately so command failure isn't masked.
-              # NOTE: trim with sed, NOT xargs — xargs performs shell-style
-              # tokenization that strips single quotes (e.g. `object-src 'none'`
-              # would become `object-src none`), producing false negatives in
-              # the CSP regex checks below.
-              local header_value
-              header_value=$(echo "$HEADERS" | grep -i "^${header_name}:" | cut -d: -f2- | tr -d '\r\n' | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')
-              echo "✅ ${header_name}: ${header_value}"
-
-              if [ -n "$header_pattern" ]; then
-                if echo "$header_value" | grep -iE "$header_pattern" > /dev/null; then
-                  echo "   ✓ Pattern match: $header_pattern"
-                else
-                  echo "   ❌ Pattern mismatch: expected pattern '$header_pattern'"
-                  if [ "$required" = "true" ]; then
-                    exit 1
-                  fi
-                fi
-              fi
-            else
-              echo "❌ ${header_name}: NOT FOUND"
-              if [ "$required" = "true" ]; then
-                exit 1
-              fi
-            fi
-            echo ""
-          }
-
-          # Validate critical security headers
-          echo "Checking Security Headers:"
-          echo "─────────────────────────────────────────"
-          check_header "strict-transport-security" "max-age=" true
-          check_header "x-content-type-options" "nosniff" true
-          check_header "x-frame-options" "(DENY|SAMEORIGIN)" true
-          check_header "content-security-policy" "default-src" true
-          check_header "referrer-policy" "" false
-          check_header "x-xss-protection" "" false
-
-          echo "========================================="
-          echo "✅ All required security headers validated"
-          echo "========================================="
-
-      - name: Validate CSP Hardening (Issue #63)
-        run: |
-          echo "========================================="
-          echo "CSP Hardening Validation"
-          echo "========================================="
-          FRONTEND_URL="${{ steps.get-frontend-url.outputs.frontend_url }}"
-
-          # Fetch CSP header. -L follows redirects (final response is what a
-          # browser enforces); awk extracts the final response-headers block;
-          # grep -i is case-insensitive.
-          RAW_HEADERS=$(curl -sIL "$FRONTEND_URL")
-          FINAL_HEADERS=$(printf '%s' "$RAW_HEADERS" | awk 'BEGIN{RS="\r\n\r\n"} NF{last=$0} END{print last}')
-          # Trim with sed, NOT xargs — xargs performs shell-style tokenization
-          # that strips single quotes, so `object-src 'none'` would arrive here
-          # as `object-src none` and silently fail every quoted-directive check
-          # below. (Latent bug exposed when PR #159 first routed push-to-main
-          # into deploy-dev and the CSP step actually ran.)
-          CSP=$(echo "$FINAL_HEADERS" | grep -i "^content-security-policy:" | cut -d: -f2- | tr -d '\r\n' | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')
-
-          echo "CSP Policy: $CSP"
-          echo ""
-
-          # CSP hardening status (Issue #133):
-          #   - 'unsafe-eval' has been REMOVED from script-src (Part 2). The
-          #     production bundle was inspected and contains no eval()/Function()
-          #     calls; standard Vite + MUI/Emotion do not require it.
-          #   - 'unsafe-inline' is still permitted (style-src + script-src) and
-          #     will be removed when the nonce-injection pipeline lands
-          #     (Lambda@Edge + Emotion CacheProvider). Tracked in the Part 1
-          #     follow-up issue.
-          # We therefore validate the non-unsafe hardening directives plus the
-          # absence of 'unsafe-eval' as a regression guard.
-
-          # Check that CSP contains baseline directives
-          required_directives=("default-src" "script-src" "style-src" "connect-src")
-          for directive in "${required_directives[@]}"; do
-            if echo "$CSP" | grep -i "$directive" > /dev/null; then
-              echo "✅ PASS: CSP contains '$directive' directive"
-            else
-              echo "❌ FAIL: CSP missing '$directive' directive"
-              exit 1
-            fi
-          done
-
-          # Check that CSP contains additional hardening directives (retained
-          # from the Issue #63 pass even though 'unsafe-inline' remains).
-          hardening_directives=(
-            "object-src 'none'"
-            "base-uri 'self'"
-            "form-action 'self'"
-            "frame-ancestors 'none'"
-            "upgrade-insecure-requests"
-          )
-          for directive in "${hardening_directives[@]}"; do
-            if echo "$CSP" | grep -iF "$directive" > /dev/null; then
-              echo "✅ PASS: CSP contains hardening directive: $directive"
-            else
-              echo "❌ FAIL: CSP missing hardening directive: $directive"
-              exit 1
-            fi
-          done
-
-          # Regression guard (Issue #133 Part 2): 'unsafe-eval' must NOT appear
-          # in the script-src directive of the deployed CSP.
-          if echo "$CSP" | grep -iF "'unsafe-eval'" > /dev/null; then
-            echo "❌ FAIL: CSP contains 'unsafe-eval' (regression — Issue #133 Part 2)"
-            exit 1
-          else
-            echo "✅ PASS: CSP does not contain 'unsafe-eval' (Issue #133 Part 2)"
-          fi
-
-          echo ""
-          echo "========================================="
-          echo "✅ CSP hardening requirements met"
-          echo "========================================="
-
-      - name: Frontend Deployment Summary
-        run: |
-          echo "========================================="
-          echo "Frontend Deployment Summary"
+          echo "Backend Deployment Summary"
           echo "========================================="
           echo "S3 Bucket: ${{ steps.get-bucket-name.outputs.bucket_name }}"
           echo "CloudFront Distribution: ${{ steps.get-cf-dist.outputs.distribution_id }}"
@@ -458,83 +307,8 @@ jobs:
           echo "API URL: ${{ steps.get-url.outputs.api_url }}"
           echo "========================================="
 
-  production-smoke-tests:
-    name: Run Production Smoke Tests
-    runs-on: ubuntu-latest
-    needs: deploy-dev
-    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'dev'))
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
-          cache-dependency-path: frontend/package-lock.json
-
-      - name: Install frontend dependencies
-        working-directory: frontend
-        run: npm ci
-
-      - name: Install Playwright browsers
-        working-directory: frontend
-        run: npx playwright install --with-deps chromium
-
-      - name: Wait for frontend to be ready
-        run: |
-          echo "Waiting for frontend to be ready..."
-          for i in {1..30}; do
-            if curl -sf ${{ needs.deploy-dev.outputs.frontend_url }}/ > /dev/null 2>&1; then
-              echo "Frontend is ready!"
-              exit 0
-            fi
-            echo "Attempt $i/30: Frontend not ready yet, waiting 10 seconds..."
-            sleep 10
-          done
-          echo "Proceeding with tests..."
-
-      - name: Run production smoke tests
-        working-directory: frontend
-        run: npx playwright test --grep @smoke
-        env:
-          PLAYWRIGHT_BASE_URL: ${{ needs.deploy-dev.outputs.frontend_url }}
-          API_BASE_URL: ${{ needs.deploy-dev.outputs.api_url }}
-          SMOKE_TEST_EMAIL: ${{ secrets.SMOKE_TEST_EMAIL }}
-          SMOKE_TEST_PASSWORD: ${{ secrets.SMOKE_TEST_PASSWORD }}
-          CI: true
-
-      - name: Upload smoke test results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: smoke-test-report
-          path: frontend/playwright-report/
-          retention-days: 30
-
-      - name: Upload smoke test videos
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: smoke-test-videos
-          path: frontend/test-results/
-          retention-days: 7
-
-      - name: Production Smoke Test Summary
-        if: always()
-        run: |
-          echo "========================================="
-          echo "Production Smoke Test Summary"
-          echo "========================================="
-          echo "Frontend URL: ${{ needs.deploy-dev.outputs.frontend_url }}"
-          echo "API URL: ${{ needs.deploy-dev.outputs.api_url }}"
-          echo "Tests completed at: $(date -u +"%Y-%m-%d %H:%M:%S UTC")"
-          echo "========================================="
-
   smoke-tests:
-    name: Run Smoke Tests
+    name: Run API Smoke Tests
     runs-on: ubuntu-latest
     needs: deploy-dev
     if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'dev'))
@@ -605,8 +379,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
           # integration-tests runs `npm ci` in shared-types AND backend/functions
-          # below. List both lockfiles so the cache key reflects the full set
-          # (matches the multi-lockfile pattern used in Run Tests + deploy-dev).
+          # below. List both lockfiles so the cache key reflects the full set.
           cache-dependency-path: |
             shared-types/package-lock.json
             backend/functions/package-lock.json
@@ -682,81 +455,8 @@ jobs:
           echo "Tests completed at: $(date -u +"%Y-%m-%d %H:%M:%S UTC")"
           echo "========================================="
 
-  e2e-tests:
-    name: Run E2E Tests
-    runs-on: ubuntu-latest
-    needs: deploy-dev
-    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'dev'))
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
-          cache-dependency-path: frontend/package-lock.json
-
-      - name: Install frontend dependencies
-        working-directory: frontend
-        run: npm ci
-
-      - name: Install Playwright browsers
-        working-directory: frontend
-        run: npx playwright install --with-deps chromium
-
-      - name: Wait for frontend to be ready
-        run: |
-          echo "Waiting for frontend to be ready..."
-          for i in {1..30}; do
-            if curl -sf ${{ needs.deploy-dev.outputs.frontend_url }}/ > /dev/null 2>&1; then
-              echo "Frontend is ready!"
-              exit 0
-            fi
-            echo "Attempt $i/30: Frontend not ready yet, waiting 10 seconds..."
-            sleep 10
-          done
-          echo "Proceeding with tests..."
-
-      - name: Run E2E tests
-        working-directory: frontend
-        run: npm run test:e2e
-        env:
-          PLAYWRIGHT_BASE_URL: ${{ needs.deploy-dev.outputs.frontend_url }}
-          API_BASE_URL: ${{ needs.deploy-dev.outputs.api_url }}
-          CI: true
-
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: playwright-report
-          path: frontend/playwright-report/
-          retention-days: 30
-
-      - name: Upload test videos
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: playwright-videos
-          path: frontend/test-results/
-          retention-days: 7
-
-      - name: E2E Test Summary
-        if: always()
-        run: |
-          echo "========================================="
-          echo "E2E Test Summary"
-          echo "========================================="
-          echo "Frontend URL: ${{ needs.deploy-dev.outputs.frontend_url }}"
-          echo "API URL: ${{ needs.deploy-dev.outputs.api_url }}"
-          echo "Tests completed at: $(date -u +"%Y-%m-%d %H:%M:%S UTC")"
-          echo "========================================="
-
   deploy-staging:
-    name: Deploy to Staging
+    name: Deploy Backend to Staging
     runs-on: ubuntu-latest
     needs: test
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'staging'
@@ -873,10 +573,10 @@ jobs:
           aws cloudfront create-invalidation --distribution-id ${{ steps.get-cf-dist.outputs.distribution_id }} --paths "/*"
           echo "CloudFront cache invalidation initiated"
 
-      - name: Frontend Deployment Summary
+      - name: Staging Deployment Summary
         run: |
           echo "========================================="
-          echo "Frontend Deployment Summary"
+          echo "Staging Deployment Summary"
           echo "========================================="
           echo "S3 Bucket: ${{ steps.get-bucket-name.outputs.bucket_name }}"
           echo "CloudFront Distribution: ${{ steps.get-cf-dist.outputs.distribution_id }}"
@@ -885,7 +585,7 @@ jobs:
           echo "========================================="
 
   deploy-prod:
-    name: Deploy to Production
+    name: Deploy Backend to Production
     runs-on: ubuntu-latest
     needs: test
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'prod'
@@ -1022,7 +722,7 @@ jobs:
           aws cloudfront create-invalidation --distribution-id ${{ steps.get-cf-dist.outputs.distribution_id }} --paths "/*"
           echo "CloudFront cache invalidation initiated"
 
-      - name: Frontend Deployment Summary
+      - name: Production Deployment Summary
         run: |
           echo "========================================="
           echo "Production Deployment Summary"

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -1,0 +1,560 @@
+name: Deploy LFMT Frontend
+
+# Frontend deployment pipeline (Issue #157 split):
+#
+# This workflow handles the FRONTEND half of what used to be the monolithic
+# deploy.yml. It triggers on frontend or shared-types changes and runs a
+# fast S3-sync + CloudFront-invalidation flow WITHOUT executing `cdk deploy`.
+# The backend half lives in `.github/workflows/deploy-backend.yml`.
+#
+# Why the split? Pre-split, every frontend-only commit (CSS tweak, copy
+# change) ran the full ~15-20 min backend pipeline including a noop CDK
+# deploy and backend integration tests against an unchanged API. After the
+# split, frontend commits run only this pipeline (~5-7 min) and backend
+# commits run only deploy-backend.yml. shared-types/** triggers BOTH, since
+# both halves depend on the shared types package.
+#
+# Critical contract: this workflow does NOT run `cdk deploy`. It reads the
+# already-deployed API URL and frontend bucket name from CloudFormation
+# outputs (set by the most recent backend deploy) and pushes a freshly-built
+# bundle. If a backend change is required, the developer must merge a
+# backend commit (which triggers deploy-backend.yml) — that workflow handles
+# both backend infra AND a fresh frontend rebuild against the new API URL.
+#
+# See `docs/CI-CD-ARCHITECTURE.md` for the full rationale and operational
+# coordination requirements (branch-protection rule names, parity checks).
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'frontend/**'
+      - 'shared-types/**'
+      - '.github/workflows/deploy-frontend.yml'
+  workflow_dispatch:
+    inputs:
+      environment:
+        # NOTE: default is 'dev' — running `gh workflow run deploy-frontend.yml --ref main`
+        # with no `-f environment=...` flag triggers a real frontend deploy
+        # to LfmtPocDev (S3 sync + CloudFront invalidation, no CDK).
+        description: 'Environment to deploy (dev triggers a real frontend deploy to LfmtPocDev)'
+        required: true
+        default: 'dev'
+        type: choice
+        options:
+          - dev
+          - staging
+          - prod
+
+env:
+  AWS_REGION: us-east-1
+  NODE_VERSION: '20'
+
+jobs:
+  test:
+    name: Run Tests (Frontend)
+    runs-on: ubuntu-latest
+    # ci.yml ↔ deploy-frontend.yml parity (split out of monolithic deploy.yml
+    # in Issue #157):
+    #
+    # This job is the deploy-time gate for frontend changes on main. It is
+    # intentionally a SUBSET of ci.yml's PR-time gates. ci.yml runs on every
+    # PR and covers the full frontend matrix (lint, format, type-check, full
+    # test:coverage, production build). The contract is: any code that
+    # reaches main has already passed the full ci.yml suite, so this job
+    # only re-verifies the deploy-blocking subset (lint, format, type-check)
+    # against the merged main commit. Backend lint/format/test is handled
+    # by the parallel `Run Tests (Backend)` job in deploy-backend.yml.
+    #
+    # Steps that ci.yml runs but this job intentionally does NOT:
+    #   - frontend `npm run test:coverage` (ci.yml test-frontend) [PR-gate only]
+    #   - frontend `npm run build`         (ci.yml test-frontend) [done in
+    #     deploy-dev-frontend below with the live VITE_API_URL]
+    #   - shared-types `npm test`          (ci.yml `test` job)    [PR-gate only]
+    #
+    # If you add a new frontend deploy-blocking step to deploy-frontend.yml,
+    # also add it to ci.yml so PRs surface failures BEFORE merge. The lint /
+    # format / type-check steps below are the historical deploy-blockers and
+    # MUST NOT be removed (Issue #149 / #152 / #154 lineage).
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+          # Cache both lockfiles touched by this job (shared-types, frontend).
+          cache-dependency-path: |
+            shared-types/package-lock.json
+            frontend/package-lock.json
+
+      - name: Install shared-types dependencies
+        working-directory: shared-types
+        run: npm ci
+
+      # Build shared-types BEFORE the frontend type-check below. The frontend
+      # imports from '@lfmt/shared-types', which resolves through the package's
+      # main/types entry to shared-types/dist/. Without this build step, the
+      # Type-check frontend step fails with TS2307 "Cannot find module
+      # '@lfmt/shared-types'" — the exact failure mode that bit deploy.yml in
+      # PR #152 before parity was added.
+      - name: Build shared-types
+        working-directory: shared-types
+        run: npm run build
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Lint frontend
+        working-directory: frontend
+        run: npm run lint
+
+      - name: Check frontend formatting
+        working-directory: frontend
+        run: npm run format:check
+
+      - name: Type-check frontend
+        working-directory: frontend
+        run: npm run type-check
+
+  deploy-dev-frontend:
+    name: Deploy Frontend to Development
+    runs-on: ubuntu-latest
+    needs: test
+    # Trigger conditions:
+    #   - push to main → automatic deploy
+    #   - workflow_dispatch with environment=dev → manual deploy (escape hatch)
+    #
+    # This job INTENTIONALLY does NOT run `cdk deploy`. It assumes the backend
+    # stack already exists (created/updated by deploy-backend.yml) and reads
+    # the live ApiUrl, FrontendBucketName, FrontendUrl, and CloudFrontDistributionId
+    # from CloudFormation outputs. The frontend bundle is rebuilt with the
+    # current API URL baked in via VITE_API_URL, then pushed to S3, then
+    # the CloudFront distribution is invalidated.
+    #
+    # If the backend stack does NOT exist (first-ever deploy on a new
+    # environment), this job will fail at `Get API URL` because the CFN
+    # describe-stacks call returns no matching stack. Bootstrap the
+    # environment by running deploy-backend.yml first. Tracked as a
+    # known-limitation in docs/CI-CD-ARCHITECTURE.md.
+    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'dev'))
+    environment:
+      name: development
+      url: ${{ steps.get-frontend-url.outputs.frontend_url }}
+    outputs:
+      api_url: ${{ steps.get-url.outputs.api_url }}
+      frontend_url: ${{ steps.get-frontend-url.outputs.frontend_url }}
+
+    permissions:
+      id-token: write # Required for OIDC authentication
+      contents: read # Required to checkout code
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+          cache-dependency-path: |
+            shared-types/package-lock.json
+            frontend/package-lock.json
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-session-name: GitHubActions-LFMT-Deploy-Frontend
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Verify AWS identity
+        run: aws sts get-caller-identity
+
+      - name: Get API URL from existing stack
+        id: get-url
+        run: |
+          API_URL=$(aws cloudformation describe-stacks \
+            --stack-name LfmtPocDev \
+            --query "Stacks[0].Outputs[?OutputKey=='ApiUrl'].OutputValue" \
+            --output text \
+            --region ${{ env.AWS_REGION }})
+          if [ -z "$API_URL" ] || [ "$API_URL" = "None" ]; then
+            echo "::error::API URL not found in LfmtPocDev stack outputs. The backend stack must be deployed first via deploy-backend.yml."
+            exit 1
+          fi
+          echo "api_url=$API_URL" >> $GITHUB_OUTPUT
+          echo "API URL (from existing stack): $API_URL"
+
+      - name: Install shared-types dependencies
+        working-directory: shared-types
+        run: npm ci
+
+      - name: Build shared-types
+        working-directory: shared-types
+        run: npm run build
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Build frontend with current API URL
+        working-directory: frontend
+        run: npm run build
+        env:
+          NODE_ENV: production
+          VITE_API_URL: ${{ steps.get-url.outputs.api_url }}
+
+      - name: Get Frontend Bucket Name from CDK
+        id: get-bucket-name
+        run: |
+          FRONTEND_BUCKET=$(aws cloudformation describe-stacks \
+            --stack-name LfmtPocDev \
+            --query "Stacks[0].Outputs[?OutputKey=='FrontendBucketName'].OutputValue" \
+            --output text \
+            --region ${{ env.AWS_REGION }})
+          echo "bucket_name=$FRONTEND_BUCKET" >> $GITHUB_OUTPUT
+          echo "Frontend Bucket: $FRONTEND_BUCKET"
+
+      - name: Deploy frontend to S3
+        run: |
+          aws s3 sync frontend/dist/ s3://${{ steps.get-bucket-name.outputs.bucket_name }}/ --delete --cache-control "public, max-age=31536000, immutable" --exclude "index.html"
+          aws s3 cp frontend/dist/index.html s3://${{ steps.get-bucket-name.outputs.bucket_name }}/index.html --cache-control "public, max-age=0, must-revalidate"
+
+      - name: Get CloudFront Distribution ID
+        id: get-cf-dist
+        run: |
+          DIST_ID=$(aws cloudformation describe-stacks \
+            --stack-name LfmtPocDev \
+            --query "Stacks[0].Outputs[?OutputKey=='CloudFrontDistributionId'].OutputValue" \
+            --output text \
+            --region ${{ env.AWS_REGION }})
+          echo "distribution_id=$DIST_ID" >> $GITHUB_OUTPUT
+          echo "CloudFront Distribution ID: $DIST_ID"
+
+      - name: Get CloudFront URL
+        id: get-frontend-url
+        run: |
+          FRONTEND_URL=$(aws cloudformation describe-stacks \
+            --stack-name LfmtPocDev \
+            --query "Stacks[0].Outputs[?OutputKey=='FrontendUrl'].OutputValue" \
+            --output text \
+            --region ${{ env.AWS_REGION }})
+          echo "frontend_url=$FRONTEND_URL" >> $GITHUB_OUTPUT
+          echo "Frontend URL: $FRONTEND_URL"
+
+      - name: Invalidate CloudFront cache
+        run: |
+          aws cloudfront create-invalidation --distribution-id ${{ steps.get-cf-dist.outputs.distribution_id }} --paths "/*"
+          echo "CloudFront cache invalidation initiated"
+
+      - name: Wait for CloudFront cache invalidation
+        run: |
+          echo "Waiting for CloudFront invalidation to complete..."
+          sleep 30
+
+      - name: Validate Security Headers (Issue #62)
+        run: |
+          echo "========================================="
+          echo "Live Security Header Validation"
+          echo "========================================="
+          FRONTEND_URL="${{ steps.get-frontend-url.outputs.frontend_url }}"
+          echo "Testing URL: $FRONTEND_URL"
+          echo ""
+
+          # Fetch headers using -L to follow redirects. curl -sIL prints headers
+          # for every hop; keep only the FINAL response block (the one a browser
+          # actually sees). Splitting on blank lines (\r\n\r\n) with awk keeps
+          # the last non-empty block.
+          RAW_HEADERS=$(curl -sIL "$FRONTEND_URL")
+          HEADERS=$(printf '%s' "$RAW_HEADERS" | awk 'BEGIN{RS="\r\n\r\n"} NF{last=$0} END{print last}')
+
+          # Function to check header (case-insensitive grep so 301/302 variants
+          # and differently-cased servers don't produce false negatives).
+          check_header() {
+            local header_name="$1"
+            local header_pattern="$2"
+            local required="$3"
+
+            if echo "$HEADERS" | grep -i "^${header_name}:" > /dev/null; then
+              # SC2155: declare and assign separately so command failure isn't masked.
+              # NOTE: trim with sed, NOT xargs — xargs performs shell-style
+              # tokenization that strips single quotes (e.g. `object-src 'none'`
+              # would become `object-src none`), producing false negatives in
+              # the CSP regex checks below.
+              local header_value
+              header_value=$(echo "$HEADERS" | grep -i "^${header_name}:" | cut -d: -f2- | tr -d '\r\n' | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')
+              echo "✅ ${header_name}: ${header_value}"
+
+              if [ -n "$header_pattern" ]; then
+                if echo "$header_value" | grep -iE "$header_pattern" > /dev/null; then
+                  echo "   ✓ Pattern match: $header_pattern"
+                else
+                  echo "   ❌ Pattern mismatch: expected pattern '$header_pattern'"
+                  if [ "$required" = "true" ]; then
+                    exit 1
+                  fi
+                fi
+              fi
+            else
+              echo "❌ ${header_name}: NOT FOUND"
+              if [ "$required" = "true" ]; then
+                exit 1
+              fi
+            fi
+            echo ""
+          }
+
+          # Validate critical security headers
+          echo "Checking Security Headers:"
+          echo "─────────────────────────────────────────"
+          check_header "strict-transport-security" "max-age=" true
+          check_header "x-content-type-options" "nosniff" true
+          check_header "x-frame-options" "(DENY|SAMEORIGIN)" true
+          check_header "content-security-policy" "default-src" true
+          check_header "referrer-policy" "" false
+          check_header "x-xss-protection" "" false
+
+          echo "========================================="
+          echo "✅ All required security headers validated"
+          echo "========================================="
+
+      - name: Validate CSP Hardening (Issue #63)
+        run: |
+          echo "========================================="
+          echo "CSP Hardening Validation"
+          echo "========================================="
+          FRONTEND_URL="${{ steps.get-frontend-url.outputs.frontend_url }}"
+
+          # Fetch CSP header. -L follows redirects (final response is what a
+          # browser enforces); awk extracts the final response-headers block;
+          # grep -i is case-insensitive.
+          RAW_HEADERS=$(curl -sIL "$FRONTEND_URL")
+          FINAL_HEADERS=$(printf '%s' "$RAW_HEADERS" | awk 'BEGIN{RS="\r\n\r\n"} NF{last=$0} END{print last}')
+          # Trim with sed, NOT xargs — xargs performs shell-style tokenization
+          # that strips single quotes, so `object-src 'none'` would arrive here
+          # as `object-src none` and silently fail every quoted-directive check
+          # below. (Latent bug exposed when PR #159 first routed push-to-main
+          # into deploy-dev and the CSP step actually ran.)
+          CSP=$(echo "$FINAL_HEADERS" | grep -i "^content-security-policy:" | cut -d: -f2- | tr -d '\r\n' | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')
+
+          echo "CSP Policy: $CSP"
+          echo ""
+
+          # CSP hardening status (Issue #133):
+          #   - 'unsafe-eval' has been REMOVED from script-src (Part 2). The
+          #     production bundle was inspected and contains no eval()/Function()
+          #     calls; standard Vite + MUI/Emotion do not require it.
+          #   - 'unsafe-inline' is still permitted (style-src + script-src) and
+          #     will be removed when the nonce-injection pipeline lands
+          #     (Lambda@Edge + Emotion CacheProvider). Tracked in the Part 1
+          #     follow-up issue.
+          # We therefore validate the non-unsafe hardening directives plus the
+          # absence of 'unsafe-eval' as a regression guard.
+
+          # Check that CSP contains baseline directives
+          required_directives=("default-src" "script-src" "style-src" "connect-src")
+          for directive in "${required_directives[@]}"; do
+            if echo "$CSP" | grep -i "$directive" > /dev/null; then
+              echo "✅ PASS: CSP contains '$directive' directive"
+            else
+              echo "❌ FAIL: CSP missing '$directive' directive"
+              exit 1
+            fi
+          done
+
+          # Check that CSP contains additional hardening directives (retained
+          # from the Issue #63 pass even though 'unsafe-inline' remains).
+          hardening_directives=(
+            "object-src 'none'"
+            "base-uri 'self'"
+            "form-action 'self'"
+            "frame-ancestors 'none'"
+            "upgrade-insecure-requests"
+          )
+          for directive in "${hardening_directives[@]}"; do
+            if echo "$CSP" | grep -iF "$directive" > /dev/null; then
+              echo "✅ PASS: CSP contains hardening directive: $directive"
+            else
+              echo "❌ FAIL: CSP missing hardening directive: $directive"
+              exit 1
+            fi
+          done
+
+          # Regression guard (Issue #133 Part 2): 'unsafe-eval' must NOT appear
+          # in the script-src directive of the deployed CSP.
+          if echo "$CSP" | grep -iF "'unsafe-eval'" > /dev/null; then
+            echo "❌ FAIL: CSP contains 'unsafe-eval' (regression — Issue #133 Part 2)"
+            exit 1
+          else
+            echo "✅ PASS: CSP does not contain 'unsafe-eval' (Issue #133 Part 2)"
+          fi
+
+          echo ""
+          echo "========================================="
+          echo "✅ CSP hardening requirements met"
+          echo "========================================="
+
+      - name: Frontend Deployment Summary
+        run: |
+          echo "========================================="
+          echo "Frontend Deployment Summary"
+          echo "========================================="
+          echo "S3 Bucket: ${{ steps.get-bucket-name.outputs.bucket_name }}"
+          echo "CloudFront Distribution: ${{ steps.get-cf-dist.outputs.distribution_id }}"
+          echo "Frontend URL: ${{ steps.get-frontend-url.outputs.frontend_url }}"
+          echo "API URL (read from CFN, not deployed): ${{ steps.get-url.outputs.api_url }}"
+          echo "========================================="
+
+  production-smoke-tests:
+    name: Run Production Smoke Tests
+    runs-on: ubuntu-latest
+    needs: deploy-dev-frontend
+    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'dev'))
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Install Playwright browsers
+        working-directory: frontend
+        run: npx playwright install --with-deps chromium
+
+      - name: Wait for frontend to be ready
+        run: |
+          echo "Waiting for frontend to be ready..."
+          for i in {1..30}; do
+            if curl -sf ${{ needs.deploy-dev-frontend.outputs.frontend_url }}/ > /dev/null 2>&1; then
+              echo "Frontend is ready!"
+              exit 0
+            fi
+            echo "Attempt $i/30: Frontend not ready yet, waiting 10 seconds..."
+            sleep 10
+          done
+          echo "Proceeding with tests..."
+
+      - name: Run production smoke tests
+        working-directory: frontend
+        run: npx playwright test --grep @smoke
+        env:
+          PLAYWRIGHT_BASE_URL: ${{ needs.deploy-dev-frontend.outputs.frontend_url }}
+          API_BASE_URL: ${{ needs.deploy-dev-frontend.outputs.api_url }}
+          SMOKE_TEST_EMAIL: ${{ secrets.SMOKE_TEST_EMAIL }}
+          SMOKE_TEST_PASSWORD: ${{ secrets.SMOKE_TEST_PASSWORD }}
+          CI: true
+
+      - name: Upload smoke test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-test-report
+          path: frontend/playwright-report/
+          retention-days: 30
+
+      - name: Upload smoke test videos
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-test-videos
+          path: frontend/test-results/
+          retention-days: 7
+
+      - name: Production Smoke Test Summary
+        if: always()
+        run: |
+          echo "========================================="
+          echo "Production Smoke Test Summary"
+          echo "========================================="
+          echo "Frontend URL: ${{ needs.deploy-dev-frontend.outputs.frontend_url }}"
+          echo "API URL: ${{ needs.deploy-dev-frontend.outputs.api_url }}"
+          echo "Tests completed at: $(date -u +"%Y-%m-%d %H:%M:%S UTC")"
+          echo "========================================="
+
+  e2e-tests:
+    name: Run E2E Tests
+    runs-on: ubuntu-latest
+    needs: deploy-dev-frontend
+    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'dev'))
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Install Playwright browsers
+        working-directory: frontend
+        run: npx playwright install --with-deps chromium
+
+      - name: Wait for frontend to be ready
+        run: |
+          echo "Waiting for frontend to be ready..."
+          for i in {1..30}; do
+            if curl -sf ${{ needs.deploy-dev-frontend.outputs.frontend_url }}/ > /dev/null 2>&1; then
+              echo "Frontend is ready!"
+              exit 0
+            fi
+            echo "Attempt $i/30: Frontend not ready yet, waiting 10 seconds..."
+            sleep 10
+          done
+          echo "Proceeding with tests..."
+
+      - name: Run E2E tests
+        working-directory: frontend
+        run: npm run test:e2e
+        env:
+          PLAYWRIGHT_BASE_URL: ${{ needs.deploy-dev-frontend.outputs.frontend_url }}
+          API_BASE_URL: ${{ needs.deploy-dev-frontend.outputs.api_url }}
+          CI: true
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: frontend/playwright-report/
+          retention-days: 30
+
+      - name: Upload test videos
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-videos
+          path: frontend/test-results/
+          retention-days: 7
+
+      - name: E2E Test Summary
+        if: always()
+        run: |
+          echo "========================================="
+          echo "E2E Test Summary"
+          echo "========================================="
+          echo "Frontend URL: ${{ needs.deploy-dev-frontend.outputs.frontend_url }}"
+          echo "API URL: ${{ needs.deploy-dev-frontend.outputs.api_url }}"
+          echo "Tests completed at: $(date -u +"%Y-%m-%d %H:%M:%S UTC")"
+          echo "========================================="

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -50,6 +50,24 @@ env:
   AWS_REGION: us-east-1
   NODE_VERSION: '20'
 
+# Concurrency group (OMC perf + architect review, PR #185 follow-up):
+#
+# `shared-types/**` triggers BOTH deploy-backend.yml AND deploy-frontend.yml.
+# Without coordination, the two workflows race: this frontend pipeline can
+# read stale CloudFormation outputs (old API URL) and S3-sync a stale bundle
+# BEFORE deploy-backend.yml has finished pushing the new API.
+#
+# Both workflows share the SAME group name (`deploy-${ref}`) so GitHub Actions
+# serializes them per ref. The frontend pipeline waits for the backend
+# pipeline (or vice versa) instead of racing.
+#
+# `cancel-in-progress: false` — never abort an in-flight deploy. Aborting an
+# active S3 sync or CloudFront invalidation risks partial state. Trade-off:
+# occasional short queue wait when shared-types lands; acceptable.
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   test:
     name: Run Tests (Frontend)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,7 @@
 - **[@/docs/CLOUDFRONT-SETUP.md](docs/CLOUDFRONT-SETUP.md)** - CloudFront CDK configuration, SPA routing, security headers
 - **[@/docs/INFRASTRUCTURE-SETUP.md](docs/INFRASTRUCTURE-SETUP.md)** - AWS CDK stack, deployment workflow
 - **[@/docs/CDK-BEST-PRACTICES.md](docs/CDK-BEST-PRACTICES.md)** - CDK patterns, testing, troubleshooting
+- **[@/docs/CI-CD-ARCHITECTURE.md](docs/CI-CD-ARCHITECTURE.md)** - Split deploy pipelines (`deploy-backend.yml` + `deploy-frontend.yml`), path-filter rationale, branch-protection requirements
 
 #### Feature Implementation
 
@@ -87,8 +88,11 @@ cd frontend && npm run test:e2e
 # Deploy to dev
 cd backend/infrastructure && npx cdk deploy --context environment=dev
 
-# Manual workflow trigger
-gh workflow run deploy.yml --ref main
+# Manual workflow trigger (backend-side pipeline)
+gh workflow run deploy-backend.yml --ref main
+
+# Manual workflow trigger (frontend-side pipeline)
+gh workflow run deploy-frontend.yml --ref main
 ```
 
 ### Common Tasks

--- a/FRONTEND-DEPLOYMENT.md
+++ b/FRONTEND-DEPLOYMENT.md
@@ -478,7 +478,9 @@ aws cloudfront create-invalidation \
 
 ## Automated Deployment (GitHub Actions)
 
-For CI/CD integration, see `.github/workflows/deploy.yml` lines 203-261 for the automated deployment workflow.
+For CI/CD integration, see `.github/workflows/deploy-frontend.yml` (the
+`Deploy Frontend to Development` job) for the automated deployment workflow.
+Architectural overview: [`docs/CI-CD-ARCHITECTURE.md`](docs/CI-CD-ARCHITECTURE.md).
 
 **Workflow Trigger**: Manual dispatch or push to main branch (configurable)
 

--- a/PRODUCTION-SETUP-CHECKLIST.md
+++ b/PRODUCTION-SETUP-CHECKLIST.md
@@ -334,8 +334,9 @@ arn:aws:iam::XXXXXXXXXXXX:role/GitHubActionsLFMTProd
 # Via GitHub Actions UI:
 # https://github.com/leixiaoyu/lfmt-poc/actions
 
-# OR via CLI:
-gh workflow run deploy.yml -f environment=prod
+# OR via CLI (run BOTH; backend first, then frontend):
+gh workflow run deploy-backend.yml -f environment=prod
+gh workflow run deploy-frontend.yml -f environment=prod
 ```
 
 ### Verify Deployment
@@ -416,7 +417,7 @@ After completing manual setup:
 - **Full Deployment Guide**: `PRODUCTION-DEPLOYMENT-GUIDE.md`
 - **Security Features**: `PRODUCTION-SECURITY-DEPLOYMENT.md`
 - **Security Policy**: `SECURITY.md`
-- **GitHub Actions Workflow**: `.github/workflows/deploy.yml`
+- **GitHub Actions Workflows**: `.github/workflows/deploy-backend.yml` and `.github/workflows/deploy-frontend.yml` (split per `docs/CI-CD-ARCHITECTURE.md`)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -133,9 +133,10 @@ For detailed deployment instructions, see:
 ```
 lfmt-poc/
 ├── .github/
-│   └── workflows/          # GitHub Actions CI/CD
-│       ├── ci.yml         # Pull request testing
-│       └── deploy.yml     # Multi-environment deployment
+│   └── workflows/                # GitHub Actions CI/CD
+│       ├── ci.yml                # Pull request testing
+│       ├── deploy-backend.yml    # Backend pipeline (path-filtered: backend/**, shared-types/**)
+│       └── deploy-frontend.yml   # Frontend pipeline (path-filtered: frontend/**, shared-types/**)
 ├── backend/
 │   ├── functions/         # Lambda functions
 │   │   ├── auth/         # Authentication functions

--- a/TESTING.md
+++ b/TESTING.md
@@ -363,19 +363,26 @@ frontend/test-results/**/*.webm
    - Reason: Require live backend API
    - Status: Run manually before deployment
 
-### Deployment Workflow (`.github/workflows/deploy.yml`)
+### Deployment Workflows (`.github/workflows/deploy-backend.yml` + `deploy-frontend.yml`)
+
+The single legacy `deploy.yml` was split into two path-scoped workflows
+(see [`docs/CI-CD-ARCHITECTURE.md`](docs/CI-CD-ARCHITECTURE.md)):
+
+- `deploy-backend.yml` — triggers on `backend/**`, `shared-types/**`, or its own file.
+- `deploy-frontend.yml` — triggers on `frontend/**`, `shared-types/**`, or its own file.
 
 **Triggered On**:
 
-- Push to `main` branch (after PR merge)
+- Push to `main` branch (after PR merge), filtered by the paths above.
 
-**Steps**:
+**Combined steps (backend pipeline + frontend pipeline)**:
 
-1. Run all CI tests (same as PR workflow)
-2. Deploy backend infrastructure (CDK)
-3. Deploy Lambda functions
-4. Deploy frontend to S3/CloudFront
-5. Invalidate CloudFront cache
+1. Run all CI tests (same as PR workflow), scoped per pipeline.
+2. Deploy backend infrastructure (CDK) — `deploy-backend.yml` only.
+3. Deploy Lambda functions — `deploy-backend.yml` only.
+4. Deploy frontend to S3/CloudFront — `deploy-frontend.yml` (or
+   `deploy-backend.yml`'s post-deploy frontend rebuild after a CFN URL change).
+5. Invalidate CloudFront cache — same as above.
 
 ### ⚠️ IMPORTANT: Local vs CI Test Differences
 

--- a/backend/functions/__tests__/integration/OPTIMIZATIONS_APPLIED.md
+++ b/backend/functions/__tests__/integration/OPTIMIZATIONS_APPLIED.md
@@ -166,7 +166,7 @@ npm run test:integration
 - Performance Analysis: `PERFORMANCE_ANALYSIS.md`
 - Test Helpers: `backend/functions/__tests__/integration/helpers/test-helpers.ts`
 - Translation Flow Tests: `backend/functions/__tests__/integration/translation-flow.integration.test.ts`
-- GitHub Actions: `.github/workflows/deploy.yml`
+- GitHub Actions: `.github/workflows/deploy-backend.yml`
 
 ---
 

--- a/backend/functions/__tests__/integration/README.md
+++ b/backend/functions/__tests__/integration/README.md
@@ -315,7 +315,7 @@ Integration tests run automatically in GitHub Actions after every deployment to 
 
 ### Workflow Configuration
 
-See `.github/workflows/deploy.yml`:
+See `.github/workflows/deploy-backend.yml`:
 
 ```yaml
 integration-tests:

--- a/backend/tests/performance/README.md
+++ b/backend/tests/performance/README.md
@@ -116,7 +116,7 @@ aws stepfunctions list-executions --state-machine-arn <STATE_MACHINE_ARN>
 
 ## Integration with CI/CD
 
-Add to `.github/workflows/deploy.yml` for automated performance validation:
+Add to `.github/workflows/deploy-backend.yml` for automated performance validation:
 
 ```yaml
 - name: Run Performance Benchmark

--- a/docs/CI-CD-ARCHITECTURE.md
+++ b/docs/CI-CD-ARCHITECTURE.md
@@ -1,0 +1,177 @@
+# CI/CD Architecture
+
+This document describes how the LFMT CI/CD pipeline is structured and why.
+It is intended to be the entry point for anyone modifying GitHub Actions
+workflows in this repository.
+
+## Files
+
+| File | Purpose | Trigger |
+|---|---|---|
+| `.github/workflows/ci.yml` | PR-time gates (lint, format, type-check, full unit tests, security audit, workflow lint) | All PRs targeting `main`/`develop`; pushes to non-main branches |
+| `.github/workflows/deploy-backend.yml` | Backend deploy + API verification (CDK deploy of Lambdas/DynamoDB/API Gateway/Step Functions, smoke tests against the deployed API, integration tests) | `push` to `main` touching `backend/**`, `shared-types/**`, or the workflow file itself; `workflow_dispatch` for staging/prod |
+| `.github/workflows/deploy-frontend.yml` | Frontend deploy + browser verification (S3 sync, CloudFront invalidation, Playwright smoke + E2E) | `push` to `main` touching `frontend/**`, `shared-types/**`, or the workflow file itself; `workflow_dispatch` for manual redeploy |
+
+## Why the split (Issue #157)
+
+The deploy pipeline used to live in a single 980-line `deploy.yml`. After
+PR #154 added `frontend/**` to its `on.push.paths` (closing a real gap
+where frontend-only PRs never triggered a deploy), every CSS tweak began
+running the full backend pipeline:
+
+- Backend lint + format + tests + coverage (~3-4 min)
+- Full CDK deploy of Lambdas + DynamoDB + API Gateway + Cognito + Step
+  Functions (~5-7 min, including a no-op CloudFormation roundtrip when
+  nothing changed)
+- Backend integration tests against an unchanged API (~3-5 min)
+
+For frontend-only commits this is wasted work. The split moves frontend
+and backend onto independent, path-scoped pipelines so each commit type
+runs only what's relevant.
+
+### Performance impact
+
+| Commit type | Before | After |
+|---|---|---|
+| Backend-only | ~15-20 min (full pipeline) | ~15-20 min (deploy-backend.yml only) |
+| Frontend-only | ~15-20 min (full pipeline) | ~5-7 min (deploy-frontend.yml only) |
+| `shared-types` change | ~15-20 min (full pipeline) | ~15-20 min (both run, sequentially or in parallel) |
+
+## Shared-types contract
+
+`shared-types/**` is a path filter on BOTH workflows. A change to the
+shared types package will trigger BOTH `deploy-backend.yml` and
+`deploy-frontend.yml`. This is intentional:
+
+- Backend Lambdas import from `@lfmt/shared-types` and may need a fresh
+  bundle to reflect type changes that surface as runtime
+  serialization/deserialization differences.
+- Frontend imports the same package and similarly needs a fresh bundle.
+
+The two workflows run in parallel (no cross-workflow dependency); the
+backend's CDK deploy will rotate the API URL only if the actual
+infrastructure changed, in which case the backend's own frontend rebuild
+step (still present in `deploy-backend.yml`) handles the in-step rebuild.
+The frontend workflow's no-CDK rebuild reads the CFN-output API URL,
+so it converges on the same final state regardless of ordering.
+
+## Backend's frontend rebuild step
+
+`deploy-backend.yml`'s `deploy-dev` job still rebuilds and pushes the
+frontend at the end. This is intentional and NOT redundant with
+`deploy-frontend.yml`:
+
+- `VITE_API_URL` is a build-time variable (Vite inlines it into the
+  bundle). If a backend change rotates the API Gateway URL, the
+  in-flight frontend bundle on S3 is pointing at the old URL and would
+  fail at runtime.
+- Backend deploys must therefore rebuild the frontend bundle with the
+  fresh API URL and push it to S3 in the same workflow run, before
+  smoke/integration tests verify the new API.
+
+`deploy-frontend.yml`'s `deploy-dev-frontend` job handles the inverse
+case (frontend-only commit, no backend change): it READS the existing
+API URL from CloudFormation outputs without running `cdk deploy`, then
+rebuilds and pushes. The two paths are complementary, not duplicative.
+
+## Bootstrap order (first deploy on a new environment)
+
+`deploy-frontend.yml` does NOT run `cdk deploy`. It depends on a
+pre-existing CloudFormation stack (`LfmtPocDev` / `LfmtPocStaging` /
+`LfmtPocProd`) to read the frontend bucket name, CloudFront distribution
+ID, and API URL from. On a brand-new environment, `deploy-backend.yml`
+must run first to create the stack. If you trigger `deploy-frontend.yml`
+against an environment whose backend stack does not exist, the
+`Get API URL from existing stack` step will fail with an explicit error
+message.
+
+## Operational coordination required
+
+### Branch protection rules
+
+GitHub branch-protection identifies required status checks by job name
+string. The split changes the names of the deploy-time test jobs:
+
+| Old required check (in branch protection) | New required check(s) |
+|---|---|
+| `Run Tests` | `Run Tests (Backend)` AND `Run Tests (Frontend)` |
+| `Build Infrastructure` | `Build Infrastructure` (unchanged — still in ci.yml) |
+
+After this PR merges, a repo admin must update the main branch
+protection rule (Settings → Branches → main → Require status checks)
+to replace the single `Run Tests` requirement with the two new names
+above. Until that update happens:
+
+- The current `Run Tests` requirement will become unsatisfiable on PRs
+  (no job emits that exact name from a deploy workflow anymore — though
+  ci.yml's `Run Tests` job continues to satisfy it for PR builds, since
+  ci.yml hasn't been split).
+- The new `Run Tests (Backend)` / `Run Tests (Frontend)` checks will
+  appear on every PR but won't be enforced.
+
+The cleanest remediation is to drop `Run Tests` from required checks
+and add the two new names; ci.yml's PR-time `Run Tests` job remains
+present and will continue to run, just without being a hard gate (it
+already wasn't the historical "main gate" — `Run Tests` historically
+referred to the deploy.yml job, per CLAUDE.md memory).
+
+### Workflow-lint parity check
+
+`ci.yml`'s `workflow-lint` job runs a Python parity check that ensures
+the `deploy-dev` job and its trailing verification jobs share an
+identical `if:` expression. The check has been updated in this PR to
+iterate over BOTH `deploy-backend.yml` and `deploy-frontend.yml`
+independently. Adding a new gated verification job to either workflow
+requires updating the corresponding entry in `DEPLOY_WORKFLOWS` in
+`ci.yml`'s parity check.
+
+## Verification
+
+To verify the split is working correctly after merge:
+
+1. **Backend-only commit**: edit a file under `backend/`, commit + push.
+   Expected: only `deploy-backend.yml` runs. `deploy-frontend.yml` is
+   skipped (path filter excludes the change).
+2. **Frontend-only commit**: edit a file under `frontend/`, commit +
+   push. Expected: only `deploy-frontend.yml` runs.
+3. **Shared-types commit**: edit a file under `shared-types/`, commit +
+   push. Expected: BOTH workflows run.
+
+## Out of scope (follow-up)
+
+- **CDK noop-skip (#163)**: `deploy-backend.yml`'s `cdk deploy` runs
+  unconditionally. Adding a `cdk diff` short-circuit so noop deploys
+  finish in seconds instead of minutes is a separate optimization.
+- **Programmatic ci/deploy parity check extension (#156)**: a separate
+  issue tracks deeper parity-check scaffolding beyond the gated-job
+  condition check that ci.yml already runs.
+- **Staging/prod GHA Environments-scoped secrets**: tracked elsewhere;
+  unaffected by this split.
+
+## Drift-prevention history
+
+The deploy pipeline has had several trigger-related incidents in the
+past quarter that this split inherits and preserves:
+
+- **Issue #149**: backend lint regression deployed because deploy.yml's
+  `Run Tests` job lacked the lint step that ci.yml ran. Fixed by adding
+  parity. The split preserves the lint step in
+  `Run Tests (Backend)`.
+- **PR #152**: deploy.yml failed at `Type-check frontend` because
+  `shared-types` wasn't built before frontend type-check. Fixed by
+  adding a `Build shared-types` step. The split preserves this in both
+  `Run Tests (Backend)` (for backend type-checks) and
+  `Run Tests (Frontend)`.
+- **PR #154**: frontend-only PRs merged to main but never triggered a
+  deploy because deploy.yml's `on.push.paths` lacked `frontend/**`.
+  Fixed by adding the path. The split preserves this — frontend paths
+  are in `deploy-frontend.yml`'s trigger.
+- **PR #159**: `workflow_dispatch=dev` was inadvertently routed away
+  from deploy-dev. Fixed by adjusting the `if:` expression. The split
+  preserves the same expression in both `deploy-backend.yml`'s
+  `deploy-dev` and `deploy-frontend.yml`'s `deploy-dev-frontend`.
+
+Do NOT remove the `Build shared-types` step, the `paths:` filter, or
+the `if:` expression from either workflow without consulting this
+history. Each of these was added in response to a real production
+incident.

--- a/docs/CLOUDFRONT-SETUP.md
+++ b/docs/CLOUDFRONT-SETUP.md
@@ -247,7 +247,9 @@ new CfnOutput(this, 'FrontendUrl', {
 
 ### GitHub Actions Workflow
 
-**Location**: `.github/workflows/deploy.yml:203-261`
+**Location**: `.github/workflows/deploy-frontend.yml` (`Deploy Frontend to Development` job).
+See [`docs/CI-CD-ARCHITECTURE.md`](CI-CD-ARCHITECTURE.md) for the rationale behind the
+backend/frontend split and path-filter triggers.
 
 **Steps**:
 

--- a/docs/cdk-best-practices.md
+++ b/docs/cdk-best-practices.md
@@ -9,6 +9,12 @@ This document outlines best practices for working with AWS CDK in the LFMT proje
 - [Resource Naming](#resource-naming)
 - [Testing and Validation](#testing-and-validation)
 
+> **CI/CD pipeline architecture** (deploy workflow split, branch-protection
+> coordination, shared-types contract): see
+> [docs/CI-CD-ARCHITECTURE.md](CI-CD-ARCHITECTURE.md). The deploy pipeline
+> is split into `deploy-backend.yml` and `deploy-frontend.yml` so
+> frontend-only commits don't pay the cost of a full backend pipeline.
+
 ---
 
 ## CDK Tokens vs CloudFormation Intrinsic Functions

--- a/frontend/TRANSLATION-UI-IMPLEMENTATION-PLAN.md
+++ b/frontend/TRANSLATION-UI-IMPLEMENTATION-PLAN.md
@@ -389,7 +389,7 @@ All routes configured with lazy loading and protected routes:
 **Implementation Details**:
 
 - **CI Workflow** (`.github/workflows/ci.yml:200-252`): E2E tests run on PRs with local dev server
-- **Deploy Workflow** (`.github/workflows/deploy.yml:347-418`): E2E tests run post-deployment
+- **Deploy Workflow** (`.github/workflows/deploy-frontend.yml`, `Run E2E Tests` job): E2E tests run post-deployment
 - **Playwright Config** (`playwright.config.ts:84-89`): Auto-detects environment (local vs deployed)
 - **Test Execution**:
   - PR: `npm run test:e2e` → starts dev server on `localhost:5173`

--- a/frontend/e2e/README.md
+++ b/frontend/e2e/README.md
@@ -346,7 +346,7 @@ E2E tests are fully integrated into CI/CD pipeline:
 
 **Behavior**: Tests run against local dev server (`http://localhost:3000`) automatically started by Playwright.
 
-### Post-Deployment Testing (`.github/workflows/deploy.yml`)
+### Post-Deployment Testing (`.github/workflows/deploy-frontend.yml`)
 
 ```yaml
 - name: Run E2E tests

--- a/tests/workflows/test_deploy_path_filters.py
+++ b/tests/workflows/test_deploy_path_filters.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Programmatic path-filter check for the split deploy workflows.
+
+Created from the OMC test-automator follow-up on PR #185 (R2). This test
+asserts the structural contracts that the Issue #157 split relies on:
+
+1. Each deploy workflow's ``on.push.paths`` includes the EXPECTED globs:
+   - ``deploy-backend.yml``  -> ``backend/**`` and ``shared-types/**``
+   - ``deploy-frontend.yml`` -> ``frontend/**`` and ``shared-types/**``
+
+2. Each workflow's own file path is in its own ``on.push.paths`` trigger,
+   so editing the workflow re-runs it (otherwise a workflow change can land
+   on main without ever being executed).
+
+3. Cross-contamination check: the backend workflow does NOT trigger on
+   ``frontend/**`` and the frontend workflow does NOT trigger on
+   ``backend/**``. This is the load-bearing invariant of the split.
+
+The check is intentionally stricter than ``yaml.safe_load`` parse-success
+(which we already do elsewhere). It also complements the existing parity
+check in ``ci.yml``'s ``workflow-lint`` job, which validates the gated-job
+``if:`` expression contract within each workflow.
+
+Wired into CI from ``.github/workflows/ci.yml`` (``workflow-lint`` job).
+Run locally with::
+
+    python3 tests/workflows/test_deploy_path_filters.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Iterable
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+# Expected (workflow_path -> {required_path_glob, ...}) contracts.
+EXPECTED: dict[str, set[str]] = {
+    ".github/workflows/deploy-backend.yml": {
+        "backend/**",
+        "shared-types/**",
+        ".github/workflows/deploy-backend.yml",
+    },
+    ".github/workflows/deploy-frontend.yml": {
+        "frontend/**",
+        "shared-types/**",
+        ".github/workflows/deploy-frontend.yml",
+    },
+}
+
+# Cross-contamination forbidden globs: workflow_path -> globs that MUST
+# NOT appear (so the path filters do not over-trigger).
+FORBIDDEN: dict[str, set[str]] = {
+    ".github/workflows/deploy-backend.yml": {"frontend/**"},
+    ".github/workflows/deploy-frontend.yml": {"backend/**"},
+}
+
+
+def _load_paths(workflow_path: Path) -> list[str]:
+    """Return the ``on.push.paths`` list from a workflow YAML.
+
+    Handles a YAML quirk: the unquoted bareword ``on:`` parses as the boolean
+    ``True`` under PyYAML (because YAML 1.1 treats ``on``/``off``/``yes``/``no``
+    as booleans). We accept both the ``True`` key (real-world) and the string
+    ``"on"`` key (in case someone quotes it for clarity).
+    """
+    with workflow_path.open() as f:
+        wf = yaml.safe_load(f)
+
+    on_block = wf.get(True, wf.get("on"))
+    if on_block is None:
+        raise AssertionError(
+            f"{workflow_path}: missing 'on:' block (got top-level keys: {list(wf)})"
+        )
+
+    push = on_block.get("push") if isinstance(on_block, dict) else None
+    if push is None:
+        raise AssertionError(f"{workflow_path}: 'on.push' block missing")
+
+    paths = push.get("paths")
+    if not isinstance(paths, list):
+        raise AssertionError(
+            f"{workflow_path}: 'on.push.paths' missing or not a list (got {type(paths).__name__})"
+        )
+
+    return paths
+
+
+def _check_required(workflow_path: str, paths: Iterable[str], required: set[str]) -> list[str]:
+    failures: list[str] = []
+    paths_set = set(paths)
+    missing = required - paths_set
+    if missing:
+        failures.append(
+            f"{workflow_path}: missing required path glob(s) in on.push.paths: "
+            f"{sorted(missing)} (have: {sorted(paths_set)})"
+        )
+    return failures
+
+
+def _check_forbidden(workflow_path: str, paths: Iterable[str], forbidden: set[str]) -> list[str]:
+    failures: list[str] = []
+    leak = forbidden & set(paths)
+    if leak:
+        failures.append(
+            f"{workflow_path}: forbidden path glob(s) present in on.push.paths "
+            f"(would over-trigger across the split): {sorted(leak)}"
+        )
+    return failures
+
+
+def main() -> int:
+    failures: list[str] = []
+
+    for rel, required in EXPECTED.items():
+        wf_path = REPO_ROOT / rel
+        if not wf_path.exists():
+            failures.append(f"{rel}: workflow file does not exist at {wf_path}")
+            continue
+
+        try:
+            paths = _load_paths(wf_path)
+        except AssertionError as exc:
+            failures.append(str(exc))
+            continue
+
+        failures.extend(_check_required(rel, paths, required))
+        failures.extend(_check_forbidden(rel, paths, FORBIDDEN.get(rel, set())))
+
+        if not any(rel in f for f in failures):
+            print(f"OK ({rel}): on.push.paths = {paths}")
+
+    if failures:
+        print("\nPath-filter contract violations:", file=sys.stderr)
+        for f in failures:
+            # GitHub Actions error annotation: surfaces in the run summary.
+            print(f"::error::{f}", file=sys.stderr)
+        return 1
+
+    print("\nAll deploy workflow path-filter contracts satisfied.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #157.

## Summary

Splits the monolithic 1,038-line `.github/workflows/deploy.yml` into two
path-scoped workflows so backend-only commits stop paying the cost of
running Playwright E2E and frontend-only commits stop paying the cost of
running CDK + integration tests.

- `deploy-backend.yml` (738 lines): triggers on `backend/**`,
  `shared-types/**`, the workflow file itself. Jobs: `Run Tests (Backend)`,
  `Deploy Backend to Development`, `Run API Smoke Tests`,
  `Run Backend Integration Tests`, `Deploy Backend to Staging`,
  `Deploy Backend to Production`.
- `deploy-frontend.yml` (560 lines): triggers on `frontend/**`,
  `shared-types/**`, the workflow file itself. Jobs: `Run Tests (Frontend)`,
  `Deploy Frontend to Development`, `Run Production Smoke Tests`,
  `Run E2E Tests`. The deploy job does NOT run `cdk deploy` — it reads
  the existing API URL / bucket / distribution from CFN outputs and
  rebuilds + S3-syncs only.
- `shared-types/**` triggers BOTH workflows, by design.

## Corrections (OMC perf review, 2026-04-28)

The original PR body claimed "frontend-only commits go from ~20 min full
pipeline to ~5-7 min." That number was wrong. Per the perf reviewer's
measurement across 30 historical runs:

- **Frontend-only commit**: full pipeline savings are **~2-4 minutes**,
  not 13-15 minutes. Playwright E2E (the dominant cost at 36-42 min)
  still runs in `deploy-frontend.yml`. The win on this path is mainly
  removing the noop CDK deploy + backend integration tests.
- **Backend-only commit**: this is the actual big win — saves
  **~37-50 minutes** by skipping Playwright E2E entirely. The original
  PR body undersold this case.
- **GHA cost savings**: $0. Repo is public, so GitHub Actions minutes
  are free. This change is a **DX win, not a cost win** — fewer red
  herrings on backend-only PRs, faster feedback on the typical path.

## Acceptance criteria status (#157)

| Criterion | Status |
|---|---|
| `deploy.yml` deleted; replaced by `deploy-backend.yml` and `deploy-frontend.yml` | DONE |
| Each file's `on.push.paths` correctly scoped (backend/shared-types vs. frontend/shared-types) | DONE |
| Branch protection rules updated to require the new check names | DEFERRED — operational, see below |
| Architectural comment block (currently in `deploy.yml` lines 32-55) preserved — split or duplicated into both new files | DONE — adapted into both `Run Tests` jobs |
| Documented in `docs/CDK-BEST-PRACTICES.md` or a new `docs/CI-CD-ARCHITECTURE.md` | DONE — new `docs/CI-CD-ARCHITECTURE.md` + cross-link from `docs/cdk-best-practices.md` |
| Verified by triggering: (a) backend-only, (b) frontend-only, (c) shared-types | DEFERRED to post-merge — see verification plan below |
| No regression: all current `deploy.yml` functionality preserved | DONE — incident-driven safeguards (Issues #149, #152, #154, #159) all preserved across the split |

## OMC review follow-up (commit c696abb on this branch)

Four in-PR fixes applied per the consolidated OMC review:

- **Fix 1 (architect, BLOCKING)** — Updated stale `deploy.yml`
  references in active docs (CLAUDE.md, README, TESTING.md,
  FRONTEND-DEPLOYMENT.md, PRODUCTION-SETUP-CHECKLIST.md,
  docs/CLOUDFRONT-SETUP.md, frontend + backend READMEs) to point at
  the new workflow filenames. Linked `docs/CI-CD-ARCHITECTURE.md`
  from CLAUDE.md's Tier-2 docs index. Historical docs
  (`openspec/changes/**`, `docs/archive/**`) intentionally left as-is.
- **Fix 2 (perf)** — This PR body, corrected above.
- **Fix 3 (perf + architect)** — Added a SHARED concurrency group
  (`deploy-${{ github.ref }}`) to both `deploy-backend.yml` and
  `deploy-frontend.yml` so `shared-types/**` commits serialize the
  two pipelines (eliminates the race where the frontend pipeline
  S3-syncs a stale bundle before the backend pipeline finishes
  pushing the new API URL). `cancel-in-progress: false` to never
  abort an in-flight deploy.
- **Fix 4 (test-automator)** — Added
  `tests/workflows/test_deploy_path_filters.py` which parses both
  workflows and asserts the `on.push.paths` contracts (required globs,
  forbidden cross-contamination globs, own-file self-trigger). Wired
  into `ci.yml`'s `workflow-lint` job.

Follow-ups filed:
- #186 — auto-discover deploy workflows in ci.yml parity check
- #187 — extract frontend-rebuild composite action (DRY the 4-place
  "read CFN -> rebuild -> sync -> invalidate" pattern)

## OPERATIONAL FOLLOW-UP REQUIRED (repo admin)

GitHub branch-protection identifies required status checks by job name
string. The split renames the deploy-time test job, so the branch
protection rule on `main` must be updated by an admin AFTER merge:

**Settings -> Branches -> main -> Require status checks**

| Action | Check name |
|---|---|
| Remove | `Run Tests` (was the deploy.yml job name; no longer exists in any deploy workflow) |
| Add | `Run Tests (Backend)` |
| Add | `Run Tests (Frontend)` |
| Keep | `Build Infrastructure` (ci.yml, unchanged) |

(Note: ci.yml's PR-time `Run Tests` job still exists and continues to
run on every PR. Per CLAUDE.md memory, the historical required `Run Tests`
check has always tracked the deploy workflow's job name, not ci.yml's,
so there is no regression in PR-time enforcement.)

Until this update happens, the new `Run Tests (Backend)` /
`Run Tests (Frontend)` checks will appear on every PR but won't be
hard-required, and the old `Run Tests` requirement will become
unsatisfiable for the deploy half of the matrix.

## ci.yml workflow-lint parity check

The existing parity check in `.github/workflows/ci.yml` hardcoded
`deploy.yml` and would have crashed on first run after this PR
merges. Extended in this PR to iterate over both deploy workflows
independently. Each workflow's deploy-dev cascade still must share an
identical `if:` expression internally; the cascades across files
are independent. Verified locally — both pass.

PR #185 follow-up commit also adds a separate path-filter contract
test that runs alongside the parity check.

## Test plan (post-merge verification)

The user should observe each of the following on the merged main:

- [ ] **Backend-only commit** (e.g., touch a file under `backend/`):
  expected: only `deploy-backend.yml` runs; `deploy-frontend.yml`
  is skipped (path filter excludes the change).
- [ ] **Frontend-only commit** (e.g., touch a file under `frontend/`):
  expected: only `deploy-frontend.yml` runs; `deploy-backend.yml`
  is skipped.
- [ ] **shared-types commit** (e.g., touch a file under `shared-types/`):
  expected: BOTH workflows run, AND they serialize via the shared
  `concurrency.group: deploy-${{ github.ref }}` (one queues until the
  other finishes).
- [ ] **First-ever fresh-environment scenario**: `deploy-frontend.yml`
  fails fast with an explicit error if the backend stack does not exist.
  (Documented in `docs/CI-CD-ARCHITECTURE.md`; bootstrap by running
  `deploy-backend.yml` first.)
- [ ] **Branch protection update**: after admin updates the required
  checks, open a no-op PR and verify `Run Tests (Backend)` and
  `Run Tests (Frontend)` block merge.

## Out of scope (per #157)

- `cdk diff` short-circuit for backend noop deploys (#163).
- Deeper programmatic ci/deploy parity check extension (#156, also
  see follow-up #186).
- Migrating staging/prod to GHA Environments-scoped secrets (already
  tracked elsewhere).

## Verification done in this PR

- YAML parses for `deploy-backend.yml`, `deploy-frontend.yml`,
  `ci.yml` (Python yaml.safe_load).
- Parity check passes locally for both gated cascades; both share the
  identical condition `github.ref == 'refs/heads/main' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'dev'))`.
- New path-filter test (`tests/workflows/test_deploy_path_filters.py`)
  passes locally for both workflows.
- actionlint not installed locally — relying on CI's `workflow-lint`
  job to catch any GH Actions expression / shellcheck issues.