### PR TITLE
fix(e2e): correct import depth for legalAttestationLabels (PR #189 regression)

### DIFF
--- a/frontend/e2e/tests/translation/legal-attestation.spec.ts
+++ b/frontend/e2e/tests/translation/legal-attestation.spec.ts
@@ -15,7 +15,7 @@ import { DashboardPage } from '../../pages/DashboardPage';
 import { TranslationUploadPage } from '../../pages/TranslationUploadPage';
 import { generateTestUser } from '../../fixtures/auth';
 import { TEST_DOCUMENTS } from '../../fixtures/test-documents';
-import { LEGAL_ATTESTATION_LABEL_PATTERNS as L } from '../../src/components/Translation/legalAttestationLabels';
+import { LEGAL_ATTESTATION_LABEL_PATTERNS as L } from '../../../src/components/Translation/legalAttestationLabels';
 import * as fs from 'fs';
 import * as path from 'path';
 import { fileURLToPath } from 'url';


### PR DESCRIPTION
## Summary

Hotfix for a one-character import-path regression introduced by PR #189 that breaks the entire E2E suite at module-load time.

`frontend/e2e/tests/translation/legal-attestation.spec.ts` is three directories deep (`frontend/e2e/tests/translation/`), but its import of `legalAttestationLabels` only used two `..` segments. The path resolved to `frontend/e2e/src/components/Translation/legalAttestationLabels` — which does not exist — so Playwright failed to load the spec file and the run aborted.

The sister import in `frontend/e2e/pages/TranslationUploadPage.ts:19` uses the same string but is correct because that file is only two directories deep — left untouched.

## CI failure (the bug)

From [run 25290768283](https://github.com/leixiaoyu/lfmt-poc/actions/runs/25290768283) (jobs "Run E2E Tests" and "Run Production Smoke Tests"):

```
Error: Cannot find module '/home/runner/work/lfmt-poc/lfmt-poc/frontend/e2e/src/components/Translation/legalAttestationLabels'
imported from /home/runner/work/lfmt-poc/lfmt-poc/frontend/e2e/tests/translation/legal-attestation.spec.ts
```

## Why the path was wrong (depth analysis)

| File | Depth from `frontend/` | `..` segments needed to reach `frontend/src/...` |
| --- | --- | --- |
| `frontend/e2e/pages/TranslationUploadPage.ts` | 2 (`e2e/pages/`) | `../..` (correct) |
| `frontend/e2e/tests/translation/legal-attestation.spec.ts` | 3 (`e2e/tests/translation/`) | `../../..` (was `../..` — broken) |

Fix: add the missing `..` segment.

```diff
-import { LEGAL_ATTESTATION_LABEL_PATTERNS as L } from '../../src/components/Translation/legalAttestationLabels';
+import { LEGAL_ATTESTATION_LABEL_PATTERNS as L } from '../../../src/components/Translation/legalAttestationLabels';
```

## Other broken imports?

Confirmed via `grep -rn "legalAttestationLabels" frontend/e2e/` — only the one spec file was broken. All other matches in the e2e tree are either the (correct) `TranslationUploadPage.ts:19` import or comments. No other fixes needed.

## Verification (local, before push)

| Check | Command | Result |
| --- | --- | --- |
| Type-check | `npm run type-check` (in `frontend/`) | PASS |
| Lint | `npm run lint` (in `frontend/`) | PASS |
| Format | `npm run format:check` (in `frontend/`) | PASS |

`format:check` was explicitly run because PR #189 was bitten by skipping it earlier today.

Note: `type-check` requires `shared-types/dist/` to exist (it does in CI; locally I ran `npm run build` in `shared-types/` first).

## Test plan

- [ ] CI green on this PR (`Run Tests` + `Build Infrastructure` + E2E + production smoke)
- [ ] Confirm Playwright loads `legal-attestation.spec.ts` without the `Cannot find module` error