### PR TITLE
fix(e2e): registerViaApi double /v1 prefix → 404 in CI

### DIFF
--- a/frontend/e2e/fixtures/auth.ts
+++ b/frontend/e2e/fixtures/auth.ts
@@ -2,9 +2,16 @@
  * Authentication Helpers for E2E Tests
  *
  * Provides utilities for authentication flows in E2E tests.
+ *
+ * URL normalisation is handled by the Playwright-free `resolveApiUrl` helper
+ * in `./url` so that the pure logic can be unit-tested with Vitest without
+ * pulling in the Playwright bootstrap.
+ *
+ * @see url.ts for the `resolveApiUrl` contract and env-var documentation.
  */
 
 import { APIRequestContext, Page } from '@playwright/test';
+import { resolveApiUrl } from './url';
 
 /**
  * Generate unique test email
@@ -32,28 +39,6 @@ export function generateTestUser() {
 }
 
 /**
- * Resolve the API base URL from an optional override or the `API_BASE_URL`
- * environment variable, normalising it so callers can safely append a path
- * segment with a single leading slash.
- *
- * Contract (matches production-smoke.spec.ts and all backend integration
- * tests): `API_BASE_URL` already includes the version prefix, e.g.
- * `https://8brwlwf68h.execute-api.us-east-1.amazonaws.com/v1` (or the same
- * URL with a trailing slash as emitted by CloudFormation's `ApiUrl` output).
- * Callers must therefore append only the resource path (e.g. `/auth/register`)
- * — NOT `/v1/auth/register` — to avoid the double-prefix
- * `.../v1/v1/auth/register` bug that produced 404s in CI.
- *
- * Exported as a pure function so it can be unit-tested independently of any
- * network calls (see `src/__tests__/resolveApiUrl.test.ts`).
- */
-export function resolveApiUrl(apiBaseUrl?: string): string {
-  const raw = apiBaseUrl ?? process.env.API_BASE_URL ?? 'http://localhost:3000';
-  // Strip a single trailing slash to avoid double-slash in composed URLs.
-  return raw.endsWith('/') ? raw.slice(0, -1) : raw;
-}
-
-/**
  * Register a user via the backend API (bypassing the UI).
  *
  * Many E2E specs need a known authenticated user but want to skip the
@@ -65,14 +50,14 @@ export function resolveApiUrl(apiBaseUrl?: string): string {
  * shape so the contract can't drift again.
  *
  * `apiBaseUrl` (and `API_BASE_URL`) must be the full base URL including the
- * version prefix, e.g. `https://<id>.execute-api.us-east-1.amazonaws.com/v1`.
- * This is the value CloudFormation emits as `ApiUrl` and what CI passes as
- * `API_BASE_URL`. The helper appends only `/auth/register` — not
- * `/v1/auth/register` — to avoid a double version prefix.
+ * version prefix. See `./url.ts` for the full contract. The helper appends
+ * only `/auth/register` — not `/v1/auth/register`.
  *
  * Returns the raw Playwright APIResponse so callers can choose their own
  * assertion (most just check `response.ok()`; some treat 409 "already exists"
  * as success on retries).
+ *
+ * @see resolveApiUrl in url.ts for the URL normalisation contract.
  */
 export async function registerViaApi(
   request: APIRequestContext,
@@ -89,6 +74,34 @@ export async function registerViaApi(
       confirmPassword: user.password,
       acceptedTerms: true,
       acceptedPrivacy: true,
+    },
+    failOnStatusCode: false,
+  });
+}
+
+/**
+ * Fetch a translation job from the backend API by ID.
+ *
+ * Centralises the `/translation/jobs/{jobId}` GET call used across multiple
+ * E2E specs so the URL construction cannot drift. Requires the caller to
+ * supply a valid auth token (obtained from `page.evaluate(() =>
+ * localStorage.getItem('authToken'))`).
+ *
+ * Appends only `/translation/jobs/${jobId}` — not `/v1/translation/jobs/${jobId}` —
+ * because `API_BASE_URL` already includes the version prefix.
+ *
+ * @see resolveApiUrl in url.ts for the URL normalisation contract.
+ */
+export async function getJobViaApi(
+  request: APIRequestContext,
+  jobId: string,
+  authToken: string,
+  apiBaseUrl?: string
+) {
+  const normalized = resolveApiUrl(apiBaseUrl);
+  return request.get(`${normalized}/translation/jobs/${jobId}`, {
+    headers: {
+      Authorization: `Bearer ${authToken}`,
     },
     failOnStatusCode: false,
   });

--- a/frontend/e2e/fixtures/auth.ts
+++ b/frontend/e2e/fixtures/auth.ts
@@ -32,6 +32,28 @@ export function generateTestUser() {
 }
 
 /**
+ * Resolve the API base URL from an optional override or the `API_BASE_URL`
+ * environment variable, normalising it so callers can safely append a path
+ * segment with a single leading slash.
+ *
+ * Contract (matches production-smoke.spec.ts and all backend integration
+ * tests): `API_BASE_URL` already includes the version prefix, e.g.
+ * `https://8brwlwf68h.execute-api.us-east-1.amazonaws.com/v1` (or the same
+ * URL with a trailing slash as emitted by CloudFormation's `ApiUrl` output).
+ * Callers must therefore append only the resource path (e.g. `/auth/register`)
+ * — NOT `/v1/auth/register` — to avoid the double-prefix
+ * `.../v1/v1/auth/register` bug that produced 404s in CI.
+ *
+ * Exported as a pure function so it can be unit-tested independently of any
+ * network calls (see `src/__tests__/resolveApiUrl.test.ts`).
+ */
+export function resolveApiUrl(apiBaseUrl?: string): string {
+  const raw = apiBaseUrl ?? process.env.API_BASE_URL ?? 'http://localhost:3000';
+  // Strip a single trailing slash to avoid double-slash in composed URLs.
+  return raw.endsWith('/') ? raw.slice(0, -1) : raw;
+}
+
+/**
  * Register a user via the backend API (bypassing the UI).
  *
  * Many E2E specs need a known authenticated user but want to skip the
@@ -42,6 +64,12 @@ export function generateTestUser() {
  * shared-types/src/auth.ts:85). This helper centralizes the correct payload
  * shape so the contract can't drift again.
  *
+ * `apiBaseUrl` (and `API_BASE_URL`) must be the full base URL including the
+ * version prefix, e.g. `https://<id>.execute-api.us-east-1.amazonaws.com/v1`.
+ * This is the value CloudFormation emits as `ApiUrl` and what CI passes as
+ * `API_BASE_URL`. The helper appends only `/auth/register` — not
+ * `/v1/auth/register` — to avoid a double version prefix.
+ *
  * Returns the raw Playwright APIResponse so callers can choose their own
  * assertion (most just check `response.ok()`; some treat 409 "already exists"
  * as success on retries).
@@ -51,10 +79,8 @@ export async function registerViaApi(
   user: ReturnType<typeof generateTestUser>,
   apiBaseUrl?: string
 ) {
-  const baseUrl = apiBaseUrl || process.env.API_BASE_URL || 'http://localhost:3000';
-  // Strip trailing slash to avoid `//v1/auth/register`.
-  const normalized = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
-  return request.post(`${normalized}/v1/auth/register`, {
+  const normalized = resolveApiUrl(apiBaseUrl);
+  return request.post(`${normalized}/auth/register`, {
     data: {
       firstName: user.firstName,
       lastName: user.lastName,

--- a/frontend/e2e/fixtures/url.ts
+++ b/frontend/e2e/fixtures/url.ts
@@ -1,0 +1,32 @@
+/**
+ * URL utilities for E2E test fixtures.
+ *
+ * This module is intentionally free of any Playwright imports so that its
+ * exports can be unit-tested with Vitest (jsdom) without dragging in the
+ * Playwright bootstrap. E2E fixture files that need Playwright types (e.g.
+ * auth.ts) import from here rather than inlining URL normalisation logic.
+ *
+ * @see auth.ts for the Playwright-dependent helpers that consume resolveApiUrl.
+ */
+
+/**
+ * Resolve the API base URL from an optional override or the `API_BASE_URL`
+ * environment variable, normalising it so callers can safely append a path
+ * segment with a single leading slash.
+ *
+ * Contract (matches production-smoke.spec.ts and all backend integration
+ * tests): `API_BASE_URL` already includes the API Gateway stage / version
+ * prefix, e.g. `https://8brwlwf68h.execute-api.us-east-1.amazonaws.com/v1`
+ * (or the same URL with a trailing slash as emitted by CloudFormation's
+ * `ApiUrl` output). Callers must therefore append only the resource path
+ * (e.g. `/auth/register`) — NOT `/v1/auth/register` — to avoid the
+ * double-prefix `.../v1/v1/auth/register` bug that produced HTTP 404s in CI.
+ *
+ * @param apiBaseUrl - Optional explicit override; falls back to
+ *   `process.env.API_BASE_URL` then `http://localhost:3000`.
+ */
+export function resolveApiUrl(apiBaseUrl?: string): string {
+  const raw = apiBaseUrl ?? process.env.API_BASE_URL ?? 'http://localhost:3000';
+  // Strip a single trailing slash to avoid double-slash in composed URLs.
+  return raw.endsWith('/') ? raw.slice(0, -1) : raw;
+}

--- a/frontend/e2e/tests/smoke/production-smoke.spec.ts
+++ b/frontend/e2e/tests/smoke/production-smoke.spec.ts
@@ -20,6 +20,7 @@ import * as path from 'path';
 import { fileURLToPath } from 'node:url';
 import { test, expect } from '@playwright/test';
 import { TranslationUploadPage } from '../../pages/TranslationUploadPage';
+import { resolveApiUrl } from '../../fixtures/url';
 
 // Smoke tests use a longer timeout because they run against production.
 // 3 minutes is sufficient when we use the ~1 KB smoke-test-minimal.txt
@@ -94,19 +95,21 @@ test.describe('Production Smoke Tests @smoke', () => {
     // endpoint requires confirmPassword + acceptedTerms + acceptedPrivacy on
     // top of the basic credential fields (see shared-types/src/auth.ts:85).
     if (!presharedEmail || !presharedPassword) {
-      const apiUrl = apiBaseURL.endsWith('/') ? apiBaseURL.slice(0, -1) : apiBaseURL;
-      const registerResponse = await page.request.post(`${apiUrl}/auth/register`, {
-        data: {
-          email: user.email,
-          password: user.password,
-          confirmPassword: user.password,
-          firstName: user.firstName,
-          lastName: user.lastName,
-          acceptedTerms: true,
-          acceptedPrivacy: true,
-        },
-        failOnStatusCode: false,
-      });
+      const registerResponse = await page.request.post(
+        `${resolveApiUrl(apiBaseURL)}/auth/register`,
+        {
+          data: {
+            email: user.email,
+            password: user.password,
+            confirmPassword: user.password,
+            firstName: user.firstName,
+            lastName: user.lastName,
+            acceptedTerms: true,
+            acceptedPrivacy: true,
+          },
+          failOnStatusCode: false,
+        }
+      );
       // 201 = created, 409 = already exists (acceptable on retries)
       const registerStatus = registerResponse.status();
       if (registerStatus !== 201 && registerStatus !== 409) {

--- a/frontend/e2e/tests/translation/complete-workflow.spec.ts
+++ b/frontend/e2e/tests/translation/complete-workflow.spec.ts
@@ -12,7 +12,7 @@ import { LoginPage } from '../../pages/LoginPage';
 import { DashboardPage } from '../../pages/DashboardPage';
 import { TranslationUploadPage } from '../../pages/TranslationUploadPage';
 import { TranslationDetailPage } from '../../pages/TranslationDetailPage';
-import { generateTestUser } from '../../fixtures/auth';
+import { generateTestUser, registerViaApi, getJobViaApi } from '../../fixtures/auth';
 import { TEST_DOCUMENTS } from '../../fixtures/test-documents';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -60,17 +60,7 @@ test.describe('Complete Translation Workflow - Full E2E', () => {
   }) => {
     // ===== STEP 1: User Registration =====
     const user = generateTestUser();
-    const registerResponse = await page.request.post(
-      `${process.env.API_BASE_URL || 'http://localhost:3000'}/v1/auth/register`,
-      {
-        data: {
-          firstName: user.firstName,
-          lastName: user.lastName,
-          email: user.email,
-          password: user.password,
-        },
-      }
-    );
+    const registerResponse = await registerViaApi(page.request, user);
     expect(registerResponse.ok()).toBeTruthy();
 
     // ===== STEP 2: Login =====
@@ -155,14 +145,7 @@ test.describe('Complete Translation Workflow - Full E2E', () => {
     const authToken = await page.evaluate(() => localStorage.getItem('authToken'));
     expect(authToken).toBeTruthy();
 
-    const jobResponse = await page.request.get(
-      `${process.env.API_BASE_URL || 'http://localhost:3000'}/v1/translation/jobs/${jobId}`,
-      {
-        headers: {
-          Authorization: `Bearer ${authToken}`,
-        },
-      }
-    );
+    const jobResponse = await getJobViaApi(page.request, jobId, authToken!);
     expect(jobResponse.ok()).toBeTruthy();
 
     const job = await jobResponse.json();
@@ -216,17 +199,7 @@ test.describe('Complete Translation Workflow - Full E2E', () => {
   test('should persist data across page refreshes', async ({ page }) => {
     // Setup: Create job
     const user = generateTestUser();
-    await page.request.post(
-      `${process.env.API_BASE_URL || 'http://localhost:3000'}/v1/auth/register`,
-      {
-        data: {
-          firstName: user.firstName,
-          lastName: user.lastName,
-          email: user.email,
-          password: user.password,
-        },
-      }
-    );
+    await registerViaApi(page.request, user);
 
     await loginPage.goto();
     await loginPage.login(user.email, user.password);
@@ -259,17 +232,7 @@ test.describe('Complete Translation Workflow - Full E2E', () => {
   test('should maintain authentication across workflow', async ({ page }) => {
     // Register and login
     const user = generateTestUser();
-    await page.request.post(
-      `${process.env.API_BASE_URL || 'http://localhost:3000'}/v1/auth/register`,
-      {
-        data: {
-          firstName: user.firstName,
-          lastName: user.lastName,
-          email: user.email,
-          password: user.password,
-        },
-      }
-    );
+    await registerViaApi(page.request, user);
 
     await loginPage.goto();
     await loginPage.login(user.email, user.password);
@@ -296,17 +259,7 @@ test.describe('Complete Translation Workflow - Full E2E', () => {
   test('should handle browser back button correctly', async ({ page }) => {
     // Setup
     const user = generateTestUser();
-    await page.request.post(
-      `${process.env.API_BASE_URL || 'http://localhost:3000'}/v1/auth/register`,
-      {
-        data: {
-          firstName: user.firstName,
-          lastName: user.lastName,
-          email: user.email,
-          password: user.password,
-        },
-      }
-    );
+    await registerViaApi(page.request, user);
 
     await loginPage.goto();
     await loginPage.login(user.email, user.password);

--- a/frontend/e2e/tests/translation/download-translation.spec.ts
+++ b/frontend/e2e/tests/translation/download-translation.spec.ts
@@ -14,7 +14,7 @@ import { LoginPage } from '../../pages/LoginPage';
 import { DashboardPage } from '../../pages/DashboardPage';
 import { TranslationUploadPage } from '../../pages/TranslationUploadPage';
 import { TranslationDetailPage } from '../../pages/TranslationDetailPage';
-import { generateTestUser } from '../../fixtures/auth';
+import { generateTestUser, registerViaApi } from '../../fixtures/auth';
 import { TEST_DOCUMENTS } from '../../fixtures/test-documents';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -60,17 +60,7 @@ test.describe('Translation Download Workflow', () => {
   test('should show download button only when translation is completed', async ({ page }) => {
     // Setup: Register and login
     const user = generateTestUser();
-    await page.request.post(
-      `${process.env.API_BASE_URL || 'http://localhost:3000'}/v1/auth/register`,
-      {
-        data: {
-          firstName: user.firstName,
-          lastName: user.lastName,
-          email: user.email,
-          password: user.password,
-        },
-      }
-    );
+    await registerViaApi(page.request, user);
 
     await loginPage.goto();
     await loginPage.login(user.email, user.password);
@@ -98,17 +88,7 @@ test.describe('Translation Download Workflow', () => {
   test('should download translated file when clicking download button', async ({ page }) => {
     // Setup: Register and login
     const user = generateTestUser();
-    await page.request.post(
-      `${process.env.API_BASE_URL || 'http://localhost:3000'}/v1/auth/register`,
-      {
-        data: {
-          firstName: user.firstName,
-          lastName: user.lastName,
-          email: user.email,
-          password: user.password,
-        },
-      }
-    );
+    await registerViaApi(page.request, user);
 
     await loginPage.goto();
     await loginPage.login(user.email, user.password);
@@ -159,17 +139,7 @@ test.describe('Translation Download Workflow', () => {
   test('should display downloading state while downloading', async ({ page }) => {
     // Setup
     const user = generateTestUser();
-    await page.request.post(
-      `${process.env.API_BASE_URL || 'http://localhost:3000'}/v1/auth/register`,
-      {
-        data: {
-          firstName: user.firstName,
-          lastName: user.lastName,
-          email: user.email,
-          password: user.password,
-        },
-      }
-    );
+    await registerViaApi(page.request, user);
 
     await loginPage.goto();
     await loginPage.login(user.email, user.password);
@@ -206,17 +176,7 @@ test.describe('Translation Download Workflow', () => {
   test('should show error message when download fails', async ({ page }) => {
     // Setup
     const user = generateTestUser();
-    await page.request.post(
-      `${process.env.API_BASE_URL || 'http://localhost:3000'}/v1/auth/register`,
-      {
-        data: {
-          firstName: user.firstName,
-          lastName: user.lastName,
-          email: user.email,
-          password: user.password,
-        },
-      }
-    );
+    await registerViaApi(page.request, user);
 
     await loginPage.goto();
     await loginPage.login(user.email, user.password);
@@ -258,17 +218,7 @@ test.describe('Translation Download Workflow', () => {
   test('should allow re-downloading the same file multiple times', async ({ page }) => {
     // Setup
     const user = generateTestUser();
-    await page.request.post(
-      `${process.env.API_BASE_URL || 'http://localhost:3000'}/v1/auth/register`,
-      {
-        data: {
-          firstName: user.firstName,
-          lastName: user.lastName,
-          email: user.email,
-          password: user.password,
-        },
-      }
-    );
+    await registerViaApi(page.request, user);
 
     await loginPage.goto();
     await loginPage.login(user.email, user.password);
@@ -306,17 +256,7 @@ test.describe('Translation Download Workflow', () => {
   test('should download file with correct naming convention', async ({ page }) => {
     // Setup
     const user = generateTestUser();
-    await page.request.post(
-      `${process.env.API_BASE_URL || 'http://localhost:3000'}/v1/auth/register`,
-      {
-        data: {
-          firstName: user.firstName,
-          lastName: user.lastName,
-          email: user.email,
-          password: user.password,
-        },
-      }
-    );
+    await registerViaApi(page.request, user);
 
     await loginPage.goto();
     await loginPage.login(user.email, user.password);
@@ -345,17 +285,7 @@ test.describe('Translation Download Workflow', () => {
   test('should navigate back to history from detail page after download', async ({ page }) => {
     // Setup
     const user = generateTestUser();
-    await page.request.post(
-      `${process.env.API_BASE_URL || 'http://localhost:3000'}/v1/auth/register`,
-      {
-        data: {
-          firstName: user.firstName,
-          lastName: user.lastName,
-          email: user.email,
-          password: user.password,
-        },
-      }
-    );
+    await registerViaApi(page.request, user);
 
     await loginPage.goto();
     await loginPage.login(user.email, user.password);

--- a/frontend/e2e/tests/translation/error-scenarios.spec.ts
+++ b/frontend/e2e/tests/translation/error-scenarios.spec.ts
@@ -16,7 +16,7 @@ import { LoginPage } from '../../pages/LoginPage';
 import { DashboardPage } from '../../pages/DashboardPage';
 import { TranslationUploadPage } from '../../pages/TranslationUploadPage';
 import { TranslationDetailPage } from '../../pages/TranslationDetailPage';
-import { generateTestUser } from '../../fixtures/auth';
+import { generateTestUser, registerViaApi } from '../../fixtures/auth';
 import { TEST_DOCUMENTS } from '../../fixtures/test-documents';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -60,17 +60,7 @@ test.describe('Error Scenarios and Error Handling', () => {
 
     // Register and login
     const user = generateTestUser();
-    await page.request.post(
-      `${process.env.API_BASE_URL || 'http://localhost:3000'}/v1/auth/register`,
-      {
-        data: {
-          firstName: user.firstName,
-          lastName: user.lastName,
-          email: user.email,
-          password: user.password,
-        },
-      }
-    );
+    await registerViaApi(page.request, user);
 
     await loginPage.goto();
     await loginPage.login(user.email, user.password);

--- a/frontend/e2e/tests/translation/legal-attestation.spec.ts
+++ b/frontend/e2e/tests/translation/legal-attestation.spec.ts
@@ -13,7 +13,7 @@ import { test, expect } from '@playwright/test';
 import { LoginPage } from '../../pages/LoginPage';
 import { DashboardPage } from '../../pages/DashboardPage';
 import { TranslationUploadPage } from '../../pages/TranslationUploadPage';
-import { generateTestUser } from '../../fixtures/auth';
+import { generateTestUser, registerViaApi, getJobViaApi } from '../../fixtures/auth';
 import { TEST_DOCUMENTS } from '../../fixtures/test-documents';
 import { LEGAL_ATTESTATION_LABEL_PATTERNS as L } from '../../../src/components/Translation/legalAttestationLabels';
 import * as fs from 'fs';
@@ -56,17 +56,7 @@ test.describe('Legal Attestation Enforcement', () => {
 
     // Setup: Register and login
     const user = generateTestUser();
-    await page.request.post(
-      `${process.env.API_BASE_URL || 'http://localhost:3000'}/v1/auth/register`,
-      {
-        data: {
-          firstName: user.firstName,
-          lastName: user.lastName,
-          email: user.email,
-          password: user.password,
-        },
-      }
-    );
+    await registerViaApi(page.request, user);
 
     await loginPage.goto();
     await loginPage.login(user.email, user.password);
@@ -187,14 +177,7 @@ test.describe('Legal Attestation Enforcement', () => {
 
     // Fetch job via API
     const authToken = await page.evaluate(() => localStorage.getItem('authToken'));
-    const jobResponse = await page.request.get(
-      `${process.env.API_BASE_URL || 'http://localhost:3000'}/v1/translation/jobs/${jobId}`,
-      {
-        headers: {
-          Authorization: `Bearer ${authToken}`,
-        },
-      }
-    );
+    const jobResponse = await getJobViaApi(page.request, jobId, authToken!);
 
     expect(jobResponse.ok()).toBeTruthy();
     const job = await jobResponse.json();
@@ -218,14 +201,7 @@ test.describe('Legal Attestation Enforcement', () => {
 
     // Fetch job
     const authToken = await page.evaluate(() => localStorage.getItem('authToken'));
-    const jobResponse = await page.request.get(
-      `${process.env.API_BASE_URL || 'http://localhost:3000'}/v1/translation/jobs/${jobId}`,
-      {
-        headers: {
-          Authorization: `Bearer ${authToken}`,
-        },
-      }
-    );
+    const jobResponse = await getJobViaApi(page.request, jobId, authToken!);
 
     const job = await jobResponse.json();
 
@@ -254,14 +230,7 @@ test.describe('Legal Attestation Enforcement', () => {
 
     // Fetch job
     const authToken = await page.evaluate(() => localStorage.getItem('authToken'));
-    const jobResponse = await page.request.get(
-      `${process.env.API_BASE_URL || 'http://localhost:3000'}/v1/translation/jobs/${jobId}`,
-      {
-        headers: {
-          Authorization: `Bearer ${authToken}`,
-        },
-      }
-    );
+    const jobResponse = await getJobViaApi(page.request, jobId, authToken!);
 
     const job = await jobResponse.json();
 

--- a/frontend/e2e/tests/translation/multi-language.spec.ts
+++ b/frontend/e2e/tests/translation/multi-language.spec.ts
@@ -12,7 +12,7 @@ import { LoginPage } from '../../pages/LoginPage';
 import { DashboardPage } from '../../pages/DashboardPage';
 import { TranslationUploadPage } from '../../pages/TranslationUploadPage';
 import { TranslationDetailPage } from '../../pages/TranslationDetailPage';
-import { generateTestUser } from '../../fixtures/auth';
+import { generateTestUser, registerViaApi, getJobViaApi } from '../../fixtures/auth';
 import { TEST_DOCUMENTS } from '../../fixtures/test-documents';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -71,17 +71,7 @@ test.describe('Multi-Language Translation Support', () => {
 
     // Register and login once per test
     const user = generateTestUser();
-    await page.request.post(
-      `${process.env.API_BASE_URL || 'http://localhost:3000'}/v1/auth/register`,
-      {
-        data: {
-          firstName: user.firstName,
-          lastName: user.lastName,
-          email: user.email,
-          password: user.password,
-        },
-      }
-    );
+    await registerViaApi(page.request, user);
 
     await loginPage.goto();
     await loginPage.login(user.email, user.password);
@@ -106,14 +96,7 @@ test.describe('Multi-Language Translation Support', () => {
       const jobId = jobIdMatch![1];
 
       const authToken = await page.evaluate(() => localStorage.getItem('authToken'));
-      const jobResponse = await page.request.get(
-        `${process.env.API_BASE_URL || 'http://localhost:3000'}/v1/translation/jobs/${jobId}`,
-        {
-          headers: {
-            Authorization: `Bearer ${authToken}`,
-          },
-        }
-      );
+      const jobResponse = await getJobViaApi(page.request, jobId, authToken!);
 
       expect(jobResponse.ok()).toBeTruthy();
       const job = await jobResponse.json();
@@ -130,15 +113,11 @@ test.describe('Multi-Language Translation Support', () => {
       await detailPage.waitForPageLoad();
 
       // Verify tone was set correctly via API
+      const toneUrl = page.url();
+      const toneJobIdMatch = toneUrl.match(/\/translation\/([a-f0-9-]+)/);
+      const toneJobId = toneJobIdMatch![1];
       const authToken = await page.evaluate(() => localStorage.getItem('authToken'));
-      const jobResponse = await page.request.get(
-        `${process.env.API_BASE_URL || 'http://localhost:3000'}/v1/auth/register`,
-        {
-          headers: {
-            Authorization: `Bearer ${authToken}`,
-          },
-        }
-      );
+      const jobResponse = await getJobViaApi(page.request, toneJobId, authToken!);
 
       expect(jobResponse.ok()).toBeTruthy();
       const job = await jobResponse.json();
@@ -203,14 +182,7 @@ test.describe('Multi-Language Translation Support', () => {
     const authToken = await page.evaluate(() => localStorage.getItem('authToken'));
 
     for (let i = 0; i < 3; i++) {
-      const jobResponse = await page.request.get(
-        `${process.env.API_BASE_URL || 'http://localhost:3000'}/v1/translation/jobs/${jobIds[i]}`,
-        {
-          headers: {
-            Authorization: `Bearer ${authToken}`,
-          },
-        }
-      );
+      const jobResponse = await getJobViaApi(page.request, jobIds[i], authToken!);
 
       expect(jobResponse.ok()).toBeTruthy();
       const job = await jobResponse.json();

--- a/frontend/e2e/tests/translation/translation-progress.spec.ts
+++ b/frontend/e2e/tests/translation/translation-progress.spec.ts
@@ -13,7 +13,7 @@ import { LoginPage } from '../../pages/LoginPage';
 import { DashboardPage } from '../../pages/DashboardPage';
 import { TranslationUploadPage } from '../../pages/TranslationUploadPage';
 import { TranslationDetailPage } from '../../pages/TranslationDetailPage';
-import { generateTestUser } from '../../fixtures/auth';
+import { generateTestUser, registerViaApi } from '../../fixtures/auth';
 import { TEST_DOCUMENTS } from '../../fixtures/test-documents';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -61,17 +61,7 @@ test.describe('Translation Progress Tracking', () => {
   test('should show initial PENDING status after upload', async ({ page }) => {
     // Setup: Register and login
     const user = generateTestUser();
-    await page.request.post(
-      `${process.env.API_BASE_URL || 'http://localhost:3000'}/v1/auth/register`,
-      {
-        data: {
-          firstName: user.firstName,
-          lastName: user.lastName,
-          email: user.email,
-          password: user.password,
-        },
-      }
-    );
+    await registerViaApi(page.request, user);
 
     await loginPage.goto();
     await loginPage.login(user.email, user.password);
@@ -91,17 +81,7 @@ test.describe('Translation Progress Tracking', () => {
   test('should transition from PENDING to CHUNKING', async ({ page }) => {
     // Setup: Upload document
     const user = generateTestUser();
-    await page.request.post(
-      `${process.env.API_BASE_URL || 'http://localhost:3000'}/v1/auth/register`,
-      {
-        data: {
-          firstName: user.firstName,
-          lastName: user.lastName,
-          email: user.email,
-          password: user.password,
-        },
-      }
-    );
+    await registerViaApi(page.request, user);
 
     await loginPage.goto();
     await loginPage.login(user.email, user.password);
@@ -123,17 +103,7 @@ test.describe('Translation Progress Tracking', () => {
   test('should display progress section for IN_PROGRESS jobs', async ({ page }) => {
     // Setup: Create job and start translation
     const user = generateTestUser();
-    await page.request.post(
-      `${process.env.API_BASE_URL || 'http://localhost:3000'}/v1/auth/register`,
-      {
-        data: {
-          firstName: user.firstName,
-          lastName: user.lastName,
-          email: user.email,
-          password: user.password,
-        },
-      }
-    );
+    await registerViaApi(page.request, user);
 
     await loginPage.goto();
     await loginPage.login(user.email, user.password);
@@ -160,17 +130,7 @@ test.describe('Translation Progress Tracking', () => {
   test('should update progress percentage during translation', async ({ page }) => {
     // Setup: Create and start translation
     const user = generateTestUser();
-    await page.request.post(
-      `${process.env.API_BASE_URL || 'http://localhost:3000'}/v1/auth/register`,
-      {
-        data: {
-          firstName: user.firstName,
-          lastName: user.lastName,
-          email: user.email,
-          password: user.password,
-        },
-      }
-    );
+    await registerViaApi(page.request, user);
 
     await loginPage.goto();
     await loginPage.login(user.email, user.password);
@@ -201,17 +161,7 @@ test.describe('Translation Progress Tracking', () => {
   test('should show chunk counts during translation', async ({ page }) => {
     // Setup: Create job
     const user = generateTestUser();
-    await page.request.post(
-      `${process.env.API_BASE_URL || 'http://localhost:3000'}/v1/auth/register`,
-      {
-        data: {
-          firstName: user.firstName,
-          lastName: user.lastName,
-          email: user.email,
-          password: user.password,
-        },
-      }
-    );
+    await registerViaApi(page.request, user);
 
     await loginPage.goto();
     await loginPage.login(user.email, user.password);
@@ -239,17 +189,7 @@ test.describe('Translation Progress Tracking', () => {
   test('should enable refresh button during translation', async ({ page }) => {
     // Setup: Create job
     const user = generateTestUser();
-    await page.request.post(
-      `${process.env.API_BASE_URL || 'http://localhost:3000'}/v1/auth/register`,
-      {
-        data: {
-          firstName: user.firstName,
-          lastName: user.lastName,
-          email: user.email,
-          password: user.password,
-        },
-      }
-    );
+    await registerViaApi(page.request, user);
 
     await loginPage.goto();
     await loginPage.login(user.email, user.password);
@@ -277,17 +217,7 @@ test.describe('Translation Progress Tracking', () => {
   test('should transition to COMPLETED status', async ({ page }) => {
     // Setup: Create job
     const user = generateTestUser();
-    await page.request.post(
-      `${process.env.API_BASE_URL || 'http://localhost:3000'}/v1/auth/register`,
-      {
-        data: {
-          firstName: user.firstName,
-          lastName: user.lastName,
-          email: user.email,
-          password: user.password,
-        },
-      }
-    );
+    await registerViaApi(page.request, user);
 
     await loginPage.goto();
     await loginPage.login(user.email, user.password);
@@ -313,17 +243,7 @@ test.describe('Translation Progress Tracking', () => {
   test('should enable download button when COMPLETED', async ({ page }) => {
     // Setup: Create job and wait for completion
     const user = generateTestUser();
-    await page.request.post(
-      `${process.env.API_BASE_URL || 'http://localhost:3000'}/v1/auth/register`,
-      {
-        data: {
-          firstName: user.firstName,
-          lastName: user.lastName,
-          email: user.email,
-          password: user.password,
-        },
-      }
-    );
+    await registerViaApi(page.request, user);
 
     await loginPage.goto();
     await loginPage.login(user.email, user.password);

--- a/frontend/e2e/tests/translation/upload-workflow.spec.ts
+++ b/frontend/e2e/tests/translation/upload-workflow.spec.ts
@@ -10,7 +10,7 @@ import { LoginPage } from '../../pages/LoginPage';
 import { DashboardPage } from '../../pages/DashboardPage';
 import { TranslationUploadPage } from '../../pages/TranslationUploadPage';
 import { TranslationDetailPage } from '../../pages/TranslationDetailPage';
-import { generateTestUser } from '../../fixtures/auth';
+import { generateTestUser, registerViaApi, getJobViaApi } from '../../fixtures/auth';
 import { TEST_DOCUMENTS } from '../../fixtures/test-documents';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -65,17 +65,7 @@ test.describe('Translation Upload Workflow - Happy Path', () => {
     const user = generateTestUser();
 
     // Register user via API
-    const registerResponse = await page.request.post(
-      `${process.env.API_BASE_URL || 'http://localhost:3000'}/v1/auth/register`,
-      {
-        data: {
-          firstName: user.firstName,
-          lastName: user.lastName,
-          email: user.email,
-          password: user.password,
-        },
-      }
-    );
+    const registerResponse = await registerViaApi(page.request, user);
     expect(registerResponse.ok()).toBeTruthy();
 
     // Login via UI
@@ -127,14 +117,7 @@ test.describe('Translation Upload Workflow - Happy Path', () => {
     const authToken = await page.evaluate(() => localStorage.getItem('authToken'));
     expect(authToken).toBeTruthy();
 
-    const jobResponse = await page.request.get(
-      `${process.env.API_BASE_URL || 'http://localhost:3000'}/v1/translation/jobs/${jobId}`,
-      {
-        headers: {
-          Authorization: `Bearer ${authToken}`,
-        },
-      }
-    );
+    const jobResponse = await getJobViaApi(page.request, jobId, authToken!);
     expect(jobResponse.ok()).toBeTruthy();
 
     const job = await jobResponse.json();
@@ -153,17 +136,7 @@ test.describe('Translation Upload Workflow - Happy Path', () => {
   test('should display legal attestation checkboxes correctly', async ({ page }) => {
     // Setup: Login
     const user = generateTestUser();
-    const registerResponse = await page.request.post(
-      `${process.env.API_BASE_URL || 'http://localhost:3000'}/v1/auth/register`,
-      {
-        data: {
-          firstName: user.firstName,
-          lastName: user.lastName,
-          email: user.email,
-          password: user.password,
-        },
-      }
-    );
+    const registerResponse = await registerViaApi(page.request, user);
     expect(registerResponse.ok()).toBeTruthy();
 
     await loginPage.goto();
@@ -203,17 +176,7 @@ test.describe('Translation Upload Workflow - Happy Path', () => {
   test('should validate file upload requirements', async ({ page }) => {
     // Setup: Login and navigate to upload
     const user = generateTestUser();
-    const registerResponse = await page.request.post(
-      `${process.env.API_BASE_URL || 'http://localhost:3000'}/v1/auth/register`,
-      {
-        data: {
-          firstName: user.firstName,
-          lastName: user.lastName,
-          email: user.email,
-          password: user.password,
-        },
-      }
-    );
+    const registerResponse = await registerViaApi(page.request, user);
     expect(registerResponse.ok()).toBeTruthy();
 
     await loginPage.goto();

--- a/frontend/src/__tests__/resolveApiUrl.test.ts
+++ b/frontend/src/__tests__/resolveApiUrl.test.ts
@@ -1,56 +1,29 @@
 /**
- * Unit tests for the resolveApiUrl URL-normalisation helper (e2e/fixtures/auth.ts).
+ * Unit tests for the resolveApiUrl URL-normalisation helper.
  *
- * The helper is the single source of truth for how `API_BASE_URL` is consumed
- * by E2E fixtures.  These tests lock in the contract so a future edit cannot
- * accidentally reintroduce the double-version-prefix bug fixed in
- * fix/e2e-register-via-api-double-v1-prefix.
+ * The function lives in `e2e/fixtures/url.ts` — a Playwright-free module
+ * extracted specifically so it can be imported here without pulling in the
+ * Playwright bootstrap. This file imports the real implementation; there is
+ * no inline copy to drift.
  *
- * Bug summary:
- *   In CI, `API_BASE_URL` is set to the CloudFormation `ApiUrl` output, which
- *   already includes the `/v1` stage suffix, e.g.:
- *     `https://8brwlwf68h.execute-api.us-east-1.amazonaws.com/v1/`
- *   The old code stripped the trailing slash → `.../v1`, then appended
- *   `/v1/auth/register`, producing `.../v1/v1/auth/register` → HTTP 404.
- *   The fix: treat `API_BASE_URL` as the full base (host + version prefix)
- *   and append only `/auth/register`.
+ * These tests lock in the API_BASE_URL env-var contract and prevent a
+ * regression of the double-version-prefix bug fixed in
+ * fix/e2e-register-via-api-double-v1-prefix:
  *
- * Implementation note:
- *   `resolveApiUrl` is a pure function with no Playwright dependency. Vitest
- *   excludes `e2e/**` files from running as test suites (to avoid Playwright
- *   bootstrap), but NOT from being imported. However, `e2e/fixtures/auth.ts`
- *   imports `@playwright/test` at the top level, which would fail in jsdom.
- *   We therefore inline the identical two-line implementation here so the
- *   logic is tested without dragging in Playwright. If the implementation
- *   ever changes, update both places.
+ *   In CI, API_BASE_URL is the CloudFormation ApiUrl output which already
+ *   includes the /v1 stage suffix, e.g.:
+ *     https://8brwlwf68h.execute-api.us-east-1.amazonaws.com/v1/
+ *   The old auth.ts helper stripped the trailing slash → .../v1, then
+ *   appended /v1/auth/register → .../v1/v1/auth/register → HTTP 404.
+ *   Fix: callers append only /auth/register (no /v1 prefix).
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { resolveApiUrl } from '../../e2e/fixtures/url';
 
-/**
- * Inline copy of `resolveApiUrl` from `e2e/fixtures/auth.ts`.
- *
- * Contract: the input already contains the version prefix (e.g. `/v1`).
- * Callers append only the resource path (e.g. `/auth/register`).
- */
-function resolveApiUrl(apiBaseUrl?: string): string {
-  const raw = apiBaseUrl ?? process.env.API_BASE_URL ?? 'http://localhost:3000';
-  return raw.endsWith('/') ? raw.slice(0, -1) : raw;
-}
-
-describe('resolveApiUrl (e2e/fixtures/auth.ts contract)', () => {
-  const ORIGINAL_ENV = process.env.API_BASE_URL;
-
-  beforeEach(() => {
-    delete process.env.API_BASE_URL;
-  });
-
+describe('resolveApiUrl (e2e/fixtures/url.ts contract)', () => {
   afterEach(() => {
-    if (ORIGINAL_ENV !== undefined) {
-      process.env.API_BASE_URL = ORIGINAL_ENV;
-    } else {
-      delete process.env.API_BASE_URL;
-    }
+    vi.unstubAllEnvs();
   });
 
   describe('explicit apiBaseUrl argument', () => {
@@ -62,16 +35,17 @@ describe('resolveApiUrl (e2e/fixtures/auth.ts contract)', () => {
       expect(resolveApiUrl('https://example.com/v1/')).toBe('https://example.com/v1');
     });
 
-    it('strips only one trailing slash (does not collapse //)', () => {
-      // Defensive: if someone passes a double slash we strip just the last one
+    it('strips only the last character when input ends with //', () => {
+      // Single strip: the function removes exactly one trailing slash per call.
+      // A double-slash input is unusual but should not silently collapse further.
       expect(resolveApiUrl('https://example.com/v1//')).toBe('https://example.com/v1/');
     });
 
     it('key regression: CloudFormation ApiUrl format does not double-prefix v1', () => {
-      // This is the exact value CI passes as API_BASE_URL (CloudFormation output).
+      // This is the exact value CI passes as API_BASE_URL (CloudFormation ApiUrl output).
       const cfnApiUrl = 'https://8brwlwf68h.execute-api.us-east-1.amazonaws.com/v1/';
       const resolved = resolveApiUrl(cfnApiUrl);
-      // After normalization, appending /auth/register must NOT contain /v1/v1/
+      // After normalisation, appending /auth/register must NOT produce /v1/v1/
       const fullUrl = `${resolved}/auth/register`;
       expect(fullUrl).toBe(
         'https://8brwlwf68h.execute-api.us-east-1.amazonaws.com/v1/auth/register'
@@ -82,17 +56,17 @@ describe('resolveApiUrl (e2e/fixtures/auth.ts contract)', () => {
 
   describe('API_BASE_URL environment variable fallback', () => {
     it('reads from process.env.API_BASE_URL when no argument provided', () => {
-      process.env.API_BASE_URL = 'https://env-api.example.com/v1';
+      vi.stubEnv('API_BASE_URL', 'https://env-api.example.com/v1');
       expect(resolveApiUrl()).toBe('https://env-api.example.com/v1');
     });
 
     it('strips trailing slash from env var value', () => {
-      process.env.API_BASE_URL = 'https://env-api.example.com/v1/';
+      vi.stubEnv('API_BASE_URL', 'https://env-api.example.com/v1/');
       expect(resolveApiUrl()).toBe('https://env-api.example.com/v1');
     });
 
     it('explicit argument takes precedence over env var', () => {
-      process.env.API_BASE_URL = 'https://env-api.example.com/v1';
+      vi.stubEnv('API_BASE_URL', 'https://env-api.example.com/v1');
       expect(resolveApiUrl('https://override.example.com/v1')).toBe(
         'https://override.example.com/v1'
       );
@@ -100,7 +74,8 @@ describe('resolveApiUrl (e2e/fixtures/auth.ts contract)', () => {
   });
 
   describe('default fallback (no argument, no env var)', () => {
-    it('returns localhost:3000 when nothing is configured', () => {
+    it('returns localhost:3000 when env var is absent', () => {
+      // vi.unstubAllEnvs() is called in afterEach, so API_BASE_URL is not set.
       expect(resolveApiUrl()).toBe('http://localhost:3000');
     });
   });

--- a/frontend/src/__tests__/resolveApiUrl.test.ts
+++ b/frontend/src/__tests__/resolveApiUrl.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Unit tests for the resolveApiUrl URL-normalisation helper (e2e/fixtures/auth.ts).
+ *
+ * The helper is the single source of truth for how `API_BASE_URL` is consumed
+ * by E2E fixtures.  These tests lock in the contract so a future edit cannot
+ * accidentally reintroduce the double-version-prefix bug fixed in
+ * fix/e2e-register-via-api-double-v1-prefix.
+ *
+ * Bug summary:
+ *   In CI, `API_BASE_URL` is set to the CloudFormation `ApiUrl` output, which
+ *   already includes the `/v1` stage suffix, e.g.:
+ *     `https://8brwlwf68h.execute-api.us-east-1.amazonaws.com/v1/`
+ *   The old code stripped the trailing slash → `.../v1`, then appended
+ *   `/v1/auth/register`, producing `.../v1/v1/auth/register` → HTTP 404.
+ *   The fix: treat `API_BASE_URL` as the full base (host + version prefix)
+ *   and append only `/auth/register`.
+ *
+ * Implementation note:
+ *   `resolveApiUrl` is a pure function with no Playwright dependency. Vitest
+ *   excludes `e2e/**` files from running as test suites (to avoid Playwright
+ *   bootstrap), but NOT from being imported. However, `e2e/fixtures/auth.ts`
+ *   imports `@playwright/test` at the top level, which would fail in jsdom.
+ *   We therefore inline the identical two-line implementation here so the
+ *   logic is tested without dragging in Playwright. If the implementation
+ *   ever changes, update both places.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+/**
+ * Inline copy of `resolveApiUrl` from `e2e/fixtures/auth.ts`.
+ *
+ * Contract: the input already contains the version prefix (e.g. `/v1`).
+ * Callers append only the resource path (e.g. `/auth/register`).
+ */
+function resolveApiUrl(apiBaseUrl?: string): string {
+  const raw = apiBaseUrl ?? process.env.API_BASE_URL ?? 'http://localhost:3000';
+  return raw.endsWith('/') ? raw.slice(0, -1) : raw;
+}
+
+describe('resolveApiUrl (e2e/fixtures/auth.ts contract)', () => {
+  const ORIGINAL_ENV = process.env.API_BASE_URL;
+
+  beforeEach(() => {
+    delete process.env.API_BASE_URL;
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_ENV !== undefined) {
+      process.env.API_BASE_URL = ORIGINAL_ENV;
+    } else {
+      delete process.env.API_BASE_URL;
+    }
+  });
+
+  describe('explicit apiBaseUrl argument', () => {
+    it('returns URL unchanged when no trailing slash', () => {
+      expect(resolveApiUrl('https://example.com/v1')).toBe('https://example.com/v1');
+    });
+
+    it('strips a single trailing slash', () => {
+      expect(resolveApiUrl('https://example.com/v1/')).toBe('https://example.com/v1');
+    });
+
+    it('strips only one trailing slash (does not collapse //)', () => {
+      // Defensive: if someone passes a double slash we strip just the last one
+      expect(resolveApiUrl('https://example.com/v1//')).toBe('https://example.com/v1/');
+    });
+
+    it('key regression: CloudFormation ApiUrl format does not double-prefix v1', () => {
+      // This is the exact value CI passes as API_BASE_URL (CloudFormation output).
+      const cfnApiUrl = 'https://8brwlwf68h.execute-api.us-east-1.amazonaws.com/v1/';
+      const resolved = resolveApiUrl(cfnApiUrl);
+      // After normalization, appending /auth/register must NOT contain /v1/v1/
+      const fullUrl = `${resolved}/auth/register`;
+      expect(fullUrl).toBe(
+        'https://8brwlwf68h.execute-api.us-east-1.amazonaws.com/v1/auth/register'
+      );
+      expect(fullUrl).not.toContain('/v1/v1/');
+    });
+  });
+
+  describe('API_BASE_URL environment variable fallback', () => {
+    it('reads from process.env.API_BASE_URL when no argument provided', () => {
+      process.env.API_BASE_URL = 'https://env-api.example.com/v1';
+      expect(resolveApiUrl()).toBe('https://env-api.example.com/v1');
+    });
+
+    it('strips trailing slash from env var value', () => {
+      process.env.API_BASE_URL = 'https://env-api.example.com/v1/';
+      expect(resolveApiUrl()).toBe('https://env-api.example.com/v1');
+    });
+
+    it('explicit argument takes precedence over env var', () => {
+      process.env.API_BASE_URL = 'https://env-api.example.com/v1';
+      expect(resolveApiUrl('https://override.example.com/v1')).toBe(
+        'https://override.example.com/v1'
+      );
+    });
+  });
+
+  describe('default fallback (no argument, no env var)', () => {
+    it('returns localhost:3000 when nothing is configured', () => {
+      expect(resolveApiUrl()).toBe('http://localhost:3000');
+    });
+  });
+});


### PR DESCRIPTION
## Bug

**File:** `frontend/e2e/fixtures/auth.ts` line 57 (before this fix)

In CI the `API_BASE_URL` env var is set to the CloudFormation `ApiUrl` output, which already includes the `/v1` stage suffix:

```
https://8brwlwf68h.execute-api.us-east-1.amazonaws.com/v1/
```

The old helper stripped the trailing slash → `.../v1`, then appended `/v1/auth/register`, producing the double prefix:

```
https://8brwlwf68h.execute-api.us-east-1.amazonaws.com/v1/v1/auth/register  ← 404
```

Every auth E2E test failed in `beforeEach` because `registerResponse.ok()` was false. The live endpoint is healthy (HTTP 201 confirmed by curl against the un-prefixed URL).

## Option chosen: A — align with the existing convention

**Why:** `production-smoke.spec.ts` (line 98) and every backend integration test already treat `API_BASE_URL` as the full base URL including version prefix and append only `/auth/register`. Matching that convention is the minimal correct fix with zero blast radius. Option B (stripping `/v1` suffix) encodes the version string into the fixture logic; Option C (changing the workflow env var) touches three workflow files and all other consumers.

## Pre-flight grep results

`API_BASE_URL` consumers in the repo:

- **`frontend/e2e/fixtures/auth.ts`** — this file (fixed here)
- **`frontend/e2e/tests/smoke/production-smoke.spec.ts`** — already uses `apiUrl + '/auth/register'` (no `/v1/` prefix added); the working reference implementation
- **`frontend/e2e/tests/translation/*.spec.ts`** — inline `API_BASE_URL + '/v1/...'` calls; these share the same bug pattern but are separate inline call-sites not going through the centralized fixture (migrated in Round 2 below)
- **`backend/functions/__tests__/integration/helpers/test-helpers.ts`** — already uses `API_BASE_URL` as base and appends `/auth/register`, `/jobs/upload` etc. directly (correct convention)
- **`.github/workflows/deploy-backend.yml`** and **`deploy-frontend.yml`** — set `API_BASE_URL` from CloudFormation `ApiUrl` output (value already includes `/v1`)

No consumer other than the old `registerViaApi` was assuming `API_BASE_URL` is host-only. Changing only `auth.ts` is safe.

## Round 1 — What changed

- **`frontend/e2e/fixtures/auth.ts`**: Added `resolveApiUrl(apiBaseUrl?)` inline. Changed `registerViaApi` to append `/auth/register` instead of `/v1/auth/register`. Extended JSDoc.

- **`frontend/src/__tests__/resolveApiUrl.test.ts`** (new): 8 Vitest unit tests covering URL normalisation, including a named regression test asserting the CloudFormation URL format resolves correctly without the double `/v1/` prefix.

## Round 2 — OMC follow-up items applied

### Critical 1 — extract `resolveApiUrl` to a Playwright-free module

`resolveApiUrl` moved from its inline location in `auth.ts` to a new file `frontend/e2e/fixtures/url.ts` that has zero Playwright imports. This allows the Vitest unit test to import the real implementation directly instead of maintaining an inlined copy. The "update both places" comment has been removed. Both `auth.ts` and `production-smoke.spec.ts` now import from `./url` / `../../fixtures/url`.

### Critical 2 — migrate all 7 translation specs to `registerViaApi` / `getJobViaApi`

All inline `process.env.API_BASE_URL + '/v1/auth/register'` call-sites across `frontend/e2e/tests/translation/*.spec.ts` have been replaced with the centralized `registerViaApi()` helper. A new `getJobViaApi(request, jobId, authToken, apiBaseUrl?)` helper was added to `auth.ts` for `GET /translation/jobs/{id}` calls; all inline job-fetch constructions have been replaced with it.

**Bonus bug fixed:** `multi-language.spec.ts` had a copy-paste bug where the tone-verification step was GET-ting `/auth/register` instead of `/translation/jobs/{id}`. The migration to `getJobViaApi` fixed this incidentally.

### Recommended 2 — `production-smoke.spec.ts` uses `resolveApiUrl`

Replaced the inline trailing-slash-strip logic with `resolveApiUrl(apiBaseURL)`.

### Recommended 3 — `vi.stubEnv()` / `vi.unstubAllEnvs()` in unit test

Replaced manual `process.env` save/restore with Vitest's built-in env stubbing API.

### Recommended 4 — `@see` cross-references in JSDoc

Added cross-references between `resolveApiUrl`, `registerViaApi`, and `getJobViaApi`.

### Out of scope (deferred)

- ESLint grep guard ensuring `API_BASE_URL + '/v1/'` never re-appears
- Permissive scheme handling in `resolveApiUrl` (http vs https)
- Double-slash comment clarity improvements

## Verification

```
npm run lint          ✅ 0 warnings, 0 errors
npm run format:check  ✅ All files pass Prettier
npx vitest run src/__tests__/resolveApiUrl.test.ts
                      ✅ 8/8 tests pass
npm run type-check    ℹ️  1 pre-existing error in uploadService.ts (unrelated, exists on main)
```