### PR TITLE
fix(e2e): correct checkbox selectors in smoke test — production smoke locator.check timeout

### DIFF
--- a/frontend/e2e/pages/TranslationUploadPage.ts
+++ b/frontend/e2e/pages/TranslationUploadPage.ts
@@ -16,6 +16,7 @@
 
 import { Page, expect } from '@playwright/test';
 import { BasePage } from './BasePage';
+import { LEGAL_ATTESTATION_LABEL_PATTERNS as L } from '../../src/components/Translation/legalAttestationLabels';
 
 export class TranslationUploadPage extends BasePage {
   // Locators
@@ -64,7 +65,14 @@ export class TranslationUploadPage extends BasePage {
   }
 
   /**
-   * Complete legal attestation step
+   * Complete legal attestation step using CSS `[name]` attribute selectors.
+   *
+   * The `[name="acceptCopyrightOwnership"]` etc. selectors target the HTML
+   * `name` attribute on the underlying `<input>` element — not the accessible
+   * name — so they remain correct and do not need to match the label text.
+   * For role-based (accessible-name) selection see `completeLegalAttestationByRole`.
+   *
+   * @see completeLegalAttestationByRole
    */
   async completeLegalAttestation() {
     await this.clickElement(this.copyrightCheckbox);
@@ -154,24 +162,26 @@ export class TranslationUploadPage extends BasePage {
 
   /**
    * Tick the three required attestation checkboxes and advance to the
-   * Translation Settings step. Returns when the target-language control
-   * is visible (handshake that step 1 has rendered).
+   * Translation Settings step using role-based accessible-name locators.
+   * Returns when the target-language control is visible (handshake that
+   * step 1 has rendered).
    *
-   * Accessible names are computed from the <FormControlLabel> label text
-   * rendered by LegalAttestation.tsx — verified against the unit tests in
-   * frontend/src/components/Translation/__tests__/LegalAttestation.test.tsx.
-   * The previous patterns (/copyright ownership/, /translation rights/,
-   * /liability/) did not appear anywhere in the rendered label strings,
-   * causing locator.check to wait the full 180 s timeout on every run.
+   * Patterns are imported from `legalAttestationLabels.ts` — the single
+   * source of truth for accessible-name substrings — so a label change in
+   * `LegalAttestation.tsx` surfaces as a test failure here rather than a
+   * silent 180 s timeout (see PR #189 for background).
+   *
+   * This method drives the same DOM as `completeLegalAttestation()`, which
+   * uses `[name="..."]` attribute selectors instead of accessible names.
+   * Both are correct; the `[name]` selectors target the HTML attribute on
+   * the `<input>`, not the label text, so they do not need label patterns.
+   *
+   * @see completeLegalAttestation
    */
   async completeLegalAttestationByRole(timeout = 10000) {
-    await this.page.getByRole('checkbox', { name: /I confirm that I own the copyright/i }).check();
-    await this.page
-      .getByRole('checkbox', { name: /I confirm that I have the right to create derivative works/i })
-      .check();
-    await this.page
-      .getByRole('checkbox', { name: /I understand that I am solely responsible/i })
-      .check();
+    await this.page.getByRole('checkbox', { name: L.copyright }).check();
+    await this.page.getByRole('checkbox', { name: L.translationRights }).check();
+    await this.page.getByRole('checkbox', { name: L.liability }).check();
 
     await this.page.getByRole('button', { name: /next/i }).click();
     await expect(this.page.getByLabel(/target.*language/i)).toBeVisible({ timeout });

--- a/frontend/e2e/pages/TranslationUploadPage.ts
+++ b/frontend/e2e/pages/TranslationUploadPage.ts
@@ -156,11 +156,22 @@ export class TranslationUploadPage extends BasePage {
    * Tick the three required attestation checkboxes and advance to the
    * Translation Settings step. Returns when the target-language control
    * is visible (handshake that step 1 has rendered).
+   *
+   * Accessible names are computed from the <FormControlLabel> label text
+   * rendered by LegalAttestation.tsx — verified against the unit tests in
+   * frontend/src/components/Translation/__tests__/LegalAttestation.test.tsx.
+   * The previous patterns (/copyright ownership/, /translation rights/,
+   * /liability/) did not appear anywhere in the rendered label strings,
+   * causing locator.check to wait the full 180 s timeout on every run.
    */
   async completeLegalAttestationByRole(timeout = 10000) {
-    await this.page.getByRole('checkbox', { name: /copyright ownership/i }).check();
-    await this.page.getByRole('checkbox', { name: /translation rights/i }).check();
-    await this.page.getByRole('checkbox', { name: /liability/i }).check();
+    await this.page.getByRole('checkbox', { name: /I confirm that I own the copyright/i }).check();
+    await this.page
+      .getByRole('checkbox', { name: /I confirm that I have the right to create derivative works/i })
+      .check();
+    await this.page
+      .getByRole('checkbox', { name: /I understand that I am solely responsible/i })
+      .check();
 
     await this.page.getByRole('button', { name: /next/i }).click();
     await expect(this.page.getByLabel(/target.*language/i)).toBeVisible({ timeout });

--- a/frontend/e2e/tests/translation/legal-attestation.spec.ts
+++ b/frontend/e2e/tests/translation/legal-attestation.spec.ts
@@ -15,6 +15,7 @@ import { DashboardPage } from '../../pages/DashboardPage';
 import { TranslationUploadPage } from '../../pages/TranslationUploadPage';
 import { generateTestUser } from '../../fixtures/auth';
 import { TEST_DOCUMENTS } from '../../fixtures/test-documents';
+import { LEGAL_ATTESTATION_LABEL_PATTERNS as L } from '../../src/components/Translation/legalAttestationLabels';
 import * as fs from 'fs';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
@@ -83,10 +84,10 @@ test.describe('Legal Attestation Enforcement', () => {
     await expect(rightsCheckbox).toBeVisible();
     await expect(liabilityCheckbox).toBeVisible();
 
-    // Verify labels are descriptive
-    await expect(page.locator('text=/copyright ownership/i')).toBeVisible();
-    await expect(page.locator('text=/translation rights/i')).toBeVisible();
-    await expect(page.locator('text=/liability/i')).toBeVisible();
+    // Verify labels are descriptive — patterns sourced from legalAttestationLabels.ts
+    await expect(page.getByRole('checkbox', { name: L.copyright })).toBeVisible();
+    await expect(page.getByRole('checkbox', { name: L.translationRights })).toBeVisible();
+    await expect(page.getByRole('checkbox', { name: L.liability })).toBeVisible();
   });
 
   test('should have all checkboxes unchecked by default', async ({ page }) => {
@@ -312,11 +313,11 @@ test.describe('Legal Attestation Enforcement', () => {
   });
 
   test('should display legal text with important terms highlighted', async ({ page }) => {
-    // Verify key legal terms are visible
-    await expect(page.locator('text=/I certify that I am the copyright owner/i')).toBeVisible();
-    await expect(
-      page.locator('text=/I have the legal right to create translations/i')
-    ).toBeVisible();
-    await expect(page.locator('text=/I accept full liability/i')).toBeVisible();
+    // Verify the actual rendered label text is visible for each checkbox.
+    // Patterns come from legalAttestationLabels.ts (the single source of truth)
+    // so a label change in LegalAttestation.tsx surfaces here immediately.
+    await expect(page.getByRole('checkbox', { name: L.copyright })).toBeVisible();
+    await expect(page.getByRole('checkbox', { name: L.translationRights })).toBeVisible();
+    await expect(page.getByRole('checkbox', { name: L.liability })).toBeVisible();
   });
 });

--- a/frontend/src/components/Translation/__tests__/LegalAttestation.test.tsx
+++ b/frontend/src/components/Translation/__tests__/LegalAttestation.test.tsx
@@ -12,6 +12,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen, waitFor } from '../../../test-utils';
 import userEvent from '@testing-library/user-event';
 import { LegalAttestation, LegalAttestationData } from '../LegalAttestation';
+import { LEGAL_ATTESTATION_LABEL_PATTERNS as L } from '../legalAttestationLabels';
 
 describe('LegalAttestation Component', () => {
   const defaultValue: LegalAttestationData = {
@@ -45,12 +46,12 @@ describe('LegalAttestation Component', () => {
       expect(checkboxes).toHaveLength(3);
 
       // Verify specific checkboxes by their labels
-      expect(screen.getByLabelText(/I confirm that I own the copyright/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(L.copyright)).toBeInTheDocument();
       expect(
-        screen.getByLabelText(/I confirm that I have the right to create derivative works/i)
+        screen.getByLabelText(L.translationRights)
       ).toBeInTheDocument();
       expect(
-        screen.getByLabelText(/I understand that I am solely responsible/i)
+        screen.getByLabelText(L.liability)
       ).toBeInTheDocument();
     });
 
@@ -121,7 +122,7 @@ describe('LegalAttestation Component', () => {
       const mockOnChange = vi.fn();
       render(<LegalAttestation {...createProps({ onChange: mockOnChange })} />);
 
-      const checkbox = screen.getByLabelText(/I confirm that I own the copyright/i);
+      const checkbox = screen.getByLabelText(L.copyright);
 
       // Act
       await user.click(checkbox);
@@ -142,7 +143,7 @@ describe('LegalAttestation Component', () => {
       render(<LegalAttestation {...createProps({ onChange: mockOnChange })} />);
 
       const checkbox = screen.getByLabelText(
-        /I confirm that I have the right to create derivative works/i
+        L.translationRights
       );
 
       // Act
@@ -163,7 +164,7 @@ describe('LegalAttestation Component', () => {
       const mockOnChange = vi.fn();
       render(<LegalAttestation {...createProps({ onChange: mockOnChange })} />);
 
-      const checkbox = screen.getByLabelText(/I understand that I am solely responsible/i);
+      const checkbox = screen.getByLabelText(L.liability);
 
       // Act
       await user.click(checkbox);
@@ -191,7 +192,7 @@ describe('LegalAttestation Component', () => {
         <LegalAttestation {...createProps({ value: checkedValue, onChange: mockOnChange })} />
       );
 
-      const checkbox = screen.getByLabelText(/I confirm that I own the copyright/i);
+      const checkbox = screen.getByLabelText(L.copyright);
 
       // Act
       await user.click(checkbox);
@@ -406,7 +407,7 @@ describe('LegalAttestation Component', () => {
       render(<LegalAttestation {...createProps()} />);
 
       // Assert
-      const checkbox = screen.getByLabelText(/I confirm that I own the copyright/i);
+      const checkbox = screen.getByLabelText(L.copyright);
       expect(checkbox).toHaveAttribute('name', 'acceptCopyrightOwnership');
     });
 
@@ -416,7 +417,7 @@ describe('LegalAttestation Component', () => {
 
       // Assert
       const checkbox = screen.getByLabelText(
-        /I confirm that I have the right to create derivative works/i
+        L.translationRights
       );
       expect(checkbox).toHaveAttribute('name', 'acceptTranslationRights');
     });
@@ -426,7 +427,7 @@ describe('LegalAttestation Component', () => {
       render(<LegalAttestation {...createProps()} />);
 
       // Assert
-      const checkbox = screen.getByLabelText(/I understand that I am solely responsible/i);
+      const checkbox = screen.getByLabelText(L.liability);
       expect(checkbox).toHaveAttribute('name', 'acceptLiabilityTerms');
     });
   });
@@ -439,11 +440,11 @@ describe('LegalAttestation Component', () => {
       render(<LegalAttestation {...createProps({ onChange: mockOnChange })} />);
 
       // Act - Check all boxes
-      await user.click(screen.getByLabelText(/I confirm that I own the copyright/i));
+      await user.click(screen.getByLabelText(L.copyright));
       await user.click(
-        screen.getByLabelText(/I confirm that I have the right to create derivative works/i)
+        screen.getByLabelText(L.translationRights)
       );
-      await user.click(screen.getByLabelText(/I understand that I am solely responsible/i));
+      await user.click(screen.getByLabelText(L.liability));
 
       // Assert
       expect(mockOnChange).toHaveBeenCalledTimes(3);
@@ -481,9 +482,53 @@ describe('LegalAttestation Component', () => {
 
       // Assert - Checkbox state should remain
       const checkbox = screen.getByLabelText(
-        /I confirm that I own the copyright/i
+        L.copyright
       ) as HTMLInputElement;
       expect(checkbox.checked).toBe(true);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Label contract tests
+  //
+  // These tests are the safety net that would have caught the original
+  // production smoke timeout (PR #189) at unit-test speed.  They assert
+  // that each pattern in LEGAL_ATTESTATION_LABEL_PATTERNS resolves to
+  // exactly one visible checkbox, keeping the patterns and the rendered
+  // labels in sync.  If a label changes in LegalAttestation.tsx these
+  // tests fail immediately (milliseconds) rather than after a 180 s
+  // production smoke timeout.
+  // -----------------------------------------------------------------------
+  describe('label contract', () => {
+    it('renders exactly one checkbox matching the copyright pattern', () => {
+      render(<LegalAttestation {...createProps()} />);
+
+      const matches = screen.getAllByRole('checkbox').filter((el) =>
+        L.copyright.test(el.getAttribute('aria-label') ?? el.closest('label')?.textContent ?? '')
+      );
+      // If this assertion fails, update legalAttestationLabels.ts to match
+      // the new label text in LegalAttestation.tsx.
+      expect(matches).toHaveLength(1);
+    });
+
+    it('renders exactly one checkbox matching the translationRights pattern', () => {
+      render(<LegalAttestation {...createProps()} />);
+
+      const matches = screen.getAllByRole('checkbox').filter((el) =>
+        L.translationRights.test(
+          el.getAttribute('aria-label') ?? el.closest('label')?.textContent ?? ''
+        )
+      );
+      expect(matches).toHaveLength(1);
+    });
+
+    it('renders exactly one checkbox matching the liability pattern', () => {
+      render(<LegalAttestation {...createProps()} />);
+
+      const matches = screen.getAllByRole('checkbox').filter((el) =>
+        L.liability.test(el.getAttribute('aria-label') ?? el.closest('label')?.textContent ?? '')
+      );
+      expect(matches).toHaveLength(1);
     });
   });
 });

--- a/frontend/src/components/Translation/__tests__/LegalAttestation.test.tsx
+++ b/frontend/src/components/Translation/__tests__/LegalAttestation.test.tsx
@@ -47,12 +47,8 @@ describe('LegalAttestation Component', () => {
 
       // Verify specific checkboxes by their labels
       expect(screen.getByLabelText(L.copyright)).toBeInTheDocument();
-      expect(
-        screen.getByLabelText(L.translationRights)
-      ).toBeInTheDocument();
-      expect(
-        screen.getByLabelText(L.liability)
-      ).toBeInTheDocument();
+      expect(screen.getByLabelText(L.translationRights)).toBeInTheDocument();
+      expect(screen.getByLabelText(L.liability)).toBeInTheDocument();
     });
 
     it('should render info alert message', () => {
@@ -142,9 +138,7 @@ describe('LegalAttestation Component', () => {
       const mockOnChange = vi.fn();
       render(<LegalAttestation {...createProps({ onChange: mockOnChange })} />);
 
-      const checkbox = screen.getByLabelText(
-        L.translationRights
-      );
+      const checkbox = screen.getByLabelText(L.translationRights);
 
       // Act
       await user.click(checkbox);
@@ -416,9 +410,7 @@ describe('LegalAttestation Component', () => {
       render(<LegalAttestation {...createProps()} />);
 
       // Assert
-      const checkbox = screen.getByLabelText(
-        L.translationRights
-      );
+      const checkbox = screen.getByLabelText(L.translationRights);
       expect(checkbox).toHaveAttribute('name', 'acceptTranslationRights');
     });
 
@@ -441,9 +433,7 @@ describe('LegalAttestation Component', () => {
 
       // Act - Check all boxes
       await user.click(screen.getByLabelText(L.copyright));
-      await user.click(
-        screen.getByLabelText(L.translationRights)
-      );
+      await user.click(screen.getByLabelText(L.translationRights));
       await user.click(screen.getByLabelText(L.liability));
 
       // Assert
@@ -481,9 +471,7 @@ describe('LegalAttestation Component', () => {
       expect(mockOnChange).not.toHaveBeenCalled();
 
       // Assert - Checkbox state should remain
-      const checkbox = screen.getByLabelText(
-        L.copyright
-      ) as HTMLInputElement;
+      const checkbox = screen.getByLabelText(L.copyright) as HTMLInputElement;
       expect(checkbox.checked).toBe(true);
     });
   });
@@ -503,9 +491,11 @@ describe('LegalAttestation Component', () => {
     it('renders exactly one checkbox matching the copyright pattern', () => {
       render(<LegalAttestation {...createProps()} />);
 
-      const matches = screen.getAllByRole('checkbox').filter((el) =>
-        L.copyright.test(el.getAttribute('aria-label') ?? el.closest('label')?.textContent ?? '')
-      );
+      const matches = screen
+        .getAllByRole('checkbox')
+        .filter((el) =>
+          L.copyright.test(el.getAttribute('aria-label') ?? el.closest('label')?.textContent ?? '')
+        );
       // If this assertion fails, update legalAttestationLabels.ts to match
       // the new label text in LegalAttestation.tsx.
       expect(matches).toHaveLength(1);
@@ -514,20 +504,24 @@ describe('LegalAttestation Component', () => {
     it('renders exactly one checkbox matching the translationRights pattern', () => {
       render(<LegalAttestation {...createProps()} />);
 
-      const matches = screen.getAllByRole('checkbox').filter((el) =>
-        L.translationRights.test(
-          el.getAttribute('aria-label') ?? el.closest('label')?.textContent ?? ''
-        )
-      );
+      const matches = screen
+        .getAllByRole('checkbox')
+        .filter((el) =>
+          L.translationRights.test(
+            el.getAttribute('aria-label') ?? el.closest('label')?.textContent ?? ''
+          )
+        );
       expect(matches).toHaveLength(1);
     });
 
     it('renders exactly one checkbox matching the liability pattern', () => {
       render(<LegalAttestation {...createProps()} />);
 
-      const matches = screen.getAllByRole('checkbox').filter((el) =>
-        L.liability.test(el.getAttribute('aria-label') ?? el.closest('label')?.textContent ?? '')
-      );
+      const matches = screen
+        .getAllByRole('checkbox')
+        .filter((el) =>
+          L.liability.test(el.getAttribute('aria-label') ?? el.closest('label')?.textContent ?? '')
+        );
       expect(matches).toHaveLength(1);
     });
   });

--- a/frontend/src/components/Translation/legalAttestationLabels.ts
+++ b/frontend/src/components/Translation/legalAttestationLabels.ts
@@ -1,0 +1,49 @@
+/**
+ * Legal Attestation Label Patterns — single source of truth.
+ *
+ * Each pattern is a stable leading substring of the corresponding
+ * <FormControlLabel> text rendered by LegalAttestation.tsx.  Consumers
+ * (unit tests, Vitest contract tests, Playwright page objects) import
+ * from here so that a label change in LegalAttestation.tsx causes a
+ * compile-time / test-time failure in the same commit rather than a
+ * silent 3-minute CI timeout.
+ *
+ * Background: PR #189 fixed a production smoke test (locator.check
+ * 180 s timeout) caused by page-object patterns that did not match the
+ * actual rendered text.  This module is the preventive measure
+ * recommended in that PR's OMC review.
+ *
+ * Usage:
+ *   import { LEGAL_ATTESTATION_LABEL_PATTERNS as L } from
+ *     'src/components/Translation/legalAttestationLabels';
+ *
+ *   // Playwright
+ *   page.getByRole('checkbox', { name: L.copyright })
+ *
+ *   // Testing Library
+ *   screen.getByLabelText(L.copyright)
+ */
+
+export const LEGAL_ATTESTATION_LABEL_PATTERNS = {
+  /**
+   * Matches the copyright-ownership checkbox label:
+   * "I confirm that I own the copyright to this document or have
+   *  authorization from the copyright holder to translate it"
+   */
+  copyright: /I confirm that I own the copyright/i,
+
+  /**
+   * Matches the translation-rights checkbox label:
+   * "I confirm that I have the right to create derivative works
+   *  (translations) from this document"
+   */
+  translationRights: /I confirm that I have the right to create derivative works/i,
+
+  /**
+   * Matches the liability checkbox label:
+   * "I understand that I am solely responsible for ensuring I have the
+   *  legal right to translate this document, and I indemnify LFMT from
+   *  any copyright claims"
+   */
+  liability: /I understand that I am solely responsible/i,
+} as const;

--- a/frontend/src/pages/__tests__/TranslationUpload.test.tsx
+++ b/frontend/src/pages/__tests__/TranslationUpload.test.tsx
@@ -142,9 +142,7 @@ describe('TranslationUpload', () => {
 
       // Check all three checkboxes
       const copyrightCheckbox = screen.getByLabelText(L.copyright);
-      const translationRightsCheckbox = screen.getByLabelText(
-        L.translationRights
-      );
+      const translationRightsCheckbox = screen.getByLabelText(L.translationRights);
       const liabilityCheckbox = screen.getByLabelText(L.liability);
 
       await user.click(copyrightCheckbox);
@@ -165,9 +163,7 @@ describe('TranslationUpload', () => {
   describe('Step 2: Translation Settings Validation', () => {
     const advanceToStep2 = async (user: ReturnType<typeof userEvent.setup>) => {
       const copyrightCheckbox = screen.getByLabelText(L.copyright);
-      const translationRightsCheckbox = screen.getByLabelText(
-        L.translationRights
-      );
+      const translationRightsCheckbox = screen.getByLabelText(L.translationRights);
       const liabilityCheckbox = screen.getByLabelText(L.liability);
 
       await user.click(copyrightCheckbox);
@@ -240,9 +236,7 @@ describe('TranslationUpload', () => {
     const advanceToStep3 = async (user: ReturnType<typeof userEvent.setup>) => {
       // Step 1: Legal attestation
       const copyrightCheckbox = screen.getByLabelText(L.copyright);
-      const translationRightsCheckbox = screen.getByLabelText(
-        L.translationRights
-      );
+      const translationRightsCheckbox = screen.getByLabelText(L.translationRights);
       const liabilityCheckbox = screen.getByLabelText(L.liability);
 
       await user.click(copyrightCheckbox);
@@ -313,9 +307,7 @@ describe('TranslationUpload', () => {
     const advanceToStep4 = async (user: ReturnType<typeof userEvent.setup>) => {
       // Step 1: Legal attestation
       await user.click(screen.getByLabelText(L.copyright));
-      await user.click(
-        screen.getByLabelText(L.translationRights)
-      );
+      await user.click(screen.getByLabelText(L.translationRights));
       await user.click(screen.getByLabelText(L.liability));
       await user.click(screen.getByRole('button', { name: /next/i }));
 
@@ -536,9 +528,7 @@ describe('TranslationUpload', () => {
 
       // Step 1: Check legal attestation
       await user.click(screen.getByLabelText(L.copyright));
-      await user.click(
-        screen.getByLabelText(L.translationRights)
-      );
+      await user.click(screen.getByLabelText(L.translationRights));
       await user.click(screen.getByLabelText(L.liability));
       await user.click(screen.getByRole('button', { name: /next/i }));
 
@@ -550,9 +540,7 @@ describe('TranslationUpload', () => {
       await user.click(screen.getByRole('button', { name: /back/i }));
 
       await waitFor(() => {
-        const copyrightCheckbox = screen.getByLabelText(
-          L.copyright
-        ) as HTMLInputElement;
+        const copyrightCheckbox = screen.getByLabelText(L.copyright) as HTMLInputElement;
         expect(copyrightCheckbox.checked).toBe(true);
       });
     });
@@ -563,9 +551,7 @@ describe('TranslationUpload', () => {
 
       // Navigate to step 2
       await user.click(screen.getByLabelText(L.copyright));
-      await user.click(
-        screen.getByLabelText(L.translationRights)
-      );
+      await user.click(screen.getByLabelText(L.translationRights));
       await user.click(screen.getByLabelText(L.liability));
       await user.click(screen.getByRole('button', { name: /next/i }));
 
@@ -601,12 +587,8 @@ describe('TranslationUpload', () => {
 
       // LegalAttestation checkboxes should be rendered
       expect(screen.getByLabelText(L.copyright)).toBeInTheDocument();
-      expect(
-        screen.getByLabelText(L.translationRights)
-      ).toBeInTheDocument();
-      expect(
-        screen.getByLabelText(L.liability)
-      ).toBeInTheDocument();
+      expect(screen.getByLabelText(L.translationRights)).toBeInTheDocument();
+      expect(screen.getByLabelText(L.liability)).toBeInTheDocument();
     });
 
     it('should pass correct props to TranslationConfig component', async () => {
@@ -615,9 +597,7 @@ describe('TranslationUpload', () => {
 
       // Navigate to step 2
       await user.click(screen.getByLabelText(L.copyright));
-      await user.click(
-        screen.getByLabelText(L.translationRights)
-      );
+      await user.click(screen.getByLabelText(L.translationRights));
       await user.click(screen.getByLabelText(L.liability));
       await user.click(screen.getByRole('button', { name: /next/i }));
 
@@ -633,9 +613,7 @@ describe('TranslationUpload', () => {
 
       // Navigate to step 3
       await user.click(screen.getByLabelText(L.copyright));
-      await user.click(
-        screen.getByLabelText(L.translationRights)
-      );
+      await user.click(screen.getByLabelText(L.translationRights));
       await user.click(screen.getByLabelText(L.liability));
       await user.click(screen.getByRole('button', { name: /next/i }));
 

--- a/frontend/src/pages/__tests__/TranslationUpload.test.tsx
+++ b/frontend/src/pages/__tests__/TranslationUpload.test.tsx
@@ -19,6 +19,7 @@ import '@testing-library/jest-dom';
 import { BrowserRouter } from 'react-router-dom';
 import { TranslationUpload } from '../TranslationUpload';
 import { translationService } from '../../services/translationService';
+import { LEGAL_ATTESTATION_LABEL_PATTERNS as L } from '../../components/Translation/legalAttestationLabels';
 
 // Mock react-router-dom's useNavigate
 const mockNavigate = vi.fn();
@@ -88,7 +89,7 @@ describe('TranslationUpload', () => {
       renderComponent();
 
       // Legal attestation checkboxes should be visible
-      expect(screen.getByLabelText(/I confirm that I own the copyright/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(L.copyright)).toBeInTheDocument();
     });
 
     it('should show Back button disabled on first step', () => {
@@ -131,7 +132,7 @@ describe('TranslationUpload', () => {
 
       // Should still be on step 0
       await waitFor(() => {
-        expect(screen.getByLabelText(/I confirm that I own the copyright/i)).toBeInTheDocument();
+        expect(screen.getByLabelText(L.copyright)).toBeInTheDocument();
       });
     });
 
@@ -140,11 +141,11 @@ describe('TranslationUpload', () => {
       renderComponent();
 
       // Check all three checkboxes
-      const copyrightCheckbox = screen.getByLabelText(/I confirm that I own the copyright/i);
+      const copyrightCheckbox = screen.getByLabelText(L.copyright);
       const translationRightsCheckbox = screen.getByLabelText(
-        /I confirm that I have the right to create derivative works/i
+        L.translationRights
       );
-      const liabilityCheckbox = screen.getByLabelText(/I understand that I am solely responsible/i);
+      const liabilityCheckbox = screen.getByLabelText(L.liability);
 
       await user.click(copyrightCheckbox);
       await user.click(translationRightsCheckbox);
@@ -163,11 +164,11 @@ describe('TranslationUpload', () => {
 
   describe('Step 2: Translation Settings Validation', () => {
     const advanceToStep2 = async (user: ReturnType<typeof userEvent.setup>) => {
-      const copyrightCheckbox = screen.getByLabelText(/I confirm that I own the copyright/i);
+      const copyrightCheckbox = screen.getByLabelText(L.copyright);
       const translationRightsCheckbox = screen.getByLabelText(
-        /I confirm that I have the right to create derivative works/i
+        L.translationRights
       );
-      const liabilityCheckbox = screen.getByLabelText(/I understand that I am solely responsible/i);
+      const liabilityCheckbox = screen.getByLabelText(L.liability);
 
       await user.click(copyrightCheckbox);
       await user.click(translationRightsCheckbox);
@@ -230,7 +231,7 @@ describe('TranslationUpload', () => {
       await user.click(backButton);
 
       await waitFor(() => {
-        expect(screen.getByLabelText(/I confirm that I own the copyright/i)).toBeInTheDocument();
+        expect(screen.getByLabelText(L.copyright)).toBeInTheDocument();
       });
     });
   });
@@ -238,11 +239,11 @@ describe('TranslationUpload', () => {
   describe('Step 3: File Upload Validation', () => {
     const advanceToStep3 = async (user: ReturnType<typeof userEvent.setup>) => {
       // Step 1: Legal attestation
-      const copyrightCheckbox = screen.getByLabelText(/I confirm that I own the copyright/i);
+      const copyrightCheckbox = screen.getByLabelText(L.copyright);
       const translationRightsCheckbox = screen.getByLabelText(
-        /I confirm that I have the right to create derivative works/i
+        L.translationRights
       );
-      const liabilityCheckbox = screen.getByLabelText(/I understand that I am solely responsible/i);
+      const liabilityCheckbox = screen.getByLabelText(L.liability);
 
       await user.click(copyrightCheckbox);
       await user.click(translationRightsCheckbox);
@@ -311,11 +312,11 @@ describe('TranslationUpload', () => {
   describe('Step 4: Review & Submit', () => {
     const advanceToStep4 = async (user: ReturnType<typeof userEvent.setup>) => {
       // Step 1: Legal attestation
-      await user.click(screen.getByLabelText(/I confirm that I own the copyright/i));
+      await user.click(screen.getByLabelText(L.copyright));
       await user.click(
-        screen.getByLabelText(/I confirm that I have the right to create derivative works/i)
+        screen.getByLabelText(L.translationRights)
       );
-      await user.click(screen.getByLabelText(/I understand that I am solely responsible/i));
+      await user.click(screen.getByLabelText(L.liability));
       await user.click(screen.getByRole('button', { name: /next/i }));
 
       await waitFor(() => {
@@ -534,11 +535,11 @@ describe('TranslationUpload', () => {
       renderComponent();
 
       // Step 1: Check legal attestation
-      await user.click(screen.getByLabelText(/I confirm that I own the copyright/i));
+      await user.click(screen.getByLabelText(L.copyright));
       await user.click(
-        screen.getByLabelText(/I confirm that I have the right to create derivative works/i)
+        screen.getByLabelText(L.translationRights)
       );
-      await user.click(screen.getByLabelText(/I understand that I am solely responsible/i));
+      await user.click(screen.getByLabelText(L.liability));
       await user.click(screen.getByRole('button', { name: /next/i }));
 
       await waitFor(() => {
@@ -550,7 +551,7 @@ describe('TranslationUpload', () => {
 
       await waitFor(() => {
         const copyrightCheckbox = screen.getByLabelText(
-          /I confirm that I own the copyright/i
+          L.copyright
         ) as HTMLInputElement;
         expect(copyrightCheckbox.checked).toBe(true);
       });
@@ -561,11 +562,11 @@ describe('TranslationUpload', () => {
       renderComponent();
 
       // Navigate to step 2
-      await user.click(screen.getByLabelText(/I confirm that I own the copyright/i));
+      await user.click(screen.getByLabelText(L.copyright));
       await user.click(
-        screen.getByLabelText(/I confirm that I have the right to create derivative works/i)
+        screen.getByLabelText(L.translationRights)
       );
-      await user.click(screen.getByLabelText(/I understand that I am solely responsible/i));
+      await user.click(screen.getByLabelText(L.liability));
       await user.click(screen.getByRole('button', { name: /next/i }));
 
       await waitFor(() => {
@@ -599,12 +600,12 @@ describe('TranslationUpload', () => {
       renderComponent();
 
       // LegalAttestation checkboxes should be rendered
-      expect(screen.getByLabelText(/I confirm that I own the copyright/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(L.copyright)).toBeInTheDocument();
       expect(
-        screen.getByLabelText(/I confirm that I have the right to create derivative works/i)
+        screen.getByLabelText(L.translationRights)
       ).toBeInTheDocument();
       expect(
-        screen.getByLabelText(/I understand that I am solely responsible/i)
+        screen.getByLabelText(L.liability)
       ).toBeInTheDocument();
     });
 
@@ -613,11 +614,11 @@ describe('TranslationUpload', () => {
       renderComponent();
 
       // Navigate to step 2
-      await user.click(screen.getByLabelText(/I confirm that I own the copyright/i));
+      await user.click(screen.getByLabelText(L.copyright));
       await user.click(
-        screen.getByLabelText(/I confirm that I have the right to create derivative works/i)
+        screen.getByLabelText(L.translationRights)
       );
-      await user.click(screen.getByLabelText(/I understand that I am solely responsible/i));
+      await user.click(screen.getByLabelText(L.liability));
       await user.click(screen.getByRole('button', { name: /next/i }));
 
       await waitFor(() => {
@@ -631,11 +632,11 @@ describe('TranslationUpload', () => {
       renderComponent();
 
       // Navigate to step 3
-      await user.click(screen.getByLabelText(/I confirm that I own the copyright/i));
+      await user.click(screen.getByLabelText(L.copyright));
       await user.click(
-        screen.getByLabelText(/I confirm that I have the right to create derivative works/i)
+        screen.getByLabelText(L.translationRights)
       );
-      await user.click(screen.getByLabelText(/I understand that I am solely responsible/i));
+      await user.click(screen.getByLabelText(L.liability));
       await user.click(screen.getByRole('button', { name: /next/i }));
 
       await waitFor(() => {


### PR DESCRIPTION
## Root Cause

`completeLegalAttestationByRole` in `frontend/e2e/pages/TranslationUploadPage.ts` (line 161–163 before this fix) used three regex patterns to locate the legal-attestation checkboxes that never appear in the actual rendered label text:

| Pattern used (wrong) | Actual `<FormControlLabel>` text |
|---|---|
| `/copyright ownership/i` | "I confirm that I **own the copyright** to this document…" |
| `/translation rights/i` | "I confirm that I have the **right to create derivative works** (translations)…" |
| `/liability/i` | "I understand that I am **solely responsible**… and I indemnify LFMT…" |

Playwright's `getByRole('checkbox', { name: ... })` computes the accessible name from the associated `<label>` text via `FormControlLabel`. None of the three old patterns are substrings of those labels, so every `.check()` call waited the full 180 s timeout before failing — all 3 retry attempts, same result (CI run 25282883531, job 74123177694).

The unit tests for `LegalAttestation.tsx` (`frontend/src/components/Translation/__tests__/LegalAttestation.test.tsx`, lines 48–54) already used the correct text substrings. The page object was simply never aligned to the real component.

## What Changed (Round 1)

**`frontend/e2e/pages/TranslationUploadPage.ts`** — replaced the three broken regex patterns in `completeLegalAttestationByRole` with patterns that match the actual `<FormControlLabel>` label text, consistent with the existing unit tests.

## Verification (Round 1)

- Read `LegalAttestation.tsx` to extract the exact label strings (lines 88–92, 135–138, 182–186).
- Cross-checked against `LegalAttestation.test.tsx` lines 48–54, which use `getByLabelText` with the same substrings — those 27 unit tests all pass locally.
- `npm run type-check` output is identical before and after this change (pre-existing environment errors unrelated to this file).

---

## Round 2 — OMC Follow-ups

Applied all Critical + Recommended items from the 5-reviewer OMC round. Second commit: `66d8ed0`.

### Item 1 (Critical) — fix stale patterns in `legal-attestation.spec.ts`

**Lines 87–89** used `page.locator('text=/copyright ownership/i')` etc. — the same selector-drift class as the original smoke bug. None of those strings appear anywhere in the rendered component.

**Lines 316–320** asserted text that is never rendered:
- `"I certify that I am the copyright owner"` — fabricated
- `"I have the legal right to create translations"` — fabricated
- `"I accept full liability"` — fabricated

Both sites now use `page.getByRole('checkbox', { name: L.* })` where `L` is imported from the new constants module (Item 2).

**File:** `frontend/e2e/tests/translation/legal-attestation.spec.ts`

### Item 2 (Recommended) — extract `LEGAL_ATTESTATION_LABEL_PATTERNS` constants

**New file:** `frontend/src/components/Translation/legalAttestationLabels.ts`

Exports a single `LEGAL_ATTESTATION_LABEL_PATTERNS` object (`copyright`, `translationRights`, `liability`) co-located with `LegalAttestation.tsx`. All four downstream consumers import `{ LEGAL_ATTESTATION_LABEL_PATTERNS as L }` from this module and reference `L.copyright` / `L.translationRights` / `L.liability` in place of every inline regex literal.

A future label change in `LegalAttestation.tsx` now requires updating `legalAttestationLabels.ts` in the same commit — the three new contract tests (Item 3) will fail within milliseconds if the patterns drift, rather than after a 180 s production smoke timeout.

**Files updated:**
- `frontend/src/components/Translation/legalAttestationLabels.ts` (new)
- `frontend/e2e/pages/TranslationUploadPage.ts` — `completeLegalAttestationByRole` uses `L.*`
- `frontend/src/components/Translation/__tests__/LegalAttestation.test.tsx` — all `getByLabelText` patterns
- `frontend/src/pages/__tests__/TranslationUpload.test.tsx` — all `getByLabelText` patterns
- `frontend/e2e/tests/translation/legal-attestation.spec.ts` — stale patterns replaced (Item 1)

### Item 3 (Recommended) — Vitest contract tests (`label contract` describe block)

Added three contract tests to the existing `LegalAttestation.test.tsx` in a new `describe('label contract')` block. Each test:
1. Mounts `<LegalAttestation />` with the same setup as the existing tests
2. For each pattern in `LEGAL_ATTESTATION_LABEL_PATTERNS`, filters rendered checkboxes by label text match
3. Asserts exactly one checkbox matches

Total Vitest tests: 27 → 30 (all passing). This is the missing safety net that would have caught the original 180 s timeout bug at unit-test speed.

**File:** `frontend/src/components/Translation/__tests__/LegalAttestation.test.tsx`

### Item 4 (Recommended) — JSDoc cross-references in `TranslationUploadPage.ts`

Added `@see completeLegalAttestationByRole` / `@see completeLegalAttestation` cross-references in both helper JSDoc blocks. The `completeLegalAttestation` JSDoc now also explains why the `[name="acceptCopyrightOwnership"]` attribute selectors remain correct without label patterns (they target the HTML `name` attribute, not the accessible name).

**File:** `frontend/e2e/pages/TranslationUploadPage.ts`

## Verification (Round 2)

- 30/30 `LegalAttestation.test.tsx` tests pass (27 original + 3 new contract tests)
- 25/25 `TranslationUpload.test.tsx` tests pass (all patterns replaced with `L.*`)
- All patterns in `legalAttestationLabels.ts` verified by direct comparison to `LegalAttestation.tsx` label strings (lines 88–92, 135–138, 182–186)
- Playwright E2E against the deployed prod URL is not runnable from this sandbox (no network access); the fix is validated by source-code analysis and unit-test coverage

## Known Limitations

- Playwright headless against deployed env was not run locally (sandbox network constraint). The next CI run on this branch will be the final gate.
- Pre-existing `npm run type-check` failures (`TS2688` for `@testing-library/jest-dom` etc.) are unrelated to this PR — separate issue recommended below.

## Recommended Follow-ups (separate issues, do not open)

1. **Fix `npm run type-check` in dev environment** — `TS2688: Cannot find type definition file for '@testing-library/jest-dom'` etc. Pre-existing, not introduced here.
2. **`legal-attestation.spec.ts` `beforeEach` registration call** omits `confirmPassword`, `acceptedTerms`, and `acceptedPrivacy` fields required by the backend auth API — tests using that setup path will fail at the API call. Low priority since this spec mostly runs in environments with a local dev server.