### PR TITLE
feat(auth): harden CSP, simplify token storage (#194 #195 #196)

### DIFF
--- a/backend/infrastructure/lib/__tests__/infrastructure.test.ts
+++ b/backend/infrastructure/lib/__tests__/infrastructure.test.ts
@@ -1311,6 +1311,13 @@ describe('LFMT Infrastructure Stack', () => {
           throw new Error(`script-src directive missing from CSP: ${flat}`);
         }
         expect(scriptSrcMatch[0]).not.toContain("'unsafe-inline'");
+        // Round 2 item 4: positive assertion. A test that only checks
+        // for absence is fragile against a future regression that
+        // accidentally drops the directive entirely (e.g.,
+        // `script-src` missing → browser defaults to `default-src`,
+        // which IS `'self'`, so the SPA still loads but the contract
+        // is now implicit). Assert `'self'` is the explicit value.
+        expect(scriptSrcMatch[0]).toMatch(/^script-src\s+'self'\s*$/);
       });
     });
 

--- a/backend/infrastructure/lib/__tests__/infrastructure.test.ts
+++ b/backend/infrastructure/lib/__tests__/infrastructure.test.ts
@@ -1237,9 +1237,6 @@ describe('LFMT Infrastructure Stack', () => {
       // 'unsafe-eval' was removed from script-src after verifying that the
       // production Vite/MUI bundle contains no eval()/new Function() calls.
       // Re-introducing it would weaken script-src CSP and must trip CI.
-      // Note: 'unsafe-inline' is intentionally NOT asserted absent yet —
-      // that lands with Part 1 (nonce-injection pipeline). Tracked in the
-      // Part 1 follow-up issue.
       const flattenCsp = (csp: unknown): string => {
         if (typeof csp === 'string') return csp;
         if (csp && typeof csp === 'object' && 'Fn::Join' in (csp as object)) {
@@ -1263,6 +1260,57 @@ describe('LFMT Infrastructure Stack', () => {
             .ContentSecurityPolicy;
         const flat = flattenCsp(csp);
         expect(flat).not.toContain("'unsafe-eval'");
+      });
+    });
+
+    test("script-src does not contain 'unsafe-inline' (Issue #194)", () => {
+      // Regression guard for Issue #194.
+      //
+      // 'unsafe-inline' on script-src would let an XSS payload inject an
+      // inline `<script>` to read `localStorage` and exfiltrate the API
+      // Gateway Bearer credential — exactly the risk the OMC reviewer
+      // flagged on PR #193 once `idToken` started living in localStorage.
+      //
+      // The directive is safely removable because the built `dist/index.html`
+      // emits no inline `<script>` blocks (verified during PR #194).
+      // Re-introducing 'unsafe-inline' on script-src would re-open the
+      // exfiltration class and must trip CI.
+      //
+      // Note: 'unsafe-inline' on style-src remains present. MUI/Emotion
+      // injects runtime styles via document.head.appendChild('<style>')
+      // and removing this directive requires a Lambda@Edge nonce
+      // pipeline. That work is tracked in a separate follow-up issue;
+      // it does not address the same exfiltration class.
+      const flattenCsp = (csp: unknown): string => {
+        if (typeof csp === 'string') return csp;
+        if (csp && typeof csp === 'object' && 'Fn::Join' in (csp as object)) {
+          const join = (csp as { 'Fn::Join': [string, unknown[]] })['Fn::Join'];
+          const parts = join[1];
+          return parts.map((p) => (typeof p === 'string' ? p : JSON.stringify(p))).join('');
+        }
+        return JSON.stringify(csp);
+      };
+
+      const policies = template.findResources('AWS::CloudFront::ResponseHeadersPolicy');
+      const cspCarryingPolicies = Object.values(policies).filter((policy: any) => {
+        return !!policy?.Properties?.ResponseHeadersPolicyConfig?.SecurityHeadersConfig
+          ?.ContentSecurityPolicy?.ContentSecurityPolicy;
+      });
+      expect(cspCarryingPolicies.length).toBeGreaterThanOrEqual(2);
+
+      cspCarryingPolicies.forEach((policy: any) => {
+        const csp =
+          policy.Properties.ResponseHeadersPolicyConfig.SecurityHeadersConfig.ContentSecurityPolicy
+            .ContentSecurityPolicy;
+        const flat = flattenCsp(csp);
+        // Extract just the script-src directive, then assert it does
+        // NOT contain 'unsafe-inline'. Avoids accidentally tripping on
+        // the style-src 'unsafe-inline' that is intentionally retained.
+        const scriptSrcMatch = flat.match(/script-src[^;]*/);
+        if (!scriptSrcMatch) {
+          throw new Error(`script-src directive missing from CSP: ${flat}`);
+        }
+        expect(scriptSrcMatch[0]).not.toContain("'unsafe-inline'");
       });
     });
 

--- a/backend/infrastructure/lib/lfmt-infrastructure-stack.ts
+++ b/backend/infrastructure/lib/lfmt-infrastructure-stack.ts
@@ -1786,33 +1786,12 @@ export class LfmtInfrastructureStack extends Stack {
           override: true,
         },
         contentSecurityPolicy: {
-          // NOTE: This CSP will be updated after API Gateway is created to include the actual API URL.
-          //
-          // CSP hardening status (Issues #133, #194):
-          //   - 'unsafe-eval' REMOVED from script-src (Part 2 — verified safe
-          //     via bundle inspection; standard Vite + MUI/Emotion do not
-          //     require eval).
-          //   - 'unsafe-inline' REMOVED from script-src (Issue #194 — verified
-          //     safe by inspecting the built `frontend/dist/index.html`:
-          //     Vite emits ONLY external `<script type="module"
-          //     src="/assets/...">` tags, no inline `<script>` blocks. With
-          //     this directive gone, an XSS payload can no longer inject an
-          //     inline `<script>` to read `localStorage` and exfiltrate the
-          //     Bearer credential — closes the specific risk OMC review
-          //     flagged on PR #193.
-          //   - 'unsafe-inline' RETAINED on style-src — MUI/Emotion emit
-          //     runtime inline styles via `document.head.appendChild('<style>')`.
-          //     Removal blocked on a nonce-injection pipeline (Lambda@Edge
-          //     for the response + Emotion CacheProvider with `nonce` for
-          //     the runtime). Deferred to a follow-up tracking issue; the
-          //     script-src tightening above already addresses the OMC
-          //     reviewer's primary concern (token exfiltration via inline
-          //     script).
-          //
-          // Other hardening directives retained: object-src 'none', base-uri 'self',
-          // form-action 'self', frame-ancestors 'none', upgrade-insecure-requests.
-          // See: https://github.com/leixiaoyu/lfmt-poc/issues/63
-          contentSecurityPolicy: "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://*.execute-api.us-east-1.amazonaws.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests;",
+          // CSP body sourced from `buildCsp()` (Round 2 item 10).
+          // The `connect-src` argument is a region-wide wildcard at
+          // initial deploy time — `updateCloudFrontCSP()` swaps it for
+          // the concrete API Gateway domain once that resource exists.
+          // See `buildCsp()` JSDoc for the full hardening status.
+          contentSecurityPolicy: this.buildCsp('https://*.execute-api.us-east-1.amazonaws.com'),
           override: true,
         },
       },
@@ -1873,6 +1852,65 @@ export class LfmtInfrastructureStack extends Stack {
     }));
   }
 
+  /**
+   * Build the Content-Security-Policy header string (Round 2 item 10).
+   *
+   * Single source of truth for the CSP — previously the policy string
+   * was duplicated between the initial response-headers policy (line
+   * ~1815) and the post-API-Gateway "Updated" policy (line ~1941).
+   * Drift between the two would have been a real risk; future hardening
+   * (e.g., Issue #197's `style-src` nonce work) now only edits ONE
+   * place.
+   *
+   * The only per-call variable is `connectSrc` — the wildcard
+   * `https://*.execute-api.us-east-1.amazonaws.com` is used at initial
+   * deploy time (before API Gateway exists), then replaced with the
+   * concrete `https://<apiId>.execute-api.<region>.amazonaws.com` once
+   * the API is provisioned.
+   *
+   * Hardening status (Issues #133, #194):
+   *   - 'unsafe-eval' REMOVED from script-src.
+   *   - 'unsafe-inline' REMOVED from script-src — Vite's built
+   *     `dist/index.html` has no inline `<script>` blocks.
+   *   - 'unsafe-inline' RETAINED on style-src — MUI/Emotion injects
+   *     runtime styles via `document.head.appendChild('<style>')`,
+   *     removal blocked on the Lambda@Edge nonce pipeline tracked in
+   *     issue #197.
+   *
+   * Telemetry (Round 2 item 9 — DEFERRED to issue #201):
+   *
+   *   The `report-uri` directive is INTENTIONALLY OMITTED from this
+   *   build. Implementing it correctly requires (1) a new Lambda
+   *   function to receive POST /csp-report; (2) a new API Gateway
+   *   route with no auth and request-size limits; (3) CORS
+   *   configuration since browsers send violation reports
+   *   cross-origin. That is a meaningful infrastructure change which
+   *   the OMC reviewer's "out of scope" guard for this PR specifically
+   *   excluded.
+   *
+   *   Issue #201 has the full implementation plan and acceptance
+   *   criteria; when it lands, the activation here is a one-line
+   *   edit: append `report-uri ${reportUri}` to the directive list
+   *   below and pass the new endpoint URL through `updateCloudFrontCSP`.
+   *   Until then, every reviewer who looks at this code will see this
+   *   block and know exactly what to do (and why we didn't do it now).
+   */
+  private buildCsp(connectSrc: string): string {
+    return [
+      `default-src 'self'`,
+      `script-src 'self'`,
+      `style-src 'self' 'unsafe-inline'`,
+      `img-src 'self' data: https:`,
+      `font-src 'self' data:`,
+      `connect-src 'self' ${connectSrc}`,
+      `object-src 'none'`,
+      `base-uri 'self'`,
+      `form-action 'self'`,
+      `frame-ancestors 'none'`,
+      `upgrade-insecure-requests`,
+    ].join('; ') + ';';
+  }
+
   private updateCloudFrontCSP() {
     /**
      * Update CloudFront CSP with API Gateway URL
@@ -1916,29 +1954,11 @@ export class LfmtInfrastructureStack extends Stack {
           override: true,
         },
         contentSecurityPolicy: {
-          // CSP with specific API Gateway domain (Issue #63).
-          //
-          // CSP hardening status (Issues #133, #194):
-          //   - 'unsafe-eval' REMOVED from script-src (Part 2 — verified safe
-          //     via bundle inspection; standard Vite + MUI/Emotion do not
-          //     require eval).
-          //   - 'unsafe-inline' REMOVED from script-src (Issue #194 — verified
-          //     safe by inspecting the built `frontend/dist/index.html`:
-          //     Vite emits ONLY external `<script type="module"
-          //     src="/assets/...">` tags, no inline `<script>` blocks. With
-          //     this directive gone, an XSS payload can no longer inject an
-          //     inline `<script>` to read `localStorage` and exfiltrate the
-          //     Bearer credential — closes the specific risk OMC review
-          //     flagged on PR #193.
-          //   - 'unsafe-inline' RETAINED on style-src — MUI/Emotion emit
-          //     runtime inline styles via `document.head.appendChild('<style>')`.
-          //     Removal blocked on a nonce-injection pipeline (Lambda@Edge
-          //     for the response + Emotion CacheProvider with `nonce` for
-          //     the runtime). Deferred to a follow-up tracking issue.
-          //
-          // Other hardening directives retained: object-src 'none', base-uri 'self',
-          // form-action 'self', frame-ancestors 'none', upgrade-insecure-requests.
-          contentSecurityPolicy: `default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://${apiDomain}; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests;`,
+          // CSP body sourced from `buildCsp()` (Round 2 item 10) so the
+          // initial and updated policies cannot drift. `connect-src` is
+          // now the concrete API Gateway domain — see `buildCsp()`
+          // JSDoc for the full hardening status (#133, #194, #197).
+          contentSecurityPolicy: this.buildCsp(`https://${apiDomain}`),
           override: true,
         },
       },

--- a/backend/infrastructure/lib/lfmt-infrastructure-stack.ts
+++ b/backend/infrastructure/lib/lfmt-infrastructure-stack.ts
@@ -1788,21 +1788,31 @@ export class LfmtInfrastructureStack extends Stack {
         contentSecurityPolicy: {
           // NOTE: This CSP will be updated after API Gateway is created to include the actual API URL.
           //
-          // CSP hardening status (Issue #133):
-          //   - 'unsafe-eval' REMOVED from script-src (Part 2 — verified safe via
-          //     bundle inspection; standard Vite + MUI/Emotion do not require eval).
-          //   - 'unsafe-inline' RETAINED on style-src — MUI/Emotion emit runtime
-          //     inline styles. Removal blocked on a nonce-injection pipeline
-          //     (Lambda@Edge + Emotion CacheProvider integration). Tracked in
-          //     follow-up issue (Part 1 of #133).
-          //   - 'unsafe-inline' RETAINED on script-src — kept until the same
-          //     nonce pipeline lands (so the script-src tightening rolls out
-          //     atomically with style-src).
+          // CSP hardening status (Issues #133, #194):
+          //   - 'unsafe-eval' REMOVED from script-src (Part 2 — verified safe
+          //     via bundle inspection; standard Vite + MUI/Emotion do not
+          //     require eval).
+          //   - 'unsafe-inline' REMOVED from script-src (Issue #194 — verified
+          //     safe by inspecting the built `frontend/dist/index.html`:
+          //     Vite emits ONLY external `<script type="module"
+          //     src="/assets/...">` tags, no inline `<script>` blocks. With
+          //     this directive gone, an XSS payload can no longer inject an
+          //     inline `<script>` to read `localStorage` and exfiltrate the
+          //     Bearer credential — closes the specific risk OMC review
+          //     flagged on PR #193.
+          //   - 'unsafe-inline' RETAINED on style-src — MUI/Emotion emit
+          //     runtime inline styles via `document.head.appendChild('<style>')`.
+          //     Removal blocked on a nonce-injection pipeline (Lambda@Edge
+          //     for the response + Emotion CacheProvider with `nonce` for
+          //     the runtime). Deferred to a follow-up tracking issue; the
+          //     script-src tightening above already addresses the OMC
+          //     reviewer's primary concern (token exfiltration via inline
+          //     script).
           //
           // Other hardening directives retained: object-src 'none', base-uri 'self',
           // form-action 'self', frame-ancestors 'none', upgrade-insecure-requests.
           // See: https://github.com/leixiaoyu/lfmt-poc/issues/63
-          contentSecurityPolicy: "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://*.execute-api.us-east-1.amazonaws.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests;",
+          contentSecurityPolicy: "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://*.execute-api.us-east-1.amazonaws.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests;",
           override: true,
         },
       },
@@ -1908,20 +1918,27 @@ export class LfmtInfrastructureStack extends Stack {
         contentSecurityPolicy: {
           // CSP with specific API Gateway domain (Issue #63).
           //
-          // CSP hardening status (Issue #133):
-          //   - 'unsafe-eval' REMOVED from script-src (Part 2 — verified safe via
-          //     bundle inspection; standard Vite + MUI/Emotion do not require eval).
-          //   - 'unsafe-inline' RETAINED on style-src — MUI/Emotion emit runtime
-          //     inline styles. Removal blocked on a nonce-injection pipeline
-          //     (Lambda@Edge + Emotion CacheProvider integration). Tracked in
-          //     follow-up issue (Part 1 of #133).
-          //   - 'unsafe-inline' RETAINED on script-src — kept until the same
-          //     nonce pipeline lands (so the script-src tightening rolls out
-          //     atomically with style-src).
+          // CSP hardening status (Issues #133, #194):
+          //   - 'unsafe-eval' REMOVED from script-src (Part 2 — verified safe
+          //     via bundle inspection; standard Vite + MUI/Emotion do not
+          //     require eval).
+          //   - 'unsafe-inline' REMOVED from script-src (Issue #194 — verified
+          //     safe by inspecting the built `frontend/dist/index.html`:
+          //     Vite emits ONLY external `<script type="module"
+          //     src="/assets/...">` tags, no inline `<script>` blocks. With
+          //     this directive gone, an XSS payload can no longer inject an
+          //     inline `<script>` to read `localStorage` and exfiltrate the
+          //     Bearer credential — closes the specific risk OMC review
+          //     flagged on PR #193.
+          //   - 'unsafe-inline' RETAINED on style-src — MUI/Emotion emit
+          //     runtime inline styles via `document.head.appendChild('<style>')`.
+          //     Removal blocked on a nonce-injection pipeline (Lambda@Edge
+          //     for the response + Emotion CacheProvider with `nonce` for
+          //     the runtime). Deferred to a follow-up tracking issue.
           //
           // Other hardening directives retained: object-src 'none', base-uri 'self',
           // form-action 'self', frame-ancestors 'none', upgrade-insecure-requests.
-          contentSecurityPolicy: `default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://${apiDomain}; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests;`,
+          contentSecurityPolicy: `default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://${apiDomain}; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests;`,
           override: true,
         },
       },

--- a/frontend/src/__tests__/auth-integration.test.tsx
+++ b/frontend/src/__tests__/auth-integration.test.tsx
@@ -14,6 +14,7 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { AuthProvider } from '../contexts/AuthContext';
 import { ProtectedRoute } from '../components/Auth/ProtectedRoute';
 import * as api from '../utils/api';
+import { setStoredSession } from '../utils/api';
 import { AUTH_CONFIG } from '../config/constants';
 
 // Mock API client
@@ -119,9 +120,12 @@ describe('Authentication Integration Tests', () => {
     const mockToken = 'valid-jwt-token';
 
     beforeEach(() => {
-      // Setup: Valid token and user in localStorage
-      localStorage.setItem(AUTH_CONFIG.ACCESS_TOKEN_KEY, mockToken);
-      localStorage.setItem(AUTH_CONFIG.USER_DATA_KEY, JSON.stringify(mockUser));
+      // Setup: Valid session blob (Issue #196 — one-blob storage).
+      setStoredSession({
+        idToken: mockToken,
+        accessToken: mockToken,
+        user: mockUser,
+      });
 
       // Mock successful API call to verify token
       vi.spyOn(api.apiClient, 'get').mockResolvedValue({
@@ -196,8 +200,8 @@ describe('Authentication Integration Tests', () => {
     const invalidToken = 'expired-jwt-token';
 
     beforeEach(() => {
-      // Setup: Invalid/expired token in localStorage
-      localStorage.setItem(AUTH_CONFIG.ACCESS_TOKEN_KEY, invalidToken);
+      // Setup: invalid/expired session blob.
+      setStoredSession({ idToken: invalidToken, accessToken: invalidToken });
 
       // Mock 401 response for expired token
       vi.spyOn(api.apiClient, 'get').mockRejectedValue({
@@ -224,9 +228,9 @@ describe('Authentication Integration Tests', () => {
       window.history.pushState({}, '', '/protected');
       renderApp();
 
-      // Assert: Should clear localStorage
+      // Assert: Should clear the session blob (and any legacy keys).
       await waitFor(() => {
-        expect(localStorage.getItem(AUTH_CONFIG.ACCESS_TOKEN_KEY)).toBeNull();
+        expect(localStorage.getItem(AUTH_CONFIG.SESSION_KEY)).toBeNull();
       });
     });
   });
@@ -242,7 +246,7 @@ describe('Authentication Integration Tests', () => {
     it.skip('should restore session on page reload with valid token', async () => {
       // Setup: Simulate existing session from previous page load
       const token = 'persisted-token';
-      localStorage.setItem(AUTH_CONFIG.ACCESS_TOKEN_KEY, token);
+      setStoredSession({ idToken: token, accessToken: token });
 
       vi.spyOn(api.apiClient, 'get').mockResolvedValue({
         data: { user: mockUser },

--- a/frontend/src/__tests__/auth-integration.test.tsx
+++ b/frontend/src/__tests__/auth-integration.test.tsx
@@ -92,17 +92,20 @@ describe('Authentication Integration Tests', () => {
       expect(screen.queryByText('Protected Content')).not.toBeInTheDocument();
     });
 
-    it.skip('should show loading state briefly before redirecting', async () => {
-      // Setup: No token
+    it.skip('should show loading state briefly before redirecting (Round 2 item 5: kept skipped — see comment)', async () => {
+      // ROUND 2 ITEM 5: kept skipped after analysis. With no stored
+      // session, AuthContext's `loadUser` effect short-circuits
+      // synchronously (no token → no API call → `isLoading` stays
+      // false → no spinner ever rendered). The test asserts a code
+      // path that doesn't exist — there's nothing to load when
+      // there's no token. The correct fix is to delete this test
+      // entirely; it's preserved here with the explicit "why
+      // skipped" so a future cleanup can remove it without re-doing
+      // the analysis. Cleanup tracked under issue #200 (auth
+      // refactor catch-all).
       window.history.pushState({}, '', '/protected');
-
-      // Act: Render app
       renderApp();
-
-      // Assert: Should show loading initially
       expect(screen.getByRole('progressbar')).toBeInTheDocument();
-
-      // Then redirect to login
       await waitFor(() => {
         expect(screen.getByText('Login Page')).toBeInTheDocument();
       });
@@ -137,50 +140,59 @@ describe('Authentication Integration Tests', () => {
       });
     });
 
-    it.skip('should allow access to protected route with valid token', async () => {
-      // Act: Navigate to protected route
+    // Round 2 item 5: investigated. The skips were originally added in
+    // commit a6d92815 (2025-10-19) without explanation. Re-enabling
+    // surfaces a real failure: the AuthProvider's `loadUser` effect
+    // races the `ProtectedRoute` first render. By the time
+    // `await waitFor(...)` runs, ProtectedRoute has already
+    // `<Navigate to="/login">`-d because `user === null`. Root cause:
+    // BrowserRouter + window.history.pushState + initial client-side
+    // render snapshots before the async loadUser settles, so the test
+    // asserts a state the component briefly was in.
+    //
+    // Two clean fixes — both out of scope for this PR:
+    //   (a) refactor AuthProvider to read user synchronously from
+    //       getStoredUser() and skip the /auth/me round-trip when the
+    //       blob already contains a user object; or
+    //   (b) gate ProtectedRoute on a "still bootstrapping" flag
+    //       distinct from `isLoading` so the redirect doesn't fire
+    //       during the bootstrap window.
+    //
+    // Option (a) is the better long-term answer (it eliminates a
+    // deploy-blocking failure mode where the SPA can't render
+    // anything until /auth/me round-trips); option (b) is a band-aid.
+    // Both belong in issue #200 (the auth refactor catch-all).
+    //
+    // Decision: re-skip with explicit "why" so the next PR has the
+    // analysis ready to go. The "redirect to login when no token
+    // exists" test (above, NOT skipped) covers the negative case.
+    it.skip('should allow access to protected route with valid token (Round 2: see comment, tracked in #200)', async () => {
       window.history.pushState({}, '', '/protected');
       renderApp();
-
-      // Assert: Should show protected content after loading
       await waitFor(() => {
         expect(screen.getByText('Protected Content')).toBeInTheDocument();
       });
-
       expect(screen.queryByText('Login Page')).not.toBeInTheDocument();
     });
 
-    it.skip('should verify token by calling /auth/me endpoint', async () => {
-      // Act: Navigate to protected route
+    it.skip('should verify token by calling /auth/me endpoint (Round 2: see comment, tracked in #200)', async () => {
       window.history.pushState({}, '', '/protected');
       renderApp();
-
-      // Assert: Should call getCurrentUser API
       await waitFor(() => {
         expect(api.apiClient.get).toHaveBeenCalledWith('/auth/me');
       });
-
-      // And show protected content
       expect(await screen.findByText('Protected Content')).toBeInTheDocument();
     });
 
-    it.skip('should show loading state while verifying token', async () => {
-      // Setup: Delay API response to observe loading state
+    it.skip('should show loading state while verifying token (Round 2: see comment, tracked in #200)', async () => {
       let resolveGetUser: (value: any) => void;
       const getUserPromise = new Promise((resolve) => {
         resolveGetUser = resolve;
       });
-
       vi.spyOn(api.apiClient, 'get').mockReturnValue(getUserPromise as any);
-
-      // Act: Navigate to protected route
       window.history.pushState({}, '', '/protected');
       renderApp();
-
-      // Assert: Should show loading
       expect(screen.getByRole('progressbar')).toBeInTheDocument();
-
-      // Resolve API call
       resolveGetUser!({
         data: { user: mockUser },
         status: 200,
@@ -188,8 +200,6 @@ describe('Authentication Integration Tests', () => {
         headers: {},
         config: {} as any,
       });
-
-      // Should show content after loading
       await waitFor(() => {
         expect(screen.getByText('Protected Content')).toBeInTheDocument();
       });
@@ -243,11 +253,12 @@ describe('Authentication Integration Tests', () => {
       lastName: 'User',
     };
 
-    it.skip('should restore session on page reload with valid token', async () => {
-      // Setup: Simulate existing session from previous page load
+    // Round 2 item 5: see the analysis at "Protected Route with Valid
+    // Authentication" above. Same race window — re-skipped with
+    // tracker.
+    it.skip('should restore session on page reload with valid token (Round 2: race window, tracked in #200)', async () => {
       const token = 'persisted-token';
       setStoredSession({ idToken: token, accessToken: token });
-
       vi.spyOn(api.apiClient, 'get').mockResolvedValue({
         data: { user: mockUser },
         status: 200,
@@ -255,16 +266,11 @@ describe('Authentication Integration Tests', () => {
         headers: {},
         config: {} as any,
       });
-
-      // Act: Load protected page (simulating page reload)
       window.history.pushState({}, '', '/protected');
       renderApp();
-
-      // Assert: Should automatically verify token and show content
       await waitFor(() => {
         expect(screen.getByText('Protected Content')).toBeInTheDocument();
       });
-
       expect(api.apiClient.get).toHaveBeenCalledWith('/auth/me');
     });
 

--- a/frontend/src/config/constants.ts
+++ b/frontend/src/config/constants.ts
@@ -69,14 +69,15 @@ export const AUTH_CONFIG = {
    * keys directly — go through the session helpers in `utils/api.ts`
    * instead.
    *
-   * See JSDoc on `LEGACY_KEYS` in `utils/api.ts` for the migration
-   * contract, idempotency guarantees, and the rationale for keeping
-   * these literals in one place.
+   * `utils/api.ts` derives its `LEGACY_KEYS` array from
+   * `Object.values(AUTH_CONFIG.LEGACY)` so this object is the single
+   * source of truth — addition or rename here automatically
+   * propagates to the migration code (Round 2 item 13).
    *
-   * Removal plan: once telemetry confirms no in-the-wild sessions
-   * pre-date the blob (one release cycle is sufficient — the worst
-   * outcome is one 401 → refresh → re-login), this object can be
-   * deleted along with the migration code.
+   * Removal plan: tracked in issue #199. Once telemetry confirms no
+   * in-the-wild sessions pre-date the blob (one release cycle is
+   * sufficient — worst case is one 401 → refresh → re-login), this
+   * object can be deleted along with the migration code.
    */
   LEGACY: {
     ID_TOKEN_KEY: 'lfmt_id_token',

--- a/frontend/src/config/constants.ts
+++ b/frontend/src/config/constants.ts
@@ -44,35 +44,46 @@ export const API_CONFIG = {
  */
 export const AUTH_CONFIG = {
   /**
-   * Local storage key for access token (Cognito AccessToken — for OAuth resource
-   * servers only; NOT accepted by API Gateway CognitoUserPoolsAuthorizer).
-   * Kept for reference but the ID token is used as the Bearer credential.
-   * Note: In production, consider httpOnly cookies for better security.
-   */
-  ACCESS_TOKEN_KEY: 'lfmt_access_token',
-
-  /**
-   * Local storage key for the Cognito ID token.
+   * Local storage key for the one-blob session document (Issue #196).
    *
-   * API Gateway CognitoUserPoolsAuthorizer validates ID tokens (they carry the
-   * user's identity claims — sub, email, given_name, etc.). Access tokens are
-   * designed for OAuth2 resource servers and are NOT accepted by the Cognito
-   * authorizer.  See PR #76 for the backend-side discovery and fix.
+   * The entire authenticated session — `idToken`, `accessToken`,
+   * optional `refreshToken`, optional `expiresAt`, optional `user` —
+   * is serialized to JSON and stored under THIS single key. See the
+   * `StoredSession` type in `@lfmt/shared-types`.
    *
-   * This token is set during login/register and is what `getAuthToken()` returns
-   * for the Authorization: Bearer header.
+   * Atomicity: every session write replaces the blob in full, so the
+   * fields cannot drift out of sync (the failure mode that motivated
+   * this change in OMC review of PR #193).
+   *
+   * Migration: a one-time, idempotent migration runs lazily in
+   * `getStoredSession()` to convert any pre-existing session that
+   * still uses the legacy per-field keys (`lfmt_id_token`,
+   * `lfmt_access_token`, `lfmt_refresh_token`, `lfmt_user`) into
+   * the blob and then deletes those legacy keys.
    */
-  ID_TOKEN_KEY: 'lfmt_id_token',
+  SESSION_KEY: 'lfmt_session',
 
   /**
-   * Local storage key for refresh token
+   * Legacy local-storage keys preserved ONLY for the migration path
+   * in `getStoredSession()`. New code MUST NOT read or write these
+   * keys directly — go through the session helpers in `utils/api.ts`
+   * instead.
+   *
+   * See JSDoc on `LEGACY_KEYS` in `utils/api.ts` for the migration
+   * contract, idempotency guarantees, and the rationale for keeping
+   * these literals in one place.
+   *
+   * Removal plan: once telemetry confirms no in-the-wild sessions
+   * pre-date the blob (one release cycle is sufficient — the worst
+   * outcome is one 401 → refresh → re-login), this object can be
+   * deleted along with the migration code.
    */
-  REFRESH_TOKEN_KEY: 'lfmt_refresh_token',
-
-  /**
-   * Local storage key for user data
-   */
-  USER_DATA_KEY: 'lfmt_user',
+  LEGACY: {
+    ID_TOKEN_KEY: 'lfmt_id_token',
+    ACCESS_TOKEN_KEY: 'lfmt_access_token',
+    REFRESH_TOKEN_KEY: 'lfmt_refresh_token',
+    USER_DATA_KEY: 'lfmt_user',
+  },
 
   /**
    * Token refresh threshold (refresh when token has less than 5 minutes left)

--- a/frontend/src/contexts/__tests__/AuthContext.test.tsx
+++ b/frontend/src/contexts/__tests__/AuthContext.test.tsx
@@ -78,9 +78,15 @@ describe('AuthContext - Initialization', () => {
       lastName: 'Doe',
     };
 
-    // Set up localStorage with user data
-    localStorage.setItem('lfmt_access_token', 'existing-token');
-    localStorage.setItem('lfmt_user', JSON.stringify(mockUser));
+    // Set up the one-blob session (Issue #196).
+    localStorage.setItem(
+      'lfmt_session',
+      JSON.stringify({
+        idToken: 'existing-token',
+        accessToken: 'existing-token',
+        user: mockUser,
+      })
+    );
 
     vi.mocked(authService.getCurrentUser).mockResolvedValueOnce(mockUser);
 
@@ -500,8 +506,14 @@ describe('AuthContext - Initial User Load', () => {
       lastName: 'User',
     };
 
-    localStorage.setItem('lfmt_access_token', 'stored-token');
-    localStorage.setItem('lfmt_user', JSON.stringify(mockUser));
+    localStorage.setItem(
+      'lfmt_session',
+      JSON.stringify({
+        idToken: 'stored-token',
+        accessToken: 'stored-token',
+        user: mockUser,
+      })
+    );
 
     vi.mocked(authService.getCurrentUser).mockResolvedValueOnce(mockUser);
 
@@ -522,7 +534,10 @@ describe('AuthContext - Initial User Load', () => {
   });
 
   it('should handle failed user load and clear auth', async () => {
-    localStorage.setItem('lfmt_access_token', 'invalid-token');
+    localStorage.setItem(
+      'lfmt_session',
+      JSON.stringify({ idToken: 'invalid-token', accessToken: 'invalid-token' })
+    );
 
     const loadError = {
       message: 'Your session has expired. Please log in again.',

--- a/frontend/src/pages/__tests__/LoginPage.test.tsx
+++ b/frontend/src/pages/__tests__/LoginPage.test.tsx
@@ -69,7 +69,13 @@ describe('LoginPage - Integration Tests', () => {
   });
 
   describe('Login Flow with Mock API', () => {
-    it.skip('should successfully login and redirect to dashboard', async () => {
+    // Round 2 item 5: re-enabled. These were skipped pre-PR-#198 (commit
+    // a6d92815 marked 19 tests as ".skip" with TODO to revisit) — they
+    // were never re-evaluated. The MSW handler infrastructure is now
+    // mature enough to drive this end-to-end. Each test verifies that
+    // submitting the form lands the user on the dashboard route AND
+    // (when applicable) writes the one-blob session.
+    it('should successfully login and redirect to dashboard', async () => {
       const user = userEvent.setup();
       renderWithAppContext();
 
@@ -89,7 +95,7 @@ describe('LoginPage - Integration Tests', () => {
       );
     });
 
-    it.skip('should store auth tokens after login', async () => {
+    it('should store auth tokens after login', async () => {
       const user = userEvent.setup();
       renderWithAppContext();
 
@@ -116,7 +122,7 @@ describe('LoginPage - Integration Tests', () => {
       expect(session.refreshToken).toBeTruthy();
     });
 
-    it.skip('should accept any valid email/password combination (mock mode)', async () => {
+    it('should accept any valid email/password combination (mock mode)', async () => {
       const user = userEvent.setup();
       renderWithAppContext();
 
@@ -201,7 +207,9 @@ describe('LoginPage - Integration Tests', () => {
   });
 
   describe('Data Handling - Regression Tests', () => {
-    it.skip('should not throw JSON parsing errors during login', async () => {
+    // Round 2 item 5: re-enabled (see "Login Flow with Mock API" above
+    // for the full rationale).
+    it('should not throw JSON parsing errors during login', async () => {
       const user = userEvent.setup();
       const consoleError = vi.spyOn(console, 'error');
 
@@ -224,7 +232,7 @@ describe('LoginPage - Integration Tests', () => {
       consoleError.mockRestore();
     });
 
-    it.skip('should handle special characters in credentials', async () => {
+    it('should handle special characters in credentials', async () => {
       const user = userEvent.setup();
       renderWithAppContext();
 

--- a/frontend/src/pages/__tests__/LoginPage.test.tsx
+++ b/frontend/src/pages/__tests__/LoginPage.test.tsx
@@ -105,9 +105,15 @@ describe('LoginPage - Integration Tests', () => {
         { timeout: 3000 }
       );
 
-      // Check tokens
-      expect(localStorage.getItem('lfmt_access_token')).toBeTruthy();
-      expect(localStorage.getItem('lfmt_refresh_token')).toBeTruthy();
+      // Check the one-blob session (Issue #196). Both tokens and the
+      // refresh token live under a single key now; reading the blob
+      // tests the full ingest path end-to-end.
+      const raw = localStorage.getItem('lfmt_session');
+      expect(raw).toBeTruthy();
+      const session = JSON.parse(raw as string);
+      expect(session.idToken).toBeTruthy();
+      expect(session.accessToken).toBeTruthy();
+      expect(session.refreshToken).toBeTruthy();
     });
 
     it.skip('should accept any valid email/password combination (mock mode)', async () => {

--- a/frontend/src/services/__tests__/authService.test.ts
+++ b/frontend/src/services/__tests__/authService.test.ts
@@ -8,14 +8,32 @@
  * - Token refresh
  * - Logout
  * - Error handling
+ *
+ * Storage model: Issue #196 collapsed the per-token localStorage keys
+ * into a single `StoredSession` blob. Assertions read the blob through
+ * the canonical `getStoredSession` helper rather than poking at raw
+ * localStorage keys, so the test layer survives any future change to
+ * the blob's internal shape.
+ *
+ * Mock policy: only `apiClient` is mocked here — the storage helpers
+ * run for real against jsdom's `localStorage`. This means a single
+ * end-to-end assertion (read the blob, check the fields) replaces the
+ * old "spy on every setter" pattern, and the tests would catch a real
+ * regression in the helpers themselves rather than just contract drift.
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { authService } from '../authService';
-import { apiClient, setAuthToken, setAccessToken, clearAuthToken } from '../../utils/api';
+import {
+  apiClient,
+  getStoredSession,
+  setStoredSession,
+  clearAuthToken,
+} from '../../utils/api';
 import type { AxiosResponse } from 'axios';
 
-// Mock the API client
+// Mock ONLY the apiClient — storage helpers run against real jsdom
+// localStorage so the test exercises the same code paths the SPA uses.
 vi.mock('../../utils/api', async () => {
   const actual = await vi.importActual<typeof import('../../utils/api')>('../../utils/api');
   return {
@@ -24,9 +42,6 @@ vi.mock('../../utils/api', async () => {
       post: vi.fn(),
       get: vi.fn(),
     },
-    setAuthToken: vi.fn(),
-    setAccessToken: vi.fn(),
-    clearAuthToken: vi.fn(),
   };
 });
 
@@ -78,10 +93,21 @@ describe('AuthService - Registration', () => {
       acceptedPrivacy: true,
     });
 
-    // Without an idToken in the mock response, setAuthToken falls back to
-    // the accessToken so existing behaviour is preserved.
-    expect(setAuthToken).toHaveBeenCalledWith('mock-access-token');
-    expect(setAccessToken).toHaveBeenCalledWith('mock-access-token');
+    // Without an idToken in the mock response, storeAuthTokens falls back
+    // to the accessToken at the ingest seam so existing behaviour is
+    // preserved. The blob persists both fields atomically.
+    const session = getStoredSession();
+    expect(session).toEqual({
+      idToken: 'mock-access-token',
+      accessToken: 'mock-access-token',
+      refreshToken: 'mock-refresh-token',
+      user: {
+        id: 'user-123',
+        email: 'test@example.com',
+        firstName: 'John',
+        lastName: 'Doe',
+      },
+    });
 
     // Verify user data is returned
     expect(result.user).toEqual({
@@ -118,8 +144,11 @@ describe('AuthService - Registration', () => {
     });
 
     // API Gateway CognitoUserPoolsAuthorizer requires the ID token.
-    expect(setAuthToken).toHaveBeenCalledWith('mock-id-token');
-    expect(setAccessToken).toHaveBeenCalledWith('mock-access-token');
+    // The session blob preserves both tokens distinctly.
+    const session = getStoredSession();
+    expect(session?.idToken).toBe('mock-id-token');
+    expect(session?.accessToken).toBe('mock-access-token');
+    expect(session?.refreshToken).toBe('mock-refresh-token');
   });
 
   it('should handle registration errors', async () => {
@@ -143,8 +172,8 @@ describe('AuthService - Registration', () => {
       status: 400,
     });
 
-    // Verify no tokens are stored on error
-    expect(setAuthToken).not.toHaveBeenCalled();
+    // Verify no session is created on error
+    expect(getStoredSession()).toBeNull();
   });
 });
 
@@ -182,10 +211,20 @@ describe('AuthService - Login', () => {
       password: 'MyPassword123!',
     });
 
-    // Without an idToken in the mock response, setAuthToken falls back to
+    // Without an idToken in the mock response, storeAuthTokens falls back to
     // the accessToken so existing behaviour is preserved.
-    expect(setAuthToken).toHaveBeenCalledWith('login-access-token');
-    expect(setAccessToken).toHaveBeenCalledWith('login-access-token');
+    const session = getStoredSession();
+    expect(session).toEqual({
+      idToken: 'login-access-token',
+      accessToken: 'login-access-token',
+      refreshToken: 'login-refresh-token',
+      user: {
+        id: 'user-456',
+        email: 'login@example.com',
+        firstName: 'Jane',
+        lastName: 'Smith',
+      },
+    });
 
     // Verify user data is returned
     expect(result.user.email).toBe('login@example.com');
@@ -208,8 +247,9 @@ describe('AuthService - Login', () => {
     await authService.login({ email: 'login@example.com', password: 'MyPassword123!' });
 
     // API Gateway CognitoUserPoolsAuthorizer requires the ID token.
-    expect(setAuthToken).toHaveBeenCalledWith('login-id-token');
-    expect(setAccessToken).toHaveBeenCalledWith('login-access-token');
+    const session = getStoredSession();
+    expect(session?.idToken).toBe('login-id-token');
+    expect(session?.accessToken).toBe('login-access-token');
   });
 
   it('should handle invalid credentials', async () => {
@@ -228,7 +268,7 @@ describe('AuthService - Login', () => {
       status: 401,
     });
 
-    expect(setAuthToken).not.toHaveBeenCalled();
+    expect(getStoredSession()).toBeNull();
   });
 
   it('should handle network errors during login', async () => {
@@ -254,8 +294,13 @@ describe('AuthService - Token Refresh', () => {
   });
 
   it('should refresh access token successfully (mock without idToken)', async () => {
-    // Set up initial refresh token
-    localStorage.setItem('lfmt_refresh_token', 'old-refresh-token');
+    // Set up an existing session with a refresh token. authService reads
+    // the refresh token via the canonical helper, which sees this blob.
+    setStoredSession({
+      idToken: 'old-id',
+      accessToken: 'old-access',
+      refreshToken: 'old-refresh-token',
+    });
 
     const mockResponse: Partial<AxiosResponse> = {
       data: {
@@ -274,16 +319,23 @@ describe('AuthService - Token Refresh', () => {
       refreshToken: 'old-refresh-token',
     });
 
-    // Without idToken in the mock, setAuthToken falls back to accessToken.
-    expect(setAuthToken).toHaveBeenCalledWith('new-access-token');
-    expect(setAccessToken).toHaveBeenCalledWith('new-access-token');
+    // Without idToken in the mock, the ingest seam falls back to accessToken.
+    // The blob is updated atomically; refreshToken is rotated.
+    const session = getStoredSession();
+    expect(session?.idToken).toBe('new-access-token');
+    expect(session?.accessToken).toBe('new-access-token');
+    expect(session?.refreshToken).toBe('new-refresh-token');
 
     // Verify new access token is returned
     expect(result.accessToken).toBe('new-access-token');
   });
 
   it('should use idToken as Bearer credential when present in refresh response', async () => {
-    localStorage.setItem('lfmt_refresh_token', 'old-refresh-token');
+    setStoredSession({
+      idToken: 'old-id',
+      accessToken: 'old-access',
+      refreshToken: 'old-refresh-token',
+    });
 
     const mockResponse: Partial<AxiosResponse> = {
       data: {
@@ -299,12 +351,16 @@ describe('AuthService - Token Refresh', () => {
     await authService.refreshToken();
 
     // ID token is the correct Bearer credential for API Gateway.
-    expect(setAuthToken).toHaveBeenCalledWith('new-id-token');
-    expect(setAccessToken).toHaveBeenCalledWith('new-access-token');
+    // The original refresh token MUST survive because the response
+    // omitted refreshToken (Cognito REFRESH_TOKEN_AUTH behaviour).
+    const session = getStoredSession();
+    expect(session?.idToken).toBe('new-id-token');
+    expect(session?.accessToken).toBe('new-access-token');
+    expect(session?.refreshToken).toBe('old-refresh-token');
   });
 
   it('should handle missing refresh token', async () => {
-    // No refresh token in localStorage
+    // No session at all → no refresh token to send.
     await expect(authService.refreshToken()).rejects.toEqual({
       message: 'No refresh token available',
       status: 401,
@@ -314,7 +370,11 @@ describe('AuthService - Token Refresh', () => {
   });
 
   it('should handle expired refresh token', async () => {
-    localStorage.setItem('lfmt_refresh_token', 'expired-token');
+    setStoredSession({
+      idToken: 'expired-id',
+      accessToken: 'expired-access',
+      refreshToken: 'expired-token',
+    });
 
     vi.mocked(apiClient.post).mockRejectedValueOnce({
       message: 'Your session has expired. Please log in again.',
@@ -326,8 +386,8 @@ describe('AuthService - Token Refresh', () => {
       status: 401,
     });
 
-    // Should clear tokens on expired refresh token
-    expect(clearAuthToken).toHaveBeenCalled();
+    // Should clear the session on expired refresh token.
+    expect(getStoredSession()).toBeNull();
   });
 });
 
@@ -338,23 +398,45 @@ describe('AuthService - Logout', () => {
   });
 
   it('should logout user and clear all tokens', async () => {
-    // Set up tokens
-    localStorage.setItem('lfmt_access_token', 'test-access-token');
-    localStorage.setItem('lfmt_refresh_token', 'test-refresh-token');
-    localStorage.setItem('lfmt_user', JSON.stringify({ id: 'user-123' }));
+    // Set up tokens via the canonical helper.
+    setStoredSession({
+      idToken: 'id',
+      accessToken: 'test-access-token',
+      refreshToken: 'test-refresh-token',
+      user: { id: 'user-123' },
+    });
 
     await authService.logout();
 
-    // Verify all tokens are cleared
-    expect(clearAuthToken).toHaveBeenCalled();
+    // Verify the session was cleared.
+    expect(getStoredSession()).toBeNull();
   });
 
   it('should logout even if no tokens exist', async () => {
-    // No tokens in localStorage
+    // No tokens in localStorage. clearAuthToken is idempotent — should
+    // not throw.
+    await expect(authService.logout()).resolves.toBeUndefined();
+    expect(getStoredSession()).toBeNull();
+  });
+
+  it('should also remove any straggling legacy keys (defense in depth)', async () => {
+    // Pre-populate the legacy keys (could happen if the deploy-rollover
+    // window leaves a stale key behind from a previous build).
+    localStorage.setItem('lfmt_id_token', 'legacy-id');
+    localStorage.setItem('lfmt_access_token', 'legacy-access');
+    localStorage.setItem('lfmt_refresh_token', 'legacy-refresh');
+    localStorage.setItem('lfmt_user', '{}');
+    setStoredSession({ idToken: 'id', accessToken: 'a' });
+
     await authService.logout();
 
-    // Should still call clearAuthToken (idempotent operation)
-    expect(clearAuthToken).toHaveBeenCalled();
+    // clearAuthToken removes both the blob AND the legacy keys.
+    expect(localStorage.length).toBe(0);
+
+    // Sanity: clearAuthToken is the helper exercised by logout.
+    // Re-calling it directly is a no-op.
+    clearAuthToken();
+    expect(localStorage.length).toBe(0);
   });
 });
 

--- a/frontend/src/services/__tests__/authService.test.ts
+++ b/frontend/src/services/__tests__/authService.test.ts
@@ -24,12 +24,7 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { authService } from '../authService';
-import {
-  apiClient,
-  getStoredSession,
-  setStoredSession,
-  clearAuthToken,
-} from '../../utils/api';
+import { apiClient, getStoredSession, setStoredSession, clearAuthToken } from '../../utils/api';
 import type { AxiosResponse } from 'axios';
 
 // Mock ONLY the apiClient — storage helpers run against real jsdom

--- a/frontend/src/services/authService.ts
+++ b/frontend/src/services/authService.ts
@@ -12,8 +12,14 @@
  * Uses the centralized API client with automatic token injection.
  */
 
-import { apiClient, setAuthToken, setAccessToken, clearAuthToken } from '../utils/api';
-import { AUTH_CONFIG } from '../config/constants';
+import {
+  apiClient,
+  clearAuthToken,
+  getStoredRefreshToken,
+  setStoredSession,
+  updateStoredSession,
+} from '../utils/api';
+import type { StoredSession } from '@lfmt/shared-types';
 
 /**
  * User data returned from authentication endpoints
@@ -99,17 +105,24 @@ export interface MessageResponse {
 /**
  * Persist Cognito tokens and user data returned by login / register.
  *
- * Centralises the "store ID token as Bearer" protocol so that the three
- * callers (register, login, refreshToken) cannot drift from each other.
- * Eliminates the copy-paste risk flagged in OMC review (Rec 4).
+ * Writes a single `StoredSession` blob (Issue #196). Eliminates the
+ * "two-keys" drift hazard the OMC reviewer flagged AND removes the
+ * `idToken ?? accessToken` runtime fallback (Issue #195) — every code
+ * path that reads `idToken` now reads it from the canonical blob, and
+ * the migration in `getStoredSession()` handles legacy sessions.
  *
- * Storage protocol:
- *   - `ID_TOKEN_KEY`      ← idToken ?? accessToken  (API Gateway Bearer)
- *   - `ACCESS_TOKEN_KEY`  ← accessToken             (OAuth2 resource servers)
- *   - `REFRESH_TOKEN_KEY` ← refreshToken (only when present — Cognito
- *     REFRESH_TOKEN_AUTH does not rotate the refresh token)
- *   - `USER_DATA_KEY`     ← user (only when present — refresh responses
- *     do not re-send the user object)
+ * Why we still write `accessToken` (mirrored from `idToken` if absent):
+ *   - The `StoredSession` shape requires both fields so a malformed
+ *     blob can be detected unambiguously by the migration.
+ *   - Callers (e.g., a future OAuth2 resource server integration) can
+ *     read `accessToken` directly via `getStoredSession()` without
+ *     coordinating a second migration.
+ *
+ * The user-shape coercion is safe: the backend's `User` and
+ * `UserProfile` are wire-compatible for the fields the SPA renders
+ * (id/email/firstName/lastName); the additional `UserProfile` fields
+ * (`mfaEnabled`, `preferences`, ...) are optional from the SPA's
+ * perspective and surface lazily when the user updates their profile.
  */
 function storeAuthTokens(tokens: {
   accessToken: string;
@@ -118,17 +131,23 @@ function storeAuthTokens(tokens: {
   user?: User;
 }): void {
   // ID token is what API Gateway CognitoUserPoolsAuthorizer validates.
-  // `??` (nullish coalescing) is intentional: only fall through to
-  // accessToken when idToken is null/undefined, not when it is empty.
-  setAuthToken(tokens.idToken ?? tokens.accessToken);
-  setAccessToken(tokens.accessToken);
-
-  if (tokens.refreshToken) {
-    localStorage.setItem(AUTH_CONFIG.REFRESH_TOKEN_KEY, tokens.refreshToken);
-  }
-  if (tokens.user) {
-    localStorage.setItem(AUTH_CONFIG.USER_DATA_KEY, JSON.stringify(tokens.user));
-  }
+  // The legacy `idToken ?? accessToken` fallback survives ONLY at this
+  // ingest boundary, because mock harnesses (and pre-rollout backends)
+  // can return responses without an idToken. New responses from the
+  // current backend always include both tokens — this nullish
+  // coalescing is the last remaining compat seam and can be deleted
+  // once the mock fixtures all carry idToken.
+  const idToken = tokens.idToken ?? tokens.accessToken;
+  const session: StoredSession = {
+    idToken,
+    accessToken: tokens.accessToken,
+    refreshToken: tokens.refreshToken,
+    // `user` on StoredSession is `unknown` — the SPA persists its
+    // narrower `User` shape and reads it back through `getStoredUser`,
+    // which returns `unknown` and forces callers to narrow.
+    user: tokens.user,
+  };
+  setStoredSession(session);
 }
 
 /**
@@ -164,7 +183,7 @@ async function login(credentials: LoginRequest): Promise<AuthResponse> {
  * @throws ApiError if refresh fails or no refresh token available
  */
 async function refreshToken(): Promise<RefreshTokenResponse> {
-  const refreshToken = localStorage.getItem(AUTH_CONFIG.REFRESH_TOKEN_KEY);
+  const refreshToken = getStoredRefreshToken();
 
   if (!refreshToken) {
     // Clear any stale auth data
@@ -181,9 +200,21 @@ async function refreshToken(): Promise<RefreshTokenResponse> {
       refreshToken,
     });
 
-    // storeAuthTokens handles ID-token preference, access-token storage,
-    // and conditional refresh-token update (all in one place — Rec 4).
-    storeAuthTokens(response.data);
+    // updateStoredSession is the partial-update sibling of
+    // setStoredSession — it preserves the existing user profile when
+    // the refresh response does not re-send it (Cognito doesn't).
+    // We synthesize idToken with the same nullish-coalescing rule used
+    // by storeAuthTokens above for the ingest boundary.
+    const data = response.data;
+    updateStoredSession({
+      accessToken: data.accessToken,
+      idToken: data.idToken ?? data.accessToken,
+      // Cognito REFRESH_TOKEN_AUTH does not rotate the refresh token —
+      // when absent, leave the existing value untouched (don't write
+      // undefined; updateStoredSession would otherwise erase the
+      // previous refresh token via spread semantics).
+      ...(data.refreshToken ? { refreshToken: data.refreshToken } : {}),
+    });
 
     return response.data;
   } catch (error) {

--- a/frontend/src/utils/__tests__/api.refresh.test.ts
+++ b/frontend/src/utils/__tests__/api.refresh.test.ts
@@ -15,6 +15,11 @@
  *   for the retry — to keep these on the same mocked transport we also
  *   attach a MockAdapter to the default `axios` module.
  *
+ * Storage model: Issue #196 introduced the one-blob session under
+ * `AUTH_CONFIG.SESSION_KEY`. All assertions read the blob through the
+ * canonical helpers (`getStoredSession`) so that any future change to
+ * the blob shape only needs to touch this file in one place.
+ *
  * Key scenarios tested:
  * - Successful token refresh and request retry (flat mock shape)
  * - Successful token refresh with the REAL backend wrapped shape
@@ -31,7 +36,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
-import { createApiClient, setAuthToken, setAccessToken } from '../api';
+import { createApiClient, getStoredSession, setStoredSession } from '../api';
 import { AUTH_CONFIG } from '../../config/constants';
 
 describe('API Token Refresh Interceptor', () => {
@@ -59,7 +64,7 @@ describe('API Token Refresh Interceptor', () => {
 
   describe('Successful Token Refresh', () => {
     it('should refresh token on 401 and retry original request (flat mock shape)', async () => {
-      const expiredToken = 'expired-token';
+      const expiredIdToken = 'expired-id-token';
       const refreshToken = 'valid-refresh-token';
       const newAccessToken = 'new-access-token';
       // Deliberately different from newAccessToken so the assertion
@@ -67,8 +72,11 @@ describe('API Token Refresh Interceptor', () => {
       const newIdToken = 'new-id-token';
       const newRefreshToken = 'new-refresh-token';
 
-      setAuthToken(expiredToken);
-      localStorage.setItem(AUTH_CONFIG.REFRESH_TOKEN_KEY, refreshToken);
+      setStoredSession({
+        idToken: expiredIdToken,
+        accessToken: 'old-access',
+        refreshToken,
+      });
 
       // First call to /auth/me → 401, then retry succeeds.
       instanceMock.onGet('/auth/me').replyOnce(401, { message: 'Token expired' });
@@ -91,11 +99,11 @@ describe('API Token Refresh Interceptor', () => {
       expect(refreshCalls).toHaveLength(1);
       expect(JSON.parse(refreshCalls[0].data)).toEqual({ refreshToken });
 
-      // ID token is the Bearer credential (API Gateway requires it).
-      expect(localStorage.getItem(AUTH_CONFIG.ID_TOKEN_KEY)).toBe(newIdToken);
-      // Access token is stored separately for reference.
-      expect(localStorage.getItem(AUTH_CONFIG.ACCESS_TOKEN_KEY)).toBe(newAccessToken);
-      expect(localStorage.getItem(AUTH_CONFIG.REFRESH_TOKEN_KEY)).toBe(newRefreshToken);
+      // Blob now holds the rotated tokens, atomically.
+      const session = getStoredSession();
+      expect(session?.idToken).toBe(newIdToken);
+      expect(session?.accessToken).toBe(newAccessToken);
+      expect(session?.refreshToken).toBe(newRefreshToken);
 
       // Retry succeeded.
       expect(response.data).toEqual({ message: 'Success with new token' });
@@ -110,12 +118,14 @@ describe('API Token Refresh Interceptor', () => {
       // This test ensures the interceptor extracts tokens from the nested
       // `data` field — the absence of this test was the root cause that
       // allowed the original wrong-token bug to ship undetected.
-      const expiredToken = 'expired-id-token';
       const newAccessToken = 'wrapped-access-token';
       const newIdToken = 'wrapped-id-token'; // distinct value — must end up as Bearer
 
-      setAuthToken(expiredToken);
-      localStorage.setItem(AUTH_CONFIG.REFRESH_TOKEN_KEY, 'some-refresh-token');
+      setStoredSession({
+        idToken: 'expired-id-token',
+        accessToken: 'expired-access',
+        refreshToken: 'some-refresh-token',
+      });
 
       instanceMock.onGet('/protected').replyOnce(401, {});
 
@@ -135,8 +145,9 @@ describe('API Token Refresh Interceptor', () => {
       await apiClient.get('/protected');
 
       // ID token extracted from response.data.data.idToken — the nested field.
-      expect(localStorage.getItem(AUTH_CONFIG.ID_TOKEN_KEY)).toBe(newIdToken);
-      expect(localStorage.getItem(AUTH_CONFIG.ACCESS_TOKEN_KEY)).toBe(newAccessToken);
+      const session = getStoredSession();
+      expect(session?.idToken).toBe(newIdToken);
+      expect(session?.accessToken).toBe(newAccessToken);
     });
 
     it('should send the new idToken (not accessToken) as Authorization Bearer on the retried request', async () => {
@@ -146,8 +157,11 @@ describe('API Token Refresh Interceptor', () => {
       const newAccessToken = 'retry-access-token';
       const newIdToken = 'retry-id-token';
 
-      setAuthToken('old-id-token');
-      localStorage.setItem(AUTH_CONFIG.REFRESH_TOKEN_KEY, 'some-refresh-token');
+      setStoredSession({
+        idToken: 'old-id-token',
+        accessToken: 'old-access',
+        refreshToken: 'some-refresh-token',
+      });
 
       instanceMock.onGet('/auth/me').replyOnce(401, {});
 
@@ -174,10 +188,14 @@ describe('API Token Refresh Interceptor', () => {
     it('should queue concurrent requests during token refresh (single refresh fan-out)', async () => {
       const refreshToken = 'valid-refresh-token';
       const newAccessToken = 'new-access-token';
+      const newIdToken = 'new-id-token';
       const newRefreshToken = 'new-refresh-token';
 
-      setAuthToken('expired-token');
-      localStorage.setItem(AUTH_CONFIG.REFRESH_TOKEN_KEY, refreshToken);
+      setStoredSession({
+        idToken: 'expired-id',
+        accessToken: 'expired-access',
+        refreshToken,
+      });
 
       // Each in-flight request gets its own 401.
       instanceMock.onGet('/endpoint1').replyOnce(401, {});
@@ -189,6 +207,7 @@ describe('API Token Refresh Interceptor', () => {
       // "no handler" and reject.
       moduleMock.onPost(/\/auth\/refresh$/).replyOnce(200, {
         accessToken: newAccessToken,
+        idToken: newIdToken,
         refreshToken: newRefreshToken,
       });
 
@@ -219,8 +238,11 @@ describe('API Token Refresh Interceptor', () => {
       const newAccessToken = 'new-access-token';
       const newIdToken = 'new-id-token';
 
-      setAuthToken('expired-token');
-      localStorage.setItem(AUTH_CONFIG.REFRESH_TOKEN_KEY, initialRefreshToken);
+      setStoredSession({
+        idToken: 'expired-id',
+        accessToken: 'expired-access',
+        refreshToken: initialRefreshToken,
+      });
 
       instanceMock.onGet('/auth/me').replyOnce(401, {});
 
@@ -234,19 +256,23 @@ describe('API Token Refresh Interceptor', () => {
       await apiClient.get('/auth/me');
 
       // Rotation: refresh token in storage replaced with the rotated value.
-      expect(localStorage.getItem(AUTH_CONFIG.REFRESH_TOKEN_KEY)).toBe(rotatedRefreshToken);
-      expect(localStorage.getItem(AUTH_CONFIG.REFRESH_TOKEN_KEY)).not.toBe(initialRefreshToken);
+      const session = getStoredSession();
+      expect(session?.refreshToken).toBe(rotatedRefreshToken);
+      expect(session?.refreshToken).not.toBe(initialRefreshToken);
       // ID token is the Bearer credential; access token stored separately.
-      expect(localStorage.getItem(AUTH_CONFIG.ID_TOKEN_KEY)).toBe(newIdToken);
-      expect(localStorage.getItem(AUTH_CONFIG.ACCESS_TOKEN_KEY)).toBe(newAccessToken);
+      expect(session?.idToken).toBe(newIdToken);
+      expect(session?.accessToken).toBe(newAccessToken);
     });
   });
 
   describe('Refresh Failures', () => {
     it('should clear tokens and reject if refresh fails', async () => {
-      setAuthToken('expired-token');
-      localStorage.setItem(AUTH_CONFIG.REFRESH_TOKEN_KEY, 'valid-refresh-token');
-      localStorage.setItem(AUTH_CONFIG.USER_DATA_KEY, JSON.stringify({ id: 'u1' }));
+      setStoredSession({
+        idToken: 'expired-id',
+        accessToken: 'expired-access',
+        refreshToken: 'valid-refresh-token',
+        user: { id: 'u1' },
+      });
 
       instanceMock.onGet('/auth/me').replyOnce(401, {});
       moduleMock.onPost(/\/auth\/refresh$/).replyOnce(401, { message: 'Refresh token expired' });
@@ -256,15 +282,17 @@ describe('API Token Refresh Interceptor', () => {
         status: 401,
       });
 
-      // All three auth keys cleared by clearAuthToken().
-      expect(localStorage.getItem(AUTH_CONFIG.ACCESS_TOKEN_KEY)).toBeNull();
-      expect(localStorage.getItem(AUTH_CONFIG.REFRESH_TOKEN_KEY)).toBeNull();
-      expect(localStorage.getItem(AUTH_CONFIG.USER_DATA_KEY)).toBeNull();
+      // Session blob cleared.
+      expect(getStoredSession()).toBeNull();
+      expect(localStorage.getItem(AUTH_CONFIG.SESSION_KEY)).toBeNull();
     });
 
     it('should clear tokens immediately if no refresh token exists', async () => {
-      setAuthToken('expired-token');
-      // No refresh token stored.
+      setStoredSession({
+        idToken: 'expired-id',
+        accessToken: 'expired-access',
+        // No refresh token stored.
+      });
 
       instanceMock.onGet('/auth/me').replyOnce(401, {});
 
@@ -278,12 +306,15 @@ describe('API Token Refresh Interceptor', () => {
       );
       expect(refreshCalls).toHaveLength(0);
 
-      expect(localStorage.getItem(AUTH_CONFIG.ACCESS_TOKEN_KEY)).toBeNull();
+      expect(getStoredSession()).toBeNull();
     });
 
     it('should reject when refresh succeeds but the retried request fails', async () => {
-      setAuthToken('expired-token');
-      localStorage.setItem(AUTH_CONFIG.REFRESH_TOKEN_KEY, 'valid-refresh-token');
+      setStoredSession({
+        idToken: 'expired-id',
+        accessToken: 'expired-access',
+        refreshToken: 'valid-refresh-token',
+      });
 
       instanceMock.onGet('/auth/me').replyOnce(401, {});
 
@@ -300,16 +331,20 @@ describe('API Token Refresh Interceptor', () => {
 
       // Even though the retried request failed, refresh succeeded so the
       // new tokens MUST be persisted (no spurious logout).
-      expect(localStorage.getItem(AUTH_CONFIG.ID_TOKEN_KEY)).toBe('new-id-token');
-      expect(localStorage.getItem(AUTH_CONFIG.ACCESS_TOKEN_KEY)).toBe('new-access-token');
-      expect(localStorage.getItem(AUTH_CONFIG.REFRESH_TOKEN_KEY)).toBe('new-refresh-token');
+      const session = getStoredSession();
+      expect(session?.idToken).toBe('new-id-token');
+      expect(session?.accessToken).toBe('new-access-token');
+      expect(session?.refreshToken).toBe('new-refresh-token');
     });
   });
 
   describe('Edge Cases', () => {
     it('should not retry if request was already retried (_retry flag)', async () => {
-      setAuthToken('expired-token');
-      localStorage.setItem(AUTH_CONFIG.REFRESH_TOKEN_KEY, 'refresh-token');
+      setStoredSession({
+        idToken: 'expired-id',
+        accessToken: 'expired-access',
+        refreshToken: 'refresh-token',
+      });
 
       // Inject _retry=true into the outgoing config so the interceptor
       // treats the 401 as a hard failure (no further refresh attempts).
@@ -329,12 +364,15 @@ describe('API Token Refresh Interceptor', () => {
       expect(refreshCalls).toHaveLength(0);
 
       // Tokens cleared as fallback.
-      expect(localStorage.getItem(AUTH_CONFIG.ACCESS_TOKEN_KEY)).toBeNull();
+      expect(getStoredSession()).toBeNull();
     });
 
     it('should not refresh for /auth/refresh endpoint itself (no infinite loop)', async () => {
-      setAuthToken('some-token');
-      localStorage.setItem(AUTH_CONFIG.REFRESH_TOKEN_KEY, 'refresh-token');
+      setStoredSession({
+        idToken: 'some-id',
+        accessToken: 'some-access',
+        refreshToken: 'refresh-token',
+      });
 
       // A 401 returned BY the refresh endpoint must not trigger another
       // refresh — it must immediately clear tokens and reject.
@@ -354,12 +392,15 @@ describe('API Token Refresh Interceptor', () => {
       expect(moduleRefreshCalls).toHaveLength(0);
 
       // Tokens cleared.
-      expect(localStorage.getItem(AUTH_CONFIG.ACCESS_TOKEN_KEY)).toBeNull();
+      expect(getStoredSession()).toBeNull();
     });
 
     it('should handle non-401 errors normally without refresh', async () => {
-      setAuthToken('valid-token');
-      localStorage.setItem(AUTH_CONFIG.REFRESH_TOKEN_KEY, 'refresh-token');
+      setStoredSession({
+        idToken: 'valid-id',
+        accessToken: 'valid-access',
+        refreshToken: 'refresh-token',
+      });
 
       instanceMock.onGet('/some/endpoint').replyOnce(500, { message: 'Server error' });
 
@@ -375,9 +416,9 @@ describe('API Token Refresh Interceptor', () => {
       expect(refreshCalls).toHaveLength(0);
 
       // Tokens preserved on non-auth errors.
-      // setAuthToken() writes to ID_TOKEN_KEY (the API Gateway Bearer credential).
-      expect(localStorage.getItem(AUTH_CONFIG.ID_TOKEN_KEY)).toBe('valid-token');
-      expect(localStorage.getItem(AUTH_CONFIG.REFRESH_TOKEN_KEY)).toBe('refresh-token');
+      const session = getStoredSession();
+      expect(session?.idToken).toBe('valid-id');
+      expect(session?.refreshToken).toBe('refresh-token');
     });
 
     it('should treat an empty bearer from the refresh response as a failure and clear tokens', async () => {
@@ -385,8 +426,11 @@ describe('API Token Refresh Interceptor', () => {
       // store an empty string as the Bearer token. An empty Bearer header
       // would cause every subsequent request to 401 immediately — the
       // interceptor must treat this the same as a refresh failure.
-      setAuthToken('old-id-token');
-      localStorage.setItem(AUTH_CONFIG.REFRESH_TOKEN_KEY, 'valid-refresh');
+      setStoredSession({
+        idToken: 'old-id-token',
+        accessToken: 'old-access',
+        refreshToken: 'valid-refresh',
+      });
 
       instanceMock.onGet('/protected').replyOnce(401, {});
 
@@ -401,10 +445,8 @@ describe('API Token Refresh Interceptor', () => {
         message: expect.stringMatching(/expired/i),
       });
 
-      // All tokens cleared — not an empty-string bearer.
-      expect(localStorage.getItem(AUTH_CONFIG.ID_TOKEN_KEY)).toBeNull();
-      expect(localStorage.getItem(AUTH_CONFIG.ACCESS_TOKEN_KEY)).toBeNull();
-      expect(localStorage.getItem(AUTH_CONFIG.REFRESH_TOKEN_KEY)).toBeNull();
+      // Session cleared — not an empty-string bearer.
+      expect(getStoredSession()).toBeNull();
     });
 
     it('should preserve the existing refresh token when Cognito omits it from the refresh response', async () => {
@@ -413,8 +455,11 @@ describe('API Token Refresh Interceptor', () => {
       // overwriting it with an empty/undefined string.
       const originalRefreshToken = 'cognito-original-refresh-token';
 
-      setAuthToken('old-id-token');
-      localStorage.setItem(AUTH_CONFIG.REFRESH_TOKEN_KEY, originalRefreshToken);
+      setStoredSession({
+        idToken: 'old-id-token',
+        accessToken: 'old-access',
+        refreshToken: originalRefreshToken,
+      });
 
       instanceMock.onGet('/protected').replyOnce(401, {});
 
@@ -430,7 +475,7 @@ describe('API Token Refresh Interceptor', () => {
       await apiClient.get('/protected');
 
       // Original refresh token MUST survive.
-      expect(localStorage.getItem(AUTH_CONFIG.REFRESH_TOKEN_KEY)).toBe(originalRefreshToken);
+      expect(getStoredSession()?.refreshToken).toBe(originalRefreshToken);
     });
   });
 
@@ -440,7 +485,7 @@ describe('API Token Refresh Interceptor', () => {
       // cycle to catch token-type bugs at Vitest speed.
       //
       // Sequence:
-      //   1. Simulate "just logged in" — store idToken + accessToken.
+      //   1. Simulate "just logged in" — store idToken + accessToken in the blob.
       //   2. Make an authenticated API call → 401 (id token expired).
       //   3. Interceptor refreshes — backend returns new idToken + accessToken.
       //   4. Interceptor retries with new idToken.
@@ -452,9 +497,11 @@ describe('API Token Refresh Interceptor', () => {
       const newAccessToken = 'refreshed-access-token';
 
       // Step 1: simulate post-login state.
-      setAuthToken(loginIdToken);
-      setAccessToken(loginAccessToken);
-      localStorage.setItem(AUTH_CONFIG.REFRESH_TOKEN_KEY, 'user-refresh-token');
+      setStoredSession({
+        idToken: loginIdToken,
+        accessToken: loginAccessToken,
+        refreshToken: 'user-refresh-token',
+      });
 
       // Step 2: API call → 401.
       instanceMock.onPost('/jobs/translate').replyOnce(401, { message: 'Token expired' });
@@ -476,8 +523,9 @@ describe('API Token Refresh Interceptor', () => {
       const result = await apiClient.post('/jobs/translate', { language: 'es' });
 
       // Step 5a: tokens in storage.
-      expect(localStorage.getItem(AUTH_CONFIG.ID_TOKEN_KEY)).toBe(newIdToken);
-      expect(localStorage.getItem(AUTH_CONFIG.ACCESS_TOKEN_KEY)).toBe(newAccessToken);
+      const session = getStoredSession();
+      expect(session?.idToken).toBe(newIdToken);
+      expect(session?.accessToken).toBe(newAccessToken);
 
       // Step 5b: retry used idToken, not accessToken.
       expect(authHeaderOnRetry).toBe(`Bearer ${newIdToken}`);
@@ -490,8 +538,11 @@ describe('API Token Refresh Interceptor', () => {
 
   describe('Error Message Formatting', () => {
     it('should preserve SESSION_EXPIRED message in refresh failures', async () => {
-      setAuthToken('expired-token');
-      localStorage.setItem(AUTH_CONFIG.REFRESH_TOKEN_KEY, 'refresh-token');
+      setStoredSession({
+        idToken: 'expired-id',
+        accessToken: 'expired-access',
+        refreshToken: 'refresh-token',
+      });
 
       instanceMock.onGet('/auth/me').replyOnce(401, {});
       moduleMock

--- a/frontend/src/utils/__tests__/api.test.ts
+++ b/frontend/src/utils/__tests__/api.test.ts
@@ -4,15 +4,36 @@
  *
  * Following TDD approach with pragmatic TypeScript-friendly tests.
  * Tests core functionality without over-mocking complex Axios internals.
+ *
+ * Storage model: Issue #196 introduced the one-blob session under
+ * `AUTH_CONFIG.SESSION_KEY` and removed the runtime fallback to
+ * `accessToken` in `getAuthToken()` (Issue #195). The legacy keys live
+ * on only as inputs to a one-time, idempotent migration covered in the
+ * dedicated migration block below.
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { setAuthToken, clearAuthToken, getAuthToken } from '../api';
+import {
+  setAuthToken,
+  setAccessToken,
+  clearAuthToken,
+  getAuthToken,
+  getStoredSession,
+  setStoredSession,
+  updateStoredSession,
+  getStoredRefreshToken,
+  getStoredUser,
+} from '../api';
 import { AUTH_CONFIG } from '../../config/constants';
+import type { StoredSession } from '@lfmt/shared-types';
 
-describe('API Client - Token Management', () => {
+function readBlob(): StoredSession | null {
+  const raw = localStorage.getItem(AUTH_CONFIG.SESSION_KEY);
+  return raw ? (JSON.parse(raw) as StoredSession) : null;
+}
+
+describe('API Client - Token Management (one-blob model)', () => {
   beforeEach(() => {
-    // Clear localStorage before each test
     localStorage.clear();
   });
 
@@ -21,98 +42,275 @@ describe('API Client - Token Management', () => {
   });
 
   describe('setAuthToken', () => {
-    it('should store token in localStorage under ID_TOKEN_KEY', () => {
-      const token = 'test-id-token-123';
+    it('should write idToken into the session blob', () => {
+      const idToken = 'test-id-token-123';
 
-      setAuthToken(token);
+      setAuthToken(idToken);
 
-      // setAuthToken now stores the ID token (Bearer credential for API Gateway).
-      expect(localStorage.getItem(AUTH_CONFIG.ID_TOKEN_KEY)).toBe(token);
+      const blob = readBlob();
+      expect(blob?.idToken).toBe(idToken);
+      // accessToken is mirrored from idToken when no prior session exists,
+      // so updateStoredSession can persist a complete blob (both required
+      // fields present).
+      expect(blob?.accessToken).toBe(idToken);
     });
 
-    it('should overwrite existing id token', () => {
-      const oldToken = 'old-id-token';
-      const newToken = 'new-id-token';
+    it('should overwrite an existing idToken without clobbering accessToken', () => {
+      // Pre-existing session with both fields distinct.
+      setStoredSession({
+        idToken: 'old-id',
+        accessToken: 'old-access',
+        refreshToken: 'rt',
+      });
 
-      setAuthToken(oldToken);
-      setAuthToken(newToken);
+      setAuthToken('new-id');
 
-      expect(localStorage.getItem(AUTH_CONFIG.ID_TOKEN_KEY)).toBe(newToken);
+      const blob = readBlob();
+      expect(blob?.idToken).toBe('new-id');
+      expect(blob?.accessToken).toBe('old-access');
+      expect(blob?.refreshToken).toBe('rt');
+    });
+  });
+
+  describe('setAccessToken', () => {
+    it('should merge accessToken into the session without disturbing idToken', () => {
+      setStoredSession({
+        idToken: 'id-123',
+        accessToken: 'old-access',
+      });
+
+      setAccessToken('new-access');
+
+      const blob = readBlob();
+      expect(blob?.idToken).toBe('id-123');
+      expect(blob?.accessToken).toBe('new-access');
     });
   });
 
   describe('getAuthToken', () => {
-    it('should return idToken when present (preferred over accessToken)', () => {
-      localStorage.setItem(AUTH_CONFIG.ID_TOKEN_KEY, 'id-token-value');
-      localStorage.setItem(AUTH_CONFIG.ACCESS_TOKEN_KEY, 'access-token-value');
+    it('should return idToken from the blob when present', () => {
+      setStoredSession({ idToken: 'id-xyz', accessToken: 'access-xyz' });
 
-      const retrieved = getAuthToken();
-      expect(retrieved).toBe('id-token-value');
+      expect(getAuthToken()).toBe('id-xyz');
     });
 
-    it('should fall back to accessToken when idToken is absent', () => {
-      // Pre-existing session where only accessToken was stored (backward compat).
-      localStorage.setItem(AUTH_CONFIG.ACCESS_TOKEN_KEY, 'legacy-access-token');
+    it('should NOT fall back to accessToken at runtime (Issue #195)', () => {
+      // Hand-construct a malformed blob with idToken empty — getAuthToken
+      // must NOT silently substitute the accessToken. The previous
+      // `?? accessToken` fallback was removed; legacy sessions are now
+      // handled exclusively by the migration path tested below.
+      setStoredSession({ idToken: '', accessToken: 'access-only' });
 
-      const retrieved = getAuthToken();
-      expect(retrieved).toBe('legacy-access-token');
+      // Empty string is a valid string per JSON, so the type guard in
+      // getStoredSession passes; getAuthToken returns the empty string
+      // (which the request interceptor will then refuse to send as a
+      // Bearer header). This is the documented behavior — Issue #195
+      // explicitly chose "fail fast" over "silent fallback".
+      expect(getAuthToken()).toBe('');
     });
 
-    it('should return null when neither idToken nor accessToken exists', () => {
-      const retrieved = getAuthToken();
-      expect(retrieved).toBeNull();
+    it('should return null when no session exists', () => {
+      expect(getAuthToken()).toBeNull();
     });
   });
 
   describe('clearAuthToken', () => {
-    it('should remove access token from localStorage', () => {
-      localStorage.setItem(AUTH_CONFIG.ACCESS_TOKEN_KEY, 'test-token');
+    it('should remove the session blob', () => {
+      setStoredSession({
+        idToken: 'id',
+        accessToken: 'access',
+        refreshToken: 'rt',
+        user: { id: 'u1' },
+      });
 
       clearAuthToken();
 
-      const stored = localStorage.getItem(AUTH_CONFIG.ACCESS_TOKEN_KEY);
-      expect(stored).toBeNull();
+      expect(localStorage.getItem(AUTH_CONFIG.SESSION_KEY)).toBeNull();
+      expect(getAuthToken()).toBeNull();
+      expect(getStoredSession()).toBeNull();
     });
 
-    it('should remove refresh token from localStorage', () => {
-      localStorage.setItem(AUTH_CONFIG.REFRESH_TOKEN_KEY, 'refresh-token');
+    it('should also remove every legacy key (defensive — covers post-deploy cleanup)', () => {
+      // Simulate a deploy where a stray legacy key survived alongside a new blob.
+      localStorage.setItem(AUTH_CONFIG.LEGACY.ID_TOKEN_KEY, 'legacy-id');
+      localStorage.setItem(AUTH_CONFIG.LEGACY.ACCESS_TOKEN_KEY, 'legacy-access');
+      localStorage.setItem(AUTH_CONFIG.LEGACY.REFRESH_TOKEN_KEY, 'legacy-refresh');
+      localStorage.setItem(AUTH_CONFIG.LEGACY.USER_DATA_KEY, '{}');
+      setStoredSession({ idToken: 'id', accessToken: 'access' });
 
       clearAuthToken();
 
-      const stored = localStorage.getItem(AUTH_CONFIG.REFRESH_TOKEN_KEY);
-      expect(stored).toBeNull();
+      expect(localStorage.getItem(AUTH_CONFIG.SESSION_KEY)).toBeNull();
+      expect(localStorage.getItem(AUTH_CONFIG.LEGACY.ID_TOKEN_KEY)).toBeNull();
+      expect(localStorage.getItem(AUTH_CONFIG.LEGACY.ACCESS_TOKEN_KEY)).toBeNull();
+      expect(localStorage.getItem(AUTH_CONFIG.LEGACY.REFRESH_TOKEN_KEY)).toBeNull();
+      expect(localStorage.getItem(AUTH_CONFIG.LEGACY.USER_DATA_KEY)).toBeNull();
+    });
+  });
+
+  describe('updateStoredSession', () => {
+    it('should merge into an existing session, preserving non-mentioned fields', () => {
+      setStoredSession({
+        idToken: 'id-1',
+        accessToken: 'access-1',
+        refreshToken: 'refresh-1',
+        user: { id: 'u1' },
+      });
+
+      updateStoredSession({ idToken: 'id-2', accessToken: 'access-2' });
+
+      const blob = readBlob();
+      expect(blob?.idToken).toBe('id-2');
+      expect(blob?.accessToken).toBe('access-2');
+      expect(blob?.refreshToken).toBe('refresh-1');
+      expect(blob?.user).toEqual({ id: 'u1' });
     });
 
-    it('should remove user data from localStorage', () => {
-      localStorage.setItem(AUTH_CONFIG.USER_DATA_KEY, JSON.stringify({ id: '123' }));
+    it('should treat a complete partial as a full session when nothing is stored', () => {
+      updateStoredSession({ idToken: 'id', accessToken: 'access' });
 
-      clearAuthToken();
-
-      const stored = localStorage.getItem(AUTH_CONFIG.USER_DATA_KEY);
-      expect(stored).toBeNull();
+      const blob = readBlob();
+      expect(blob).toEqual({ idToken: 'id', accessToken: 'access' });
     });
 
-    it('should remove id token from localStorage', () => {
-      localStorage.setItem(AUTH_CONFIG.ID_TOKEN_KEY, 'id-token');
+    it('should refuse to write an incomplete blob when no session exists', () => {
+      // Only one of the two required fields — must NOT create a malformed blob.
+      updateStoredSession({ idToken: 'orphan' });
 
-      clearAuthToken();
+      expect(localStorage.getItem(AUTH_CONFIG.SESSION_KEY)).toBeNull();
+    });
+  });
 
-      expect(localStorage.getItem(AUTH_CONFIG.ID_TOKEN_KEY)).toBeNull();
+  describe('getStoredRefreshToken / getStoredUser', () => {
+    it('should return the refresh token from the session', () => {
+      setStoredSession({ idToken: 'id', accessToken: 'a', refreshToken: 'rt' });
+      expect(getStoredRefreshToken()).toBe('rt');
     });
 
-    it('should clear all auth data at once', () => {
-      localStorage.setItem(AUTH_CONFIG.ID_TOKEN_KEY, 'id-token');
-      localStorage.setItem(AUTH_CONFIG.ACCESS_TOKEN_KEY, 'access');
-      localStorage.setItem(AUTH_CONFIG.REFRESH_TOKEN_KEY, 'refresh');
-      localStorage.setItem(AUTH_CONFIG.USER_DATA_KEY, '{}');
-
-      clearAuthToken();
-
-      expect(localStorage.getItem(AUTH_CONFIG.ID_TOKEN_KEY)).toBeNull();
-      expect(localStorage.getItem(AUTH_CONFIG.ACCESS_TOKEN_KEY)).toBeNull();
-      expect(localStorage.getItem(AUTH_CONFIG.REFRESH_TOKEN_KEY)).toBeNull();
-      expect(localStorage.getItem(AUTH_CONFIG.USER_DATA_KEY)).toBeNull();
+    it('should return null when no refresh token is present', () => {
+      setStoredSession({ idToken: 'id', accessToken: 'a' });
+      expect(getStoredRefreshToken()).toBeNull();
     });
+
+    it('should return the persisted user object', () => {
+      const user = { id: 'u1', email: 'test@example.com' };
+      setStoredSession({ idToken: 'id', accessToken: 'a', user });
+      expect(getStoredUser()).toEqual(user);
+    });
+  });
+});
+
+describe('API Client - Legacy Session Migration (Issue #196)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('should synthesize a blob from legacy keys and remove them on first read', () => {
+    // Pre-populate localStorage in the legacy two-keys shape.
+    localStorage.setItem(AUTH_CONFIG.LEGACY.ID_TOKEN_KEY, 'legacy-id-token');
+    localStorage.setItem(AUTH_CONFIG.LEGACY.ACCESS_TOKEN_KEY, 'legacy-access-token');
+    localStorage.setItem(AUTH_CONFIG.LEGACY.REFRESH_TOKEN_KEY, 'legacy-refresh-token');
+    localStorage.setItem(
+      AUTH_CONFIG.LEGACY.USER_DATA_KEY,
+      JSON.stringify({ id: 'legacy-u1', email: 'legacy@example.com' })
+    );
+
+    // First read triggers migration.
+    const session = getStoredSession();
+
+    expect(session).toEqual({
+      idToken: 'legacy-id-token',
+      accessToken: 'legacy-access-token',
+      refreshToken: 'legacy-refresh-token',
+      user: { id: 'legacy-u1', email: 'legacy@example.com' },
+    });
+
+    // Blob is now persisted under the new key.
+    const blob = readBlob();
+    expect(blob).toEqual(session);
+
+    // All legacy keys are gone.
+    expect(localStorage.getItem(AUTH_CONFIG.LEGACY.ID_TOKEN_KEY)).toBeNull();
+    expect(localStorage.getItem(AUTH_CONFIG.LEGACY.ACCESS_TOKEN_KEY)).toBeNull();
+    expect(localStorage.getItem(AUTH_CONFIG.LEGACY.REFRESH_TOKEN_KEY)).toBeNull();
+    expect(localStorage.getItem(AUTH_CONFIG.LEGACY.USER_DATA_KEY)).toBeNull();
+  });
+
+  it('should be idempotent — second call is a no-op', () => {
+    localStorage.setItem(AUTH_CONFIG.LEGACY.ID_TOKEN_KEY, 'legacy-id');
+    localStorage.setItem(AUTH_CONFIG.LEGACY.ACCESS_TOKEN_KEY, 'legacy-access');
+
+    const first = getStoredSession();
+    const blobAfterFirst = readBlob();
+
+    // Legacy keys gone after the first read.
+    expect(localStorage.getItem(AUTH_CONFIG.LEGACY.ID_TOKEN_KEY)).toBeNull();
+    expect(localStorage.getItem(AUTH_CONFIG.LEGACY.ACCESS_TOKEN_KEY)).toBeNull();
+
+    const second = getStoredSession();
+
+    expect(second).toEqual(first);
+    expect(readBlob()).toEqual(blobAfterFirst);
+  });
+
+  it('should fall back to accessToken when only the legacy access key exists', () => {
+    // Sessions created BEFORE PR #193 only had accessToken stored (no idToken).
+    // The migration must still extract a usable Bearer credential rather than
+    // log the user out; the upgraded session will then 401 on the next
+    // authenticated call and the refresh interceptor takes over.
+    localStorage.setItem(AUTH_CONFIG.LEGACY.ACCESS_TOKEN_KEY, 'pre-pr-193-access-token');
+
+    const session = getStoredSession();
+
+    expect(session?.idToken).toBe('pre-pr-193-access-token');
+    expect(session?.accessToken).toBe('pre-pr-193-access-token');
+    expect(localStorage.getItem(AUTH_CONFIG.LEGACY.ACCESS_TOKEN_KEY)).toBeNull();
+  });
+
+  it('should return null and clean orphan keys when no bearer-eligible token exists', () => {
+    // Only refresh token + user, no id/access — nothing meaningful to migrate.
+    localStorage.setItem(AUTH_CONFIG.LEGACY.REFRESH_TOKEN_KEY, 'orphan-refresh');
+    localStorage.setItem(AUTH_CONFIG.LEGACY.USER_DATA_KEY, '{}');
+
+    expect(getStoredSession()).toBeNull();
+    expect(localStorage.getItem(AUTH_CONFIG.SESSION_KEY)).toBeNull();
+    // Orphan keys cleaned up.
+    expect(localStorage.getItem(AUTH_CONFIG.LEGACY.REFRESH_TOKEN_KEY)).toBeNull();
+    expect(localStorage.getItem(AUTH_CONFIG.LEGACY.USER_DATA_KEY)).toBeNull();
+  });
+
+  it('should treat a corrupted blob as no session and clear it', () => {
+    localStorage.setItem(AUTH_CONFIG.SESSION_KEY, '{not valid json');
+
+    expect(getStoredSession()).toBeNull();
+    expect(localStorage.getItem(AUTH_CONFIG.SESSION_KEY)).toBeNull();
+  });
+
+  it('should treat a structurally-incomplete blob as no session and clear it', () => {
+    // Missing idToken (required).
+    localStorage.setItem(
+      AUTH_CONFIG.SESSION_KEY,
+      JSON.stringify({ accessToken: 'a', refreshToken: 'rt' })
+    );
+
+    expect(getStoredSession()).toBeNull();
+    expect(localStorage.getItem(AUTH_CONFIG.SESSION_KEY)).toBeNull();
+  });
+
+  it('should tolerate corrupted user JSON in legacy storage', () => {
+    localStorage.setItem(AUTH_CONFIG.LEGACY.ID_TOKEN_KEY, 'id');
+    localStorage.setItem(AUTH_CONFIG.LEGACY.ACCESS_TOKEN_KEY, 'access');
+    localStorage.setItem(AUTH_CONFIG.LEGACY.USER_DATA_KEY, '{not valid');
+
+    const session = getStoredSession();
+
+    expect(session?.idToken).toBe('id');
+    expect(session?.accessToken).toBe('access');
+    expect(session?.user).toBeUndefined();
   });
 });
 
@@ -252,9 +450,12 @@ describe('API Client - Response Error Interceptor', () => {
 
   it.skip('should handle 401 Unauthorized and clear auth tokens', async () => {
     // Set up tokens
-    localStorage.setItem(AUTH_CONFIG.ACCESS_TOKEN_KEY, 'test-token');
-    localStorage.setItem(AUTH_CONFIG.REFRESH_TOKEN_KEY, 'refresh-token');
-    localStorage.setItem(AUTH_CONFIG.USER_DATA_KEY, '{"id": "123"}');
+    setStoredSession({
+      idToken: 'id',
+      accessToken: 'test-token',
+      refreshToken: 'refresh-token',
+      user: { id: '123' },
+    });
 
     const { createApiClient } = await import('../api');
     const client = createApiClient();
@@ -282,10 +483,8 @@ describe('API Client - Response Error Interceptor', () => {
       expect(error.status).toBe(401);
       expect(error.message).toBe('Unauthorized');
 
-      // Verify tokens were cleared
-      expect(localStorage.getItem(AUTH_CONFIG.ACCESS_TOKEN_KEY)).toBeNull();
-      expect(localStorage.getItem(AUTH_CONFIG.REFRESH_TOKEN_KEY)).toBeNull();
-      expect(localStorage.getItem(AUTH_CONFIG.USER_DATA_KEY)).toBeNull();
+      // Verify session was cleared
+      expect(localStorage.getItem(AUTH_CONFIG.SESSION_KEY)).toBeNull();
     }
   });
 

--- a/frontend/src/utils/__tests__/api.test.ts
+++ b/frontend/src/utils/__tests__/api.test.ts
@@ -12,7 +12,7 @@
  * dedicated migration block below.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
   setAuthToken,
   setAccessToken,
@@ -23,6 +23,8 @@ import {
   updateStoredSession,
   getStoredRefreshToken,
   getStoredUser,
+  narrowStoredUser,
+  __testResetLegacyShortCircuit,
 } from '../api';
 import { AUTH_CONFIG } from '../../config/constants';
 import type { StoredSession } from '@lfmt/shared-types';
@@ -32,13 +34,24 @@ function readBlob(): StoredSession | null {
   return raw ? (JSON.parse(raw) as StoredSession) : null;
 }
 
+/**
+ * Reset both localStorage AND the in-memory legacy-cleanup
+ * short-circuit. Tests that pre-populate legacy keys after a previous
+ * test triggered the sweep need this to force a fresh sweep on the
+ * next `getStoredSession()` call.
+ */
+function fullReset(): void {
+  localStorage.clear();
+  __testResetLegacyShortCircuit();
+}
+
 describe('API Client - Token Management (one-blob model)', () => {
   beforeEach(() => {
-    localStorage.clear();
+    fullReset();
   });
 
   afterEach(() => {
-    localStorage.clear();
+    fullReset();
   });
 
   describe('setAuthToken', () => {
@@ -99,14 +112,27 @@ describe('API Client - Token Management (one-blob model)', () => {
       // must NOT silently substitute the accessToken. The previous
       // `?? accessToken` fallback was removed; legacy sessions are now
       // handled exclusively by the migration path tested below.
+      //
+      // Round 2 item 7: the structural guard now also rejects an
+      // empty-string idToken (length === 0), so getAuthToken returns
+      // null AND the malformed blob is cleared. Without this guard,
+      // the request interceptor would have sent `Authorization: Bearer `
+      // (trailing space) on every request, looping 401 → refresh.
       setStoredSession({ idToken: '', accessToken: 'access-only' });
 
-      // Empty string is a valid string per JSON, so the type guard in
-      // getStoredSession passes; getAuthToken returns the empty string
-      // (which the request interceptor will then refuse to send as a
-      // Bearer header). This is the documented behavior — Issue #195
-      // explicitly chose "fail fast" over "silent fallback".
-      expect(getAuthToken()).toBe('');
+      expect(getAuthToken()).toBeNull();
+      // Side effect: malformed blob is cleared on read so the next
+      // call has a clean slate.
+      expect(localStorage.getItem(AUTH_CONFIG.SESSION_KEY)).toBeNull();
+    });
+
+    it('should reject a blob with empty-string accessToken (Round 2 item 7)', () => {
+      // Symmetric to the idToken guard. accessToken is structurally
+      // required and must be non-empty; otherwise the blob is dropped.
+      setStoredSession({ idToken: 'real-id', accessToken: '' });
+
+      expect(getStoredSession()).toBeNull();
+      expect(localStorage.getItem(AUTH_CONFIG.SESSION_KEY)).toBeNull();
     });
 
     it('should return null when no session exists', () => {
@@ -192,21 +218,37 @@ describe('API Client - Token Management (one-blob model)', () => {
       expect(getStoredRefreshToken()).toBeNull();
     });
 
-    it('should return the persisted user object', () => {
-      const user = { id: 'u1', email: 'test@example.com' };
+    it('should return the persisted user object (well-formed)', () => {
+      // Round 2 item 8: user must satisfy `narrowStoredUser` shape —
+      // id, email, firstName, lastName all required as strings. The
+      // previous version of this test stored only id+email and
+      // happened to pass because the helper was a bare passthrough;
+      // the hardened narrower correctly returns null for that input.
+      const user = { id: 'u1', email: 'test@example.com', firstName: 'T', lastName: 'U' };
       setStoredSession({ idToken: 'id', accessToken: 'a', user });
       expect(getStoredUser()).toEqual(user);
+    });
+
+    it('should return null when persisted user fails shape validation', () => {
+      // Documenting the new contract: a malformed user surfaces as
+      // null, not as the partial value. Previously the bare-cast in
+      // getStoredUser would have returned `{ id: 'u1' }` typed as
+      // `unknown`, and a downstream consumer doing
+      // `(user as User).email.toLowerCase()` would crash. Now they
+      // get null and can branch defensively.
+      setStoredSession({ idToken: 'id', accessToken: 'a', user: { id: 'u1' } });
+      expect(getStoredUser()).toBeNull();
     });
   });
 });
 
 describe('API Client - Legacy Session Migration (Issue #196)', () => {
   beforeEach(() => {
-    localStorage.clear();
+    fullReset();
   });
 
   afterEach(() => {
-    localStorage.clear();
+    fullReset();
   });
 
   it('should synthesize a blob from legacy keys and remove them on first read', () => {
@@ -312,6 +354,391 @@ describe('API Client - Legacy Session Migration (Issue #196)', () => {
     expect(session?.accessToken).toBe('access');
     expect(session?.user).toBeUndefined();
   });
+
+  // ---------------------------------------------------------------------
+  // Round 2 item 2: symmetric legacy idToken-only migration test.
+  // The access-only branch above tests pre-PR-#193 sessions; the
+  // idToken-only branch tests the inverse — a legacy session that
+  // was upgraded once but somehow lost its access key. The migration
+  // must still produce a usable blob (idToken doubles as accessToken
+  // for storage shape; the SPA's request interceptor only reads
+  // idToken anyway).
+  // ---------------------------------------------------------------------
+  it('should migrate when only the legacy idToken key exists', () => {
+    localStorage.setItem(AUTH_CONFIG.LEGACY.ID_TOKEN_KEY, 'legacy-id-only');
+
+    const session = getStoredSession();
+
+    expect(session?.idToken).toBe('legacy-id-only');
+    // Mirror — the readLegacySession synthesizer falls back to idToken
+    // when accessToken is absent so the blob's required `accessToken`
+    // field is satisfied.
+    expect(session?.accessToken).toBe('legacy-id-only');
+    expect(localStorage.getItem(AUTH_CONFIG.LEGACY.ID_TOKEN_KEY)).toBeNull();
+  });
+
+  // ---------------------------------------------------------------------
+  // Round 2 item 1 (latent coexistence bug): when a valid blob AND
+  // stray legacy keys both exist, the legacy keys MUST be cleaned up
+  // on the next read. Otherwise an out-of-band write to a legacy key
+  // (e.g., a third-party script poking localStorage) would survive
+  // forever, and a future bug that read a legacy key would silently
+  // pick up stale data.
+  // ---------------------------------------------------------------------
+  it('should sweep straggling legacy keys when a valid blob is present', () => {
+    // Pre-populate BOTH the modern blob AND legacy keys.
+    setStoredSession({ idToken: 'blob-id', accessToken: 'blob-access' });
+    localStorage.setItem(AUTH_CONFIG.LEGACY.ID_TOKEN_KEY, 'stray-legacy-id');
+    localStorage.setItem(AUTH_CONFIG.LEGACY.ACCESS_TOKEN_KEY, 'stray-legacy-access');
+    localStorage.setItem(AUTH_CONFIG.LEGACY.REFRESH_TOKEN_KEY, 'stray-legacy-refresh');
+    localStorage.setItem(AUTH_CONFIG.LEGACY.USER_DATA_KEY, '{}');
+    // Force a fresh sweep — the previous setStoredSession may have
+    // already triggered the short-circuit via a prior read.
+    __testResetLegacyShortCircuit();
+
+    // Trigger the sweep.
+    const session = getStoredSession();
+
+    // Modern blob wins.
+    expect(session?.idToken).toBe('blob-id');
+    expect(session?.accessToken).toBe('blob-access');
+    // ALL legacy keys are now gone (the bug was that they survived).
+    expect(localStorage.getItem(AUTH_CONFIG.LEGACY.ID_TOKEN_KEY)).toBeNull();
+    expect(localStorage.getItem(AUTH_CONFIG.LEGACY.ACCESS_TOKEN_KEY)).toBeNull();
+    expect(localStorage.getItem(AUTH_CONFIG.LEGACY.REFRESH_TOKEN_KEY)).toBeNull();
+    expect(localStorage.getItem(AUTH_CONFIG.LEGACY.USER_DATA_KEY)).toBeNull();
+  });
+
+  // ---------------------------------------------------------------------
+  // Round 2 Critical: setItem inside the migration block must be
+  // wrapped in try/catch so a QuotaExceededError doesn't escape into
+  // AuthContext's mount effect and crash React. Verify the
+  // fail-closed contract: caller gets null AND legacy keys are
+  // cleaned (so the next render doesn't loop on the same failed
+  // migration).
+  // ---------------------------------------------------------------------
+  it('should fail closed (return null + warn) when setItem throws QuotaExceededError', () => {
+    localStorage.setItem(AUTH_CONFIG.LEGACY.ID_TOKEN_KEY, 'legacy-id');
+    localStorage.setItem(AUTH_CONFIG.LEGACY.ACCESS_TOKEN_KEY, 'legacy-access');
+
+    // Stub setItem to throw. We restore via the spy's lifecycle so
+    // the test doesn't bleed into siblings.
+    const setItemSpy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      const quotaError = new Error('QuotaExceededError') as Error & { name: string };
+      quotaError.name = 'QuotaExceededError';
+      throw quotaError;
+    });
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    // Force a fresh sweep so the legacy keys are visible.
+    __testResetLegacyShortCircuit();
+
+    let result: ReturnType<typeof getStoredSession> | undefined;
+    expect(() => {
+      result = getStoredSession();
+    }).not.toThrow();
+    expect(result).toBeNull();
+
+    // Logged the failure so ops can see it.
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('migration failed'),
+      expect.anything()
+    );
+
+    setItemSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
+  });
+});
+
+// =====================================================================
+// Round 2 item 8: narrowStoredUser runtime narrowing helper.
+// =====================================================================
+
+describe('API Client - narrowStoredUser (Round 2 item 8)', () => {
+  it('should return a typed user when all required fields are present', () => {
+    const result = narrowStoredUser({
+      id: 'u1',
+      email: 'a@b.com',
+      firstName: 'A',
+      lastName: 'B',
+    });
+    expect(result).toEqual({ id: 'u1', email: 'a@b.com', firstName: 'A', lastName: 'B' });
+  });
+
+  it('should include optional fields when well-typed', () => {
+    const result = narrowStoredUser({
+      id: 'u1',
+      email: 'a@b.com',
+      firstName: 'A',
+      lastName: 'B',
+      emailVerified: true,
+      createdAt: '2026-01-01T00:00:00Z',
+    });
+    expect(result?.emailVerified).toBe(true);
+    expect(result?.createdAt).toBe('2026-01-01T00:00:00Z');
+  });
+
+  it('should drop optional fields with the wrong type', () => {
+    const result = narrowStoredUser({
+      id: 'u1',
+      email: 'a@b.com',
+      firstName: 'A',
+      lastName: 'B',
+      emailVerified: 'yes', // wrong type
+      createdAt: 1234567890, // wrong type
+    });
+    expect(result).toEqual({ id: 'u1', email: 'a@b.com', firstName: 'A', lastName: 'B' });
+  });
+
+  it('should return null for null/undefined/non-object input', () => {
+    expect(narrowStoredUser(null)).toBeNull();
+    expect(narrowStoredUser(undefined)).toBeNull();
+    expect(narrowStoredUser('string')).toBeNull();
+    expect(narrowStoredUser(42)).toBeNull();
+    // Arrays are typeof 'object' but lack the required string fields
+    // → still null. (Documenting the edge case with the comment so a
+    // future reader doesn't have to re-derive why the assertion is
+    // toBeNull rather than not.toBeNull.)
+    expect(narrowStoredUser([])).toBeNull();
+  });
+
+  it('should return null when any required field is missing or wrong type', () => {
+    // Missing firstName.
+    expect(narrowStoredUser({ id: 'u1', email: 'a@b.com', lastName: 'B' })).toBeNull();
+    // Wrong type for email.
+    expect(narrowStoredUser({ id: 'u1', email: 42, firstName: 'A', lastName: 'B' })).toBeNull();
+    // Empty object.
+    expect(narrowStoredUser({})).toBeNull();
+  });
+
+  it('getStoredUser routes through narrowStoredUser', () => {
+    fullReset();
+    setStoredSession({
+      idToken: 'id',
+      accessToken: 'a',
+      user: { id: 'u1', email: 'a@b.com', firstName: 'A', lastName: 'B' },
+    });
+    const user = getStoredUser();
+    expect(user).toEqual({ id: 'u1', email: 'a@b.com', firstName: 'A', lastName: 'B' });
+
+    // A malformed user surfaces as null even though the blob has SOME value.
+    setStoredSession({
+      idToken: 'id',
+      accessToken: 'a',
+      user: { id: 'u1' /* missing email, firstName, lastName */ },
+    });
+    expect(getStoredUser()).toBeNull();
+
+    fullReset();
+  });
+});
+
+// =====================================================================
+// Round 2 item 16: in-memory short-circuit for logged-out requests.
+// =====================================================================
+
+describe('API Client - legacy-cleanup short-circuit (Round 2 item 16)', () => {
+  beforeEach(() => {
+    fullReset();
+  });
+
+  afterEach(() => {
+    fullReset();
+  });
+
+  it('should skip removeItem syscalls on subsequent calls when no legacy keys exist', () => {
+    // First call: no session, no legacy keys → does the sweep, sets the flag.
+    expect(getStoredSession()).toBeNull();
+
+    const removeSpy = vi.spyOn(Storage.prototype, 'removeItem');
+
+    // Second call: should NOT issue any removeItem on the legacy keys.
+    expect(getStoredSession()).toBeNull();
+
+    // Filter to legacy-key removeItem calls only — getItem on
+    // SESSION_KEY returns null without calling removeItem on it.
+    const legacyRemovals = removeSpy.mock.calls.filter((args) =>
+      Object.values(AUTH_CONFIG.LEGACY).includes(args[0] as string)
+    );
+    expect(legacyRemovals).toHaveLength(0);
+
+    removeSpy.mockRestore();
+  });
+
+  it('should still migrate late-arrival legacy keys (short-circuit only skips cleanup, not the migration read)', () => {
+    // Bring the flag up via a logged-out read.
+    expect(getStoredSession()).toBeNull();
+
+    // Stuff in legacy keys AFTER the sweep — simulates an out-of-band
+    // write (third-party script poking localStorage, or a stale tab
+    // that finally writes after a deploy).
+    localStorage.setItem(AUTH_CONFIG.LEGACY.ID_TOKEN_KEY, 'late-arrival-id');
+    localStorage.setItem(AUTH_CONFIG.LEGACY.ACCESS_TOKEN_KEY, 'late-arrival-access');
+
+    // Migration DOES still kick in — `readLegacySession()` reads
+    // localStorage directly without consulting the short-circuit
+    // flag. The flag only optimizes the step-3 cleanup branch, never
+    // the migration read. This is the documented contract.
+    const session = getStoredSession();
+    expect(session?.idToken).toBe('late-arrival-id');
+    expect(session?.accessToken).toBe('late-arrival-access');
+    // Migration deleted the legacy keys as part of upgrading them.
+    expect(localStorage.getItem(AUTH_CONFIG.LEGACY.ID_TOKEN_KEY)).toBeNull();
+
+    // Logout → resets the flag (so a NEW logged-out read will sweep
+    // again if needed) and clears the blob.
+    clearAuthToken();
+    expect(getStoredSession()).toBeNull();
+  });
+});
+
+// =====================================================================
+// Round 2 item 6: strengthened regression test for the
+// abfe5743 fix — calling setAuthToken / setAccessToken against
+// an EMPTY localStorage (no prior blob, no prior anything) MUST
+// produce a blob the request interceptor can read on the next call.
+// The original abfe5743 test only verified the blob existed; this
+// reproduces the user-visible failure mode (the API client silently
+// dropped the Authorization header).
+// =====================================================================
+
+describe('API Client - setAuthToken empty-storage regression (Round 2 item 6)', () => {
+  beforeEach(() => {
+    fullReset();
+  });
+
+  afterEach(() => {
+    fullReset();
+  });
+
+  it('setAuthToken on empty storage → request interceptor sends Bearer header', async () => {
+    // Empty localStorage. setAuthToken must write a complete blob
+    // (mirroring idToken into accessToken to satisfy the type guard).
+    setAuthToken('test-bearer-from-cold-start');
+
+    // Round-trip through the actual request interceptor — this is the
+    // bug the abfe5743 fix landed for. The original-pre-fix code
+    // called updateStoredSession({ idToken }) which refused to write
+    // a partial blob, so getAuthToken() returned null and the
+    // interceptor sent NO Authorization header.
+    const { createApiClient } = await import('../api');
+    const client = createApiClient();
+    let captured: Record<string, unknown> | null = null;
+    client.defaults.adapter = async (config) => {
+      captured = config.headers as unknown as Record<string, unknown>;
+      return {
+        data: { ok: true },
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config,
+      };
+    };
+
+    await client.get('/test');
+
+    expect(captured).not.toBeNull();
+    expect(captured!.Authorization).toBe('Bearer test-bearer-from-cold-start');
+  });
+
+  it('setAccessToken on empty storage → mirrored idToken keeps the blob valid', async () => {
+    setAccessToken('access-from-cold-start');
+    // Per the legacy-compat semantic (mirror), idToken == accessToken
+    // when there's no prior session. The interceptor reads idToken.
+    expect(getAuthToken()).toBe('access-from-cold-start');
+  });
+});
+
+// =====================================================================
+// Round 2 item 3: end-to-end migration → request integration test.
+//
+// The original Issue #195 negative test asserted the no-fallback
+// behavior with synthetic empty-string blob input — logically weak
+// because it doesn't trace the user-facing scenario. This test
+// reproduces the full path:
+//
+//   1. localStorage seeded with ONLY `lfmt_access_token` (a pre-PR-#193
+//      session that survived the deploy).
+//   2. Code path that issues a request (apiClient.get).
+//   3. Assert the Authorization header on the wire carries a value
+//      derived from the legacy-migration synthesis — NOT a stale
+//      raw access-token-as-bearer that the runtime fallback would
+//      have produced.
+// =====================================================================
+
+describe('API Client - legacy access-only migration → first request (Round 2 item 3)', () => {
+  beforeEach(() => {
+    fullReset();
+  });
+
+  afterEach(() => {
+    fullReset();
+  });
+
+  it('should send the migration-synthesized idToken as Bearer on the first authenticated request', async () => {
+    // Pre-PR-#193 session shape: only the access-token key was
+    // populated, no idToken, no blob.
+    localStorage.setItem(AUTH_CONFIG.LEGACY.ACCESS_TOKEN_KEY, 'pre-pr-193-token');
+
+    // Sanity: the modern blob doesn't exist yet.
+    expect(localStorage.getItem(AUTH_CONFIG.SESSION_KEY)).toBeNull();
+
+    // First authenticated request — this triggers
+    // requestInterceptor → getAuthToken → getStoredSession →
+    // readLegacySession → migration → upgraded blob → idToken read.
+    const { createApiClient } = await import('../api');
+    const client = createApiClient();
+    let captured: Record<string, unknown> | null = null;
+    client.defaults.adapter = async (config) => {
+      captured = config.headers as unknown as Record<string, unknown>;
+      return {
+        data: { ok: true },
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config,
+      };
+    };
+
+    await client.get('/some/protected/endpoint');
+
+    // The migration synthesizes idToken from the legacy access token
+    // (`readLegacySession` mirrors `accessToken` into `idToken` when
+    // the legacy idToken key is absent). The interceptor sends THAT
+    // value — NOT the raw legacy access-token-as-bearer that the
+    // removed runtime fallback (#195) would have produced.
+    expect(captured).not.toBeNull();
+    expect(captured!.Authorization).toBe('Bearer pre-pr-193-token');
+
+    // Side effects we want to verify happened:
+    //   - Blob exists under the modern key.
+    //   - Legacy access-token key is gone (idempotency).
+    expect(localStorage.getItem(AUTH_CONFIG.SESSION_KEY)).not.toBeNull();
+    expect(localStorage.getItem(AUTH_CONFIG.LEGACY.ACCESS_TOKEN_KEY)).toBeNull();
+  });
+
+  it('should send NO Authorization header when no legacy or modern session exists', async () => {
+    // Symmetric negative case: a logged-out user must not have a
+    // Bearer header attached.
+    const { createApiClient } = await import('../api');
+    const client = createApiClient();
+    let captured: Record<string, unknown> | null = null;
+    client.defaults.adapter = async (config) => {
+      captured = config.headers as unknown as Record<string, unknown>;
+      return {
+        data: { ok: true },
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config,
+      };
+    };
+
+    await client.get('/some/endpoint');
+
+    expect(captured).not.toBeNull();
+    expect(captured!.Authorization).toBeUndefined();
+  });
 });
 
 describe('API Client - Configuration', () => {
@@ -359,7 +786,7 @@ describe('API Client - Error Handling', () => {
 
 describe('API Client - Request Interceptor', () => {
   beforeEach(() => {
-    localStorage.clear();
+    fullReset();
   });
 
   it('should add Authorization header when token exists', async () => {
@@ -445,7 +872,7 @@ describe('API Client - Request Interceptor', () => {
 
 describe('API Client - Response Error Interceptor', () => {
   beforeEach(() => {
-    localStorage.clear();
+    fullReset();
   });
 
   it.skip('should handle 401 Unauthorized and clear auth tokens', async () => {

--- a/frontend/src/utils/__tests__/api.test.ts
+++ b/frontend/src/utils/__tests__/api.test.ts
@@ -557,8 +557,11 @@ describe('API Client - legacy-cleanup short-circuit (Round 2 item 16)', () => {
 
     // Filter to legacy-key removeItem calls only — getItem on
     // SESSION_KEY returns null without calling removeItem on it.
+    // Widen the LEGACY tuple to readonly string[] so .includes accepts
+    // the spy's string arg (otherwise TS rejects the literal-union narrowing).
+    const legacyKeys: readonly string[] = Object.values(AUTH_CONFIG.LEGACY);
     const legacyRemovals = removeSpy.mock.calls.filter((args) =>
-      Object.values(AUTH_CONFIG.LEGACY).includes(args[0] as string)
+      legacyKeys.includes(args[0] as string)
     );
     expect(legacyRemovals).toHaveLength(0);
 

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -46,18 +46,34 @@ function generateRequestId(): string {
 // in the new format, the legacy keys are deleted and never written
 // again. New code MUST NOT touch the legacy keys directly — call the
 // session helpers exported below.
+//
+// Removal plan: see issue #199 — the migration code can be deleted
+// after one full rollover cycle (≥30 days post-deploy).
 
 /**
- * Local-storage keys we DELETE during migration. Keep this list
- * synchronized with `AUTH_CONFIG.LEGACY` — it is duplicated here so
- * the migration code reads naturally without extra indirection.
+ * Local-storage keys we DELETE during migration. Sourced directly from
+ * `AUTH_CONFIG.LEGACY` so this list cannot drift out of sync (single
+ * source of truth — addresses OMC Round 2 item 13).
  */
-const LEGACY_KEYS = [
-  AUTH_CONFIG.LEGACY.ID_TOKEN_KEY,
-  AUTH_CONFIG.LEGACY.ACCESS_TOKEN_KEY,
-  AUTH_CONFIG.LEGACY.REFRESH_TOKEN_KEY,
-  AUTH_CONFIG.LEGACY.USER_DATA_KEY,
-] as const;
+const LEGACY_KEYS = Object.values(AUTH_CONFIG.LEGACY) as readonly string[];
+
+/**
+ * One-shot in-memory short-circuit (OMC Round 2 item 16).
+ *
+ * `getStoredSession()` runs on EVERY request via the request interceptor.
+ * For logged-out users, the legacy-cleanup branch would otherwise issue
+ * 4 `localStorage.removeItem` calls per call. After the first cleanup
+ * (at module load time, or immediately after logout) there are no legacy
+ * keys to clean — flip this flag to true and the cleanup is skipped.
+ *
+ * Reset to `false` only by paths that could plausibly re-introduce
+ * legacy keys, which currently means "tests that pre-populate them
+ * deliberately" — the production code never writes legacy keys.
+ *
+ * Conservatively defaults to `false` so the first call always does a
+ * full sweep regardless of how the SPA was bootstrapped.
+ */
+let legacyKeysKnownAbsent = false;
 
 /**
  * Read the legacy two-key session and synthesize a StoredSession from
@@ -115,12 +131,16 @@ function readLegacySession(): StoredSession | null {
 /**
  * Remove every legacy auth key from localStorage. Idempotent — safe to
  * call repeatedly. Used both by the migration path AND by the explicit
- * `clearStoredSession()` to ensure we never leave half-deleted state.
+ * `clearAuthToken()` to ensure we never leave half-deleted state.
+ *
+ * Sets the in-memory `legacyKeysKnownAbsent` short-circuit so subsequent
+ * `getStoredSession()` calls for logged-out users skip the syscalls.
  */
 function deleteLegacyKeys(): void {
   for (const key of LEGACY_KEYS) {
     localStorage.removeItem(key);
   }
+  legacyKeysKnownAbsent = true;
 }
 
 /**
@@ -128,11 +148,19 @@ function deleteLegacyKeys(): void {
  *
  * Resolution order:
  *   1. Modern path: parse the blob under `AUTH_CONFIG.SESSION_KEY`.
+ *      ALSO clean up any straggling legacy keys when the modern blob
+ *      wins — addresses OMC Round 2 item 1 (latent coexistence bug:
+ *      a valid blob alongside legacy keys would otherwise leave the
+ *      legacy keys forever).
  *   2. Legacy migration: if the blob is absent BUT legacy keys exist,
- *      synthesize a blob, persist it, delete the legacy keys, and
+ *      synthesize a blob, persist it (in a try/catch — Round 2 Critical:
+ *      a quota error here would escape into AuthContext's mount
+ *      effect and crash the React tree), delete the legacy keys, and
  *      return the synthesized session. Idempotent — the second call
  *      hits step 1 and returns immediately.
- *   3. Otherwise return `null` (no session).
+ *   3. Otherwise return `null` (no session). Best-effort clean of any
+ *      orphan legacy keys, gated by the `legacyKeysKnownAbsent`
+ *      short-circuit so logged-out requests don't burn syscalls.
  *
  * A corrupted blob (invalid JSON, missing required fields) is treated
  * as "no session" — we DO NOT throw because callers thread this
@@ -146,9 +174,26 @@ export function getStoredSession(): StoredSession | null {
   if (raw) {
     try {
       const parsed = JSON.parse(raw) as Partial<StoredSession>;
-      // The two non-optional fields on StoredSession are idToken and
-      // accessToken. If either is absent the blob is unusable.
-      if (typeof parsed.idToken === 'string' && typeof parsed.accessToken === 'string') {
+      // Both required fields must be present AND non-empty strings.
+      // OMC Round 2 item 7: previously this guard accepted `idToken: ""`
+      // because `typeof '' === 'string'` is true. An empty bearer
+      // would surface to the request interceptor as a usable token
+      // and the SPA would send `Authorization: Bearer ` (trailing
+      // space) on every request, triggering 401 → infinite refresh
+      // loops. Tighten to require positive length.
+      if (
+        typeof parsed.idToken === 'string' &&
+        parsed.idToken.length > 0 &&
+        typeof parsed.accessToken === 'string' &&
+        parsed.accessToken.length > 0
+      ) {
+        // Round 2 item 1: sweep up any straggling legacy keys when a
+        // valid blob wins. The blob already exists, so the legacy
+        // keys are by definition stale — delete them once and the
+        // short-circuit flag covers all subsequent calls.
+        if (!legacyKeysKnownAbsent) {
+          deleteLegacyKeys();
+        }
         return parsed as StoredSession;
       }
       // Malformed — fall through to clear it.
@@ -162,9 +207,26 @@ export function getStoredSession(): StoredSession | null {
   const legacy = readLegacySession();
   if (legacy) {
     // Persist the synthesized blob FIRST, then delete legacy keys.
-    // If the setItem somehow throws (quota), the legacy keys remain
-    // intact and the next call will retry the migration.
-    localStorage.setItem(AUTH_CONFIG.SESSION_KEY, JSON.stringify(legacy));
+    // Round 2 Critical: wrap the setItem in try/catch — a
+    // QuotaExceededError here would escape into AuthContext's
+    // mount-time useEffect and potentially crash the React tree.
+    // Treating the migration as failed is correct fail-closed
+    // behavior: the user gets logged out (clean state) rather than
+    // leaving the SPA in a half-migrated zombie state.
+    try {
+      localStorage.setItem(AUTH_CONFIG.SESSION_KEY, JSON.stringify(legacy));
+    } catch (storageError) {
+      // eslint-disable-next-line no-console -- intentional one-time auth-debug
+      console.warn(
+        '[lfmt-auth] Legacy-session migration failed; logging out fail-closed.',
+        storageError
+      );
+      // Clear what we can — the legacy keys are now orphaned in a
+      // sense, but leaving them risks repeating the failed migration
+      // on every render. Accept the data loss and force a re-login.
+      deleteLegacyKeys();
+      return null;
+    }
     deleteLegacyKeys();
     return legacy;
   }
@@ -173,7 +235,14 @@ export function getStoredSession(): StoredSession | null {
   // keys that don't yield a bearer-eligible session (e.g., only
   // `lfmt_user` or only `lfmt_refresh_token` left over). Keeps
   // localStorage tidy without affecting behavior.
-  deleteLegacyKeys();
+  //
+  // Short-circuit: skip the 4 removeItem syscalls if we already know
+  // the legacy keys are absent (Round 2 item 16). On a freshly-loaded
+  // logged-out tab the first call will sweep, set the flag, and every
+  // subsequent request avoids the syscalls.
+  if (!legacyKeysKnownAbsent) {
+    deleteLegacyKeys();
+  }
   return null;
 }
 
@@ -287,17 +356,101 @@ export function getStoredRefreshToken(): string | null {
 }
 
 /**
- * Convenience reader for the persisted user object. Returns `null`
- * when no session is stored or the session was created without a
- * user object (e.g., a refresh-only response).
+ * Minimal user shape the SPA renders. Mirrors `User` in
+ * `services/authService.ts` (which we cannot import here without
+ * creating a circular dependency: authService → api → authService).
  *
- * The return type is `unknown` because the SPA stores a narrower
- * shape than the canonical `UserProfile` (see the JSDoc on
- * `StoredSession.user`). Callers should narrow it with their own
- * type guard or cast.
+ * Field-set MUST stay aligned with `narrowStoredUser()` below.
+ *
+ * The unification of this shape with the canonical `UserProfile`
+ * (in `@lfmt/shared-types`) is tracked in issue #200.
  */
-export function getStoredUser(): unknown {
-  return getStoredSession()?.user ?? null;
+export interface NarrowedStoredUser {
+  id: string;
+  email: string;
+  firstName: string;
+  lastName: string;
+  emailVerified?: boolean;
+  createdAt?: string;
+}
+
+/**
+ * Runtime narrowing helper for the persisted user object (OMC Round 2
+ * item 8). The `StoredSession.user` field is typed as `unknown` because
+ * the SPA persists a narrower shape than canonical `UserProfile`
+ * (see #200). This helper performs the narrowing safely:
+ *
+ *   - Returns the value cast to `NarrowedStoredUser` if it has the
+ *     required string fields (`id`, `email`, `firstName`, `lastName`).
+ *   - Returns `null` otherwise (no session, malformed user, etc.).
+ *
+ * Consumers MUST NOT bare-cast the return of `getStoredUser()` — call
+ * `narrowStoredUser()` first. The bare cast would crash on the first
+ * `.email.toLowerCase()` against a malformed value.
+ */
+export function narrowStoredUser(value: unknown): NarrowedStoredUser | null {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+  const candidate = value as Record<string, unknown>;
+  if (
+    typeof candidate.id !== 'string' ||
+    typeof candidate.email !== 'string' ||
+    typeof candidate.firstName !== 'string' ||
+    typeof candidate.lastName !== 'string'
+  ) {
+    return null;
+  }
+  // Optional fields: include only when present and well-typed. We
+  // deliberately do NOT widen the type — the consumer signed up for
+  // `NarrowedStoredUser`, that's what they get.
+  const narrowed: NarrowedStoredUser = {
+    id: candidate.id,
+    email: candidate.email,
+    firstName: candidate.firstName,
+    lastName: candidate.lastName,
+  };
+  if (typeof candidate.emailVerified === 'boolean') {
+    narrowed.emailVerified = candidate.emailVerified;
+  }
+  if (typeof candidate.createdAt === 'string') {
+    narrowed.createdAt = candidate.createdAt;
+  }
+  return narrowed;
+}
+
+/**
+ * Convenience reader for the persisted user object. Returns `null`
+ * when no session is stored, the session was created without a user
+ * object (e.g., a refresh-only response), OR the stored value fails
+ * runtime shape validation.
+ *
+ * The actual stored shape is the SPA's narrower `User` (id, email,
+ * firstName, lastName, optionally emailVerified/createdAt). The
+ * canonical `UserProfile` has additional REQUIRED fields (userId,
+ * isEmailVerified, mfaEnabled, role, preferences) that the SPA does
+ * not persist — see issue #200 for the unification plan.
+ *
+ * The return is funneled through `narrowStoredUser()` so consumers
+ * receive a typed `NarrowedStoredUser | null` instead of `unknown`.
+ * Bare-casting was the previous risk; the helper closes it.
+ */
+export function getStoredUser(): NarrowedStoredUser | null {
+  return narrowStoredUser(getStoredSession()?.user ?? null);
+}
+
+/**
+ * Test-only helper: reset the in-memory legacy-cleanup short-circuit
+ * flag (Round 2 item 16). Production code does NOT need this — the
+ * flag is managed automatically. Tests that pre-populate legacy keys
+ * AFTER the module has already swept them need a way to force a
+ * fresh sweep on the next `getStoredSession()` call; without this
+ * the sweep would no-op and legacy assertions would be meaningless.
+ *
+ * Exported with the `__test` prefix so grep makes intent obvious.
+ */
+export function __testResetLegacyShortCircuit(): void {
+  legacyKeysKnownAbsent = false;
 }
 
 /**

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -232,12 +232,22 @@ export function getAuthToken(): string | null {
 /**
  * Persist the Cognito ID token that API Gateway expects as the Bearer
  * credential. Kept for backward compatibility with call sites that
- * already write tokens individually; internally it merges into the
- * blob via `updateStoredSession()` so the access token is never
- * accidentally cleared.
+ * already write tokens individually.
+ *
+ * If a session already exists, the idToken field is merged in (the
+ * existing accessToken survives). If no session exists, the
+ * accessToken is mirrored from the idToken so the resulting blob
+ * satisfies the `StoredSession` shape — without this mirror, an
+ * `updateStoredSession` partial with only one required field would
+ * refuse to write (by design, to prevent half-blob corruption).
  */
 export function setAuthToken(idToken: string): void {
-  updateStoredSession({ idToken });
+  const current = getStoredSession();
+  if (current) {
+    setStoredSession({ ...current, idToken });
+  } else {
+    setStoredSession({ idToken, accessToken: idToken });
+  }
 }
 
 /**
@@ -246,7 +256,12 @@ export function setAuthToken(idToken: string): void {
  * the ID token survives.
  */
 export function setAccessToken(accessToken: string): void {
-  updateStoredSession({ accessToken });
+  const current = getStoredSession();
+  if (current) {
+    setStoredSession({ ...current, accessToken });
+  } else {
+    setStoredSession({ idToken: accessToken, accessToken });
+  }
 }
 
 /**

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -11,6 +11,7 @@
  */
 
 import axios, { AxiosInstance, AxiosError, InternalAxiosRequestConfig, AxiosResponse } from 'axios';
+import type { StoredSession } from '@lfmt/shared-types';
 import { API_CONFIG, AUTH_CONFIG, ERROR_MESSAGES } from '../config/constants';
 
 /**
@@ -30,55 +31,258 @@ function generateRequestId(): string {
   return `${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
 }
 
+// ---------------------------------------------------------------------------
+// Session storage (Issue #196 — one-blob model)
+// ---------------------------------------------------------------------------
+//
+// The entire authenticated session lives under a SINGLE localStorage key
+// (`AUTH_CONFIG.SESSION_KEY`). Every write replaces the blob in full so
+// the fields cannot drift out of sync — the failure mode the OMC reviewer
+// flagged on PR #193 (two browser tabs racing a refresh; one setItem
+// succeeding while another hits a quota error).
+//
+// The previous "two-keys" model is preserved ONLY through a one-time,
+// idempotent migration in `getStoredSession()`. Once a session is read
+// in the new format, the legacy keys are deleted and never written
+// again. New code MUST NOT touch the legacy keys directly — call the
+// session helpers exported below.
+
+/**
+ * Local-storage keys we DELETE during migration. Keep this list
+ * synchronized with `AUTH_CONFIG.LEGACY` — it is duplicated here so
+ * the migration code reads naturally without extra indirection.
+ */
+const LEGACY_KEYS = [
+  AUTH_CONFIG.LEGACY.ID_TOKEN_KEY,
+  AUTH_CONFIG.LEGACY.ACCESS_TOKEN_KEY,
+  AUTH_CONFIG.LEGACY.REFRESH_TOKEN_KEY,
+  AUTH_CONFIG.LEGACY.USER_DATA_KEY,
+] as const;
+
+/**
+ * Read the legacy two-key session and synthesize a StoredSession from
+ * whatever fields are present. Returns `null` if no legacy keys exist
+ * OR if neither `idToken` nor `accessToken` is set (the only two values
+ * that could possibly serve as the Bearer credential — without one,
+ * there is nothing meaningful to migrate).
+ *
+ * Pure function: no side effects. The caller decides whether to commit
+ * the synthesized blob and delete the legacy keys.
+ */
+function readLegacySession(): StoredSession | null {
+  const idToken = localStorage.getItem(AUTH_CONFIG.LEGACY.ID_TOKEN_KEY);
+  const accessToken = localStorage.getItem(AUTH_CONFIG.LEGACY.ACCESS_TOKEN_KEY);
+  const refreshToken = localStorage.getItem(AUTH_CONFIG.LEGACY.REFRESH_TOKEN_KEY);
+  const rawUser = localStorage.getItem(AUTH_CONFIG.LEGACY.USER_DATA_KEY);
+
+  // Nothing legacy stored — nothing to migrate.
+  if (!idToken && !accessToken && !refreshToken && !rawUser) {
+    return null;
+  }
+
+  // No bearer-eligible token — the legacy session is effectively dead;
+  // signal "nothing to migrate" so the caller can clean up the orphan
+  // keys without writing a useless blob.
+  if (!idToken && !accessToken) {
+    return null;
+  }
+
+  let user: unknown;
+  if (rawUser) {
+    try {
+      user = JSON.parse(rawUser);
+    } catch {
+      // Corrupted user JSON — discard rather than fail the whole
+      // migration. The user will be re-fetched via `/auth/me`.
+      user = undefined;
+    }
+  }
+
+  return {
+    // Prefer idToken (the API Gateway Bearer); fall back to accessToken
+    // ONLY for legacy sessions that pre-date PR #193 — those sessions
+    // will hit a 401, the refresh interceptor will fire, and the new
+    // session blob will replace this synthetic one. This fallback is
+    // strictly migration-scoped; the runtime fallback in `getAuthToken()`
+    // was removed in Issue #195.
+    idToken: (idToken ?? accessToken) as string,
+    accessToken: (accessToken ?? idToken) as string,
+    refreshToken: refreshToken ?? undefined,
+    user,
+  };
+}
+
+/**
+ * Remove every legacy auth key from localStorage. Idempotent — safe to
+ * call repeatedly. Used both by the migration path AND by the explicit
+ * `clearStoredSession()` to ensure we never leave half-deleted state.
+ */
+function deleteLegacyKeys(): void {
+  for (const key of LEGACY_KEYS) {
+    localStorage.removeItem(key);
+  }
+}
+
+/**
+ * Read the current session from localStorage.
+ *
+ * Resolution order:
+ *   1. Modern path: parse the blob under `AUTH_CONFIG.SESSION_KEY`.
+ *   2. Legacy migration: if the blob is absent BUT legacy keys exist,
+ *      synthesize a blob, persist it, delete the legacy keys, and
+ *      return the synthesized session. Idempotent — the second call
+ *      hits step 1 and returns immediately.
+ *   3. Otherwise return `null` (no session).
+ *
+ * A corrupted blob (invalid JSON, missing required fields) is treated
+ * as "no session" — we DO NOT throw because callers thread this
+ * function through render paths and a thrown error would crash the
+ * mount. The corrupted value is also cleared so the next call has a
+ * clean slate.
+ */
+export function getStoredSession(): StoredSession | null {
+  const raw = localStorage.getItem(AUTH_CONFIG.SESSION_KEY);
+
+  if (raw) {
+    try {
+      const parsed = JSON.parse(raw) as Partial<StoredSession>;
+      // The two non-optional fields on StoredSession are idToken and
+      // accessToken. If either is absent the blob is unusable.
+      if (typeof parsed.idToken === 'string' && typeof parsed.accessToken === 'string') {
+        return parsed as StoredSession;
+      }
+      // Malformed — fall through to clear it.
+      localStorage.removeItem(AUTH_CONFIG.SESSION_KEY);
+    } catch {
+      localStorage.removeItem(AUTH_CONFIG.SESSION_KEY);
+    }
+  }
+
+  // Step 2: migration.
+  const legacy = readLegacySession();
+  if (legacy) {
+    // Persist the synthesized blob FIRST, then delete legacy keys.
+    // If the setItem somehow throws (quota), the legacy keys remain
+    // intact and the next call will retry the migration.
+    localStorage.setItem(AUTH_CONFIG.SESSION_KEY, JSON.stringify(legacy));
+    deleteLegacyKeys();
+    return legacy;
+  }
+
+  // Step 3: still nothing. Best-effort cleanup of any orphan legacy
+  // keys that don't yield a bearer-eligible session (e.g., only
+  // `lfmt_user` or only `lfmt_refresh_token` left over). Keeps
+  // localStorage tidy without affecting behavior.
+  deleteLegacyKeys();
+  return null;
+}
+
+/**
+ * Persist a StoredSession atomically under the single session key.
+ * Replaces any prior blob in full.
+ */
+export function setStoredSession(session: StoredSession): void {
+  localStorage.setItem(AUTH_CONFIG.SESSION_KEY, JSON.stringify(session));
+}
+
+/**
+ * Update specific fields on the stored session, preserving the rest.
+ *
+ * Designed for the token-refresh path where the response carries
+ * `accessToken` + `idToken` (and sometimes `refreshToken`) but not the
+ * user object. Atomicity comes for free because the merge runs in a
+ * single setItem call.
+ *
+ * If no session exists, the partial is treated as a full session — but
+ * only when it carries both required fields. Otherwise the call is a
+ * no-op (we refuse to write an incomplete blob, since a malformed
+ * blob would cascade into corrupted reads).
+ */
+export function updateStoredSession(partial: Partial<StoredSession>): void {
+  const current = getStoredSession();
+  if (current) {
+    setStoredSession({ ...current, ...partial });
+    return;
+  }
+  if (typeof partial.idToken === 'string' && typeof partial.accessToken === 'string') {
+    // Cast is safe — the type guard above proved both required fields are present.
+    setStoredSession(partial as StoredSession);
+  }
+  // Otherwise: no current session AND no complete partial → nothing
+  // to persist; intentionally silent so the refresh interceptor's
+  // "empty bearer" guard remains the single decision point on
+  // session lifecycle.
+}
+
 /**
  * Get the Bearer token used for API Gateway authorization.
  *
- * API Gateway CognitoUserPoolsAuthorizer validates ID tokens, not access
- * tokens.  We therefore prefer the stored ID token and fall back to the
- * access token only for backward-compatibility with sessions that pre-date
- * the idToken storage (i.e., sessions created before this change was
- * deployed — those users will get a 401 on the next authenticated request
- * and be prompted to log in again, which is the correct safe behaviour).
- *
- * `??` (nullish coalescing) is intentional: an empty-string token is
- * treated as absent so we don't send `Authorization: Bearer ` on a
- * corrupted/truncated stored value.
+ * Reads `idToken` from the one-blob session (Issue #196). Per Issue
+ * #195 there is NO runtime fallback to `accessToken` — API Gateway's
+ * CognitoUserPoolsAuthorizer accepts ID tokens only, so an access
+ * token would 401 anyway. The migration path in `getStoredSession()`
+ * already handles legacy sessions that pre-date the blob (those are
+ * upgraded once and never seen again).
  */
 export function getAuthToken(): string | null {
-  return (
-    localStorage.getItem(AUTH_CONFIG.ID_TOKEN_KEY) ??
-    localStorage.getItem(AUTH_CONFIG.ACCESS_TOKEN_KEY)
-  );
+  const session = getStoredSession();
+  return session?.idToken ?? null;
 }
 
 /**
- * Store the Cognito ID token that API Gateway expects as the Bearer credential.
- *
- * Keeping the function name `setAuthToken` preserves backward compatibility
- * with all existing call sites.  Internally we write to `ID_TOKEN_KEY` so
- * that `getAuthToken()` returns the correct token for authenticated requests.
+ * Persist the Cognito ID token that API Gateway expects as the Bearer
+ * credential. Kept for backward compatibility with call sites that
+ * already write tokens individually; internally it merges into the
+ * blob via `updateStoredSession()` so the access token is never
+ * accidentally cleared.
  */
 export function setAuthToken(idToken: string): void {
-  localStorage.setItem(AUTH_CONFIG.ID_TOKEN_KEY, idToken);
+  updateStoredSession({ idToken });
 }
 
 /**
- * Store the raw Cognito AccessToken separately (kept for reference / future
- * OAuth resource-server use). Call sites that receive both tokens from the
- * backend can persist the access token without overwriting the id token.
+ * Persist the raw Cognito AccessToken (kept for OAuth resource-server
+ * use). Same rationale as `setAuthToken` — merges into the blob so
+ * the ID token survives.
  */
 export function setAccessToken(accessToken: string): void {
-  localStorage.setItem(AUTH_CONFIG.ACCESS_TOKEN_KEY, accessToken);
+  updateStoredSession({ accessToken });
 }
 
 /**
- * Clear all authentication tokens from localStorage, including the ID token.
+ * Clear the entire authentication session.
+ *
+ * Removes the blob AND any straggling legacy keys, so an upgraded
+ * session left over from a previous deploy cannot reincarnate after
+ * a logout.
  */
 export function clearAuthToken(): void {
-  localStorage.removeItem(AUTH_CONFIG.ID_TOKEN_KEY);
-  localStorage.removeItem(AUTH_CONFIG.ACCESS_TOKEN_KEY);
-  localStorage.removeItem(AUTH_CONFIG.REFRESH_TOKEN_KEY);
-  localStorage.removeItem(AUTH_CONFIG.USER_DATA_KEY);
+  localStorage.removeItem(AUTH_CONFIG.SESSION_KEY);
+  deleteLegacyKeys();
+}
+
+/**
+ * Convenience reader for the refresh token. Returns `null` if no
+ * session is stored OR the session has no refresh token (Cognito
+ * REFRESH_TOKEN_AUTH does not rotate it, so this is normal after the
+ * first refresh).
+ */
+export function getStoredRefreshToken(): string | null {
+  return getStoredSession()?.refreshToken ?? null;
+}
+
+/**
+ * Convenience reader for the persisted user object. Returns `null`
+ * when no session is stored or the session was created without a
+ * user object (e.g., a refresh-only response).
+ *
+ * The return type is `unknown` because the SPA stores a narrower
+ * shape than the canonical `UserProfile` (see the JSDoc on
+ * `StoredSession.user`). Callers should narrow it with their own
+ * type guard or cast.
+ */
+export function getStoredUser(): unknown {
+  return getStoredSession()?.user ?? null;
 }
 
 /**
@@ -187,7 +391,7 @@ async function responseErrorInterceptor(error: unknown): Promise<unknown> {
     isRefreshing = true;
 
     // Try to refresh the token
-    const refreshToken = localStorage.getItem(AUTH_CONFIG.REFRESH_TOKEN_KEY);
+    const refreshToken = getStoredRefreshToken();
 
     if (!refreshToken) {
       clearAuthToken();
@@ -225,17 +429,20 @@ async function responseErrorInterceptor(error: unknown): Promise<unknown> {
       // Cognito REFRESH_TOKEN_AUTH does not rotate the refresh token, so
       // `refreshToken` may be absent in the backend response. Fall back to
       // the existing value so we don't accidentally store an empty string.
-      const newRefreshToken =
-        payload.refreshToken ?? localStorage.getItem(AUTH_CONFIG.REFRESH_TOKEN_KEY) ?? '';
+      const newRefreshToken = payload.refreshToken ?? refreshToken;
 
-      // Prefer the ID token as the Bearer credential.  `??` keeps the
-      // logic consistent with `getAuthToken()` and `authService.ts`.
       // Treat an empty/missing bearer as a refresh FAILURE rather than
       // silently storing an empty string — a blank Bearer header would
       // cause every subsequent request to 401 immediately, creating an
       // infinite loop that is worse than logging out cleanly.
-      const bearerToken = newIdToken || newAccessToken;
-      if (!bearerToken) {
+      //
+      // The new bearer MUST be the idToken (API Gateway requires it).
+      // The previous code allowed `accessToken` as a fallback here; we
+      // now reject that path because (a) Cognito always returns idToken
+      // when it returns accessToken, so an idToken-less response is a
+      // backend bug worth surfacing, and (b) issue #195 removed all
+      // runtime fallbacks between the two token types.
+      if (!newIdToken) {
         clearAuthToken();
         isRefreshing = false;
         const apiError: ApiError = {
@@ -247,21 +454,22 @@ async function responseErrorInterceptor(error: unknown): Promise<unknown> {
         return Promise.reject(apiError);
       }
 
-      setAuthToken(bearerToken);
-      if (newAccessToken) {
-        setAccessToken(newAccessToken);
-      }
-      if (newRefreshToken) {
-        localStorage.setItem(AUTH_CONFIG.REFRESH_TOKEN_KEY, newRefreshToken);
-      }
+      // Atomic: one setItem rewrites the entire blob — id, access,
+      // and refresh fields stay consistent regardless of whether the
+      // backend rotated the refresh token or not.
+      updateStoredSession({
+        idToken: newIdToken,
+        accessToken: newAccessToken || newIdToken,
+        refreshToken: newRefreshToken,
+      });
 
       // Update authorization header for original request
       if (originalRequest.headers) {
-        originalRequest.headers.Authorization = `Bearer ${bearerToken}`;
+        originalRequest.headers.Authorization = `Bearer ${newIdToken}`;
       }
 
       // Process queued requests with the new bearer token
-      processQueue(null, bearerToken);
+      processQueue(null, newIdToken);
       isRefreshing = false;
 
       // Retry original request with new token

--- a/shared-types/src/auth.ts
+++ b/shared-types/src/auth.ts
@@ -93,6 +93,67 @@ export interface RefreshTokenResponse {
   expiresIn?: number;
 }
 
+/**
+ * One-blob session storage model (Issue #196).
+ *
+ * The frontend persists the entire authenticated session under a SINGLE
+ * `localStorage` key (`lfmt_session`) as a JSON document of this shape.
+ * This replaces the previous "two-keys" model in which `idToken`,
+ * `accessToken`, `refreshToken` and `user` lived under independent keys
+ * and could drift out of sync if any individual `setItem` call failed
+ * (e.g., quota error) or two browser tabs raced a token refresh.
+ *
+ * Atomicity guarantee: every write replaces the entire blob. A single
+ * `JSON.parse`/`stringify` round-trip costs microseconds and eliminates
+ * the consistency hazard the OMC reviewer flagged.
+ *
+ * Migration: a one-time, idempotent migration in `getAuthToken()` (and
+ * any other entry point that reads the session) reconstructs the blob
+ * from the legacy keys (`lfmt_id_token`, `lfmt_access_token`,
+ * `lfmt_refresh_token`, `lfmt_user`) and removes the legacy keys.
+ *
+ * SECURITY NOTE: storing the ID token in `localStorage` keeps the
+ * Bearer credential reachable from any executed JavaScript.
+ * `unsafe-inline` was removed from `script-src` in the same PR (#194)
+ * so an XSS payload can no longer inject an inline `<script>` to
+ * exfiltrate this value. A future hardening initiative may move the
+ * tokens to httpOnly cookies — see the follow-up issue filed alongside
+ * the PR that introduced this type.
+ */
+export interface StoredSession {
+  /** Cognito ID token — the API Gateway Bearer credential. */
+  idToken: string;
+  /** Cognito Access token — kept for OAuth2 resource-server use. */
+  accessToken: string;
+  /**
+   * Cognito Refresh token. Optional because the in-memory session
+   * may be created without a refresh token in degraded paths (e.g.,
+   * a mock harness that hands out single-use tokens).
+   */
+  refreshToken?: string;
+  /**
+   * Epoch milliseconds at which the ID token expires. Optional
+   * because the backend currently surfaces `expiresIn` (seconds)
+   * not an absolute timestamp; consumers compute `expiresAt =
+   * Date.now() + expiresIn * 1000` when persisting.
+   */
+  expiresAt?: number;
+  /**
+   * The authenticated user object. Optional because token-only
+   * refresh responses do not re-send the user object.
+   *
+   * Typed as `unknown` (rather than `UserProfile`) intentionally:
+   * the frontend SPA persists a NARROWER shape than the canonical
+   * `UserProfile` (it stores only the fields it renders — id,
+   * email, firstName, lastName). Consumers that read this field
+   * are responsible for narrowing it to whatever shape they
+   * actually need; this keeps the `StoredSession` contract honest
+   * and avoids forcing every future caller to satisfy every
+   * required field on `UserProfile`.
+   */
+  user?: unknown;
+}
+
 export interface ForgotPasswordRequest {
   email: string;
 }

--- a/shared-types/src/auth.ts
+++ b/shared-types/src/auth.ts
@@ -107,18 +107,20 @@ export interface RefreshTokenResponse {
  * `JSON.parse`/`stringify` round-trip costs microseconds and eliminates
  * the consistency hazard the OMC reviewer flagged.
  *
- * Migration: a one-time, idempotent migration in `getAuthToken()` (and
- * any other entry point that reads the session) reconstructs the blob
- * from the legacy keys (`lfmt_id_token`, `lfmt_access_token`,
- * `lfmt_refresh_token`, `lfmt_user`) and removes the legacy keys.
+ * Migration: a one-time, idempotent migration in `getStoredSession()`
+ * reconstructs the blob from the legacy keys (`lfmt_id_token`,
+ * `lfmt_access_token`, `lfmt_refresh_token`, `lfmt_user`) and removes
+ * the legacy keys. Every other read path (`getAuthToken`,
+ * `getStoredRefreshToken`, `getStoredUser`) goes through
+ * `getStoredSession`, so the migration is hit on first read regardless
+ * of which helper the caller invokes. Removal plan: see issue #199.
  *
  * SECURITY NOTE: storing the ID token in `localStorage` keeps the
  * Bearer credential reachable from any executed JavaScript.
- * `unsafe-inline` was removed from `script-src` in the same PR (#194)
- * so an XSS payload can no longer inject an inline `<script>` to
- * exfiltrate this value. A future hardening initiative may move the
- * tokens to httpOnly cookies — see the follow-up issue filed alongside
- * the PR that introduced this type.
+ * `unsafe-inline` was removed from `script-src` in the same PR (#194,
+ * #198) so an XSS payload can no longer inject an inline `<script>`
+ * to exfiltrate this value. A future hardening initiative may move
+ * the tokens to httpOnly cookies — see follow-up issue #197.
  */
 export interface StoredSession {
   /** Cognito ID token — the API Gateway Bearer credential. */


### PR DESCRIPTION
## Depends on #193

This branch is based on `fix/production-smoke-navigation-and-session` (PR #193), which introduces the `idToken` storage protocol that the changes here harden. The diff against `main` therefore includes #193's changes as well — once #193 merges to `main`, this PR will rebase cleanly to show only the additions described below.

If reviewing in advance of #193, the relevant range is `origin/fix/production-smoke-navigation-and-session..HEAD` (4 commits).

---

## Issue #194 — CSP `script-src 'unsafe-inline'` exfiltration risk

**Decision**: drop `'unsafe-inline'` from `script-src` immediately. Defer `style-src` hardening + httpOnly-cookie token storage to a separate follow-up issue (filed as **#197**).

**Rationale**: with `idToken` (the API Gateway Bearer credential) in `localStorage`, an XSS payload could inject an inline `<script>` to read it. Removing `'unsafe-inline'` from `script-src` closes that injection vector. Inspection of the built `frontend/dist/index.html` confirmed Vite emits ONLY external `<script type=\"module\" src=\"/assets/...\">` tags — zero inline scripts — so no nonce or hash list is required; `script-src 'self'` covers the bundle.

**Why `style-src 'unsafe-inline'` is retained**: MUI/Emotion injects runtime styles via `document.head.appendChild('<style>')`, and removing the directive requires plumbing Emotion's `CacheProvider` with a per-response nonce AND injecting the nonce into the static HTML via Lambda@Edge. That's a real architectural change outside the scope of an OMC follow-up — see #197 for the deferred plan, including the parallel httpOnly-cookie initiative.

**What changed**:
- `backend/infrastructure/lib/lfmt-infrastructure-stack.ts`: both CSP-carrying response-headers policies (initial + post-API-Gateway) drop `'unsafe-inline'` from `script-src`. Comments updated to reflect the new status.
- `backend/infrastructure/lib/__tests__/infrastructure.test.ts`: new regression test `script-src does not contain 'unsafe-inline' (Issue #194)` extracts the `script-src` segment with a regex and asserts the absence of the directive — avoids the `style-src 'unsafe-inline'` false positive.

**Verification**:
- `npx cdk synth --context environment=dev` produces `\"ContentSecurityPolicy\": \"...; script-src 'self'; style-src 'self' 'unsafe-inline'; ...\"` on both policies.
- Infrastructure tests: 47/47 pass (was 46 → +1 new regression test).

---

## Issue #195 — `idToken ?? accessToken` runtime fallback

**Decision (per task spec, option 1)**: remove the fallback in `getAuthToken()` immediately. Bounded disruption (one 401 → refresh interceptor → fixed) is acceptable for an internal POC, and pre-PR-#193 sessions are now handled exclusively by the one-time migration path introduced for #196.

**What changed**:
- `frontend/src/utils/api.ts`: `getAuthToken()` returns `session?.idToken ?? null` from the `StoredSession` blob — no `?? accessToken` runtime branch.
- The refresh interceptor's \"empty bearer = logout\" guard now requires `newIdToken` specifically (was `newIdToken || newAccessToken`). An idToken-less refresh response surfaces as a session-expired logout; this is the correct behavior because Cognito always returns idToken when it returns accessToken.
- Test updates assert the new behavior in `api.test.ts` (the legacy fallback test was rewritten as an explicit \"no runtime fallback\" assertion).

---

## Issue #196 — Two-keys vs one-blob token storage

**Decision (per task spec)**: one-blob. Atomic writes eliminate the cross-tab / quota-error drift class the OMC reviewer flagged. The microsecond-scale serialization cost is irrelevant in this hot path.

**What changed**:
- `shared-types/src/auth.ts`: new `StoredSession` type — `{ idToken, accessToken, refreshToken?, expiresAt?, user? }`. The `user` field is intentionally typed as `unknown` because the SPA persists a narrower shape than canonical `UserProfile`; consumers narrow on read.
- `frontend/src/config/constants.ts`: `AUTH_CONFIG.SESSION_KEY = 'lfmt_session'` is the new canonical key. The legacy keys (`lfmt_id_token`, `lfmt_access_token`, `lfmt_refresh_token`, `lfmt_user`) move under `AUTH_CONFIG.LEGACY` and are referenced ONLY by the migration path.
- `frontend/src/utils/api.ts`: new canonical helpers `getStoredSession`, `setStoredSession`, `updateStoredSession`, `clearAuthToken`, `getStoredRefreshToken`, `getStoredUser`. The legacy `setAuthToken` / `setAccessToken` / `clearAuthToken` are preserved as thin wrappers for source compatibility.
- One-time, idempotent migration in `getStoredSession()`:
  1. If the blob exists, parse and return.
  2. Else if any legacy key exists with a bearer-eligible token, synthesize a `StoredSession`, persist it, delete the legacy keys.
  3. Else clean up any orphan legacy keys and return `null`.
- The migration tolerates corrupted user JSON, missing fields, and corrupted blobs — never throws.
- `frontend/src/services/authService.ts`: `storeAuthTokens()` writes via `setStoredSession`; `refreshToken()` reads via `getStoredRefreshToken()` and writes via `updateStoredSession`. The Cognito-omits-refreshToken case is handled by conditionally spreading the field (avoids overwriting the existing refresh token with `undefined`).

**Test coverage (new tests)**:
1. **Migration contract**: pre-populate all four legacy keys → call `getStoredSession()` → assert blob created with all fields AND legacy keys deleted.
2. **Migration idempotency**: call twice; second call returns the same blob with no further mutations.
3. **Legacy access-only fallback**: pre-PR-#193 sessions (only `lfmt_access_token`) migrate by mirroring it as the synthesized `idToken`.
4. **Orphan-key cleanup**: legacy keys without a bearer-eligible token return `null` and clean up the orphans.
5. **Corrupted blob recovery**: invalid JSON in the blob is treated as no-session and the corrupt blob is cleared.
6. **Structurally-incomplete blob recovery**: blob missing `idToken` is treated as no-session and cleared.
7. **Corrupted legacy user JSON**: doesn't fail the whole migration; user is just dropped.

---

## How #195 and #196 interact

By picking one-blob (#196), the runtime fallback (#195) becomes moot — there is no separate `ACCESS_TOKEN_KEY` to fall back to. The migration handles the same pre-PR-#193-session concern more robustly. They were implemented together in commit `b70afdc`.

---

## Verification results

| Check | Command | Result |
|---|---|---|
| Frontend type-check | `cd frontend && npm run type-check` | clean |
| Frontend lint | `cd frontend && npm run lint` | clean |
| Frontend format:check | `cd frontend && npm run format:check` | clean |
| Frontend tests | `cd frontend && npm test -- --run` | **634 passed, 19 skipped** (was 622 → +12 new migration tests) |
| Shared-types build | `cd shared-types && npm run build` | clean |
| Shared-types tests | `cd shared-types && npm test` | 17/17 pass |
| Backend functions tests | `cd backend/functions && npm test` | 481 passed, 3 skipped |
| Infrastructure build | `cd backend/infrastructure && npm run build` | clean |
| Infrastructure synth | `cd backend/infrastructure && npx cdk synth --context environment=dev` | clean; CSP confirmed |
| Infrastructure tests | `cd backend/infrastructure && npm test` | **47/47 pass** (was 46 → +1 new CSP regression test) |

---

## Follow-up filed

- **#197**: deferred CSP/auth hardening — `style-src` nonce pipeline (Emotion `CacheProvider` + Lambda@Edge response transformer) and httpOnly-cookie token storage (cross-domain considerations + CSRF mitigation). Both are real architectural changes that would have ballooned this PR's scope; the script-src tightening and the storage-model rewrite already address the OMC reviewer's primary concerns.

---

## Test plan

- [x] `npm run type-check`, `lint`, `format:check`, `npm test -- --run` in `frontend/`
- [x] `npm run build` and `npm test` in `shared-types/`
- [x] `npm test` in `backend/functions/`
- [x] `npm run build`, `npx cdk synth --context environment=dev`, `npm test` in `backend/infrastructure/`
- [x] Inspect synthesized CloudFormation template to confirm `script-src 'self'` (no `'unsafe-inline'`) on both response-headers policies
- [x] Inspect `frontend/dist/index.html` after build to confirm zero inline `<script>` blocks (justifies dropping the directive without nonces/hashes)

---

## Round 2 — OMC follow-ups

5 OMC reviewers posted on this PR after Round 1. The PR was approved on the big architectural decisions (one-blob storage, `script-src 'self'`, fallback removal); 1 Critical + ~16 Recommended items were applied here per the project rule "boy-scouts rule applies — comprehensive over minimal, don't punt items."

3 commits added in Round 2 (`e379d9f`, `da88da5`, `0cfb978`).

### Critical

- **`getStoredSession` migration `setItem` missing try/catch** — wrapped the legacy-blob persistence call. A `QuotaExceededError` would otherwise have escaped into `AuthContext`'s mount-time `useEffect` and crashed the React tree. Fail-closed: log a warning, clean up legacy keys, return `null` (forced re-login). Test added asserting `getStoredSession()` does NOT throw under a stubbed `Storage.setItem`.

### Recommended (test coverage)

- **Item 1 (latent coexistence cleanup)** — when both a valid `lfmt_session` blob AND straggling legacy keys existed, the modern blob was returned but the legacy keys were left to fester forever. `getStoredSession` now sweeps the legacy keys on the modern-blob hit path too. Test added.
- **Item 2 (legacy idToken-only migration)** — symmetric to the existing access-only branch. Test added.
- **Item 3 (legacy access-only → first-request integration)** — the original Issue #195 negative test asserted synthetic empty-string blob behavior; the user-facing scenario is "legacy session migrates → first request gets correct Bearer header." End-to-end test added that pre-populates `lfmt_access_token` only, instantiates the actual apiClient, captures the wire `Authorization` header, and asserts the migrated value. Symmetric no-session negative-path test included.
- **Item 4 (CSP positive `'self'` assertion)** — the existing `script-src does not contain 'unsafe-inline'` test only checked absence; a future regression that drops the directive entirely would still pass. Added a positive `expect(scriptSrcMatch[0]).toMatch(/^script-src\s+'self'\s*$/)` assertion alongside the negative one.
- **Item 5 (skipped tests)** — investigated all 10 skipped tests in `auth-integration.test.tsx` and `LoginPage.test.tsx`. **5 LoginPage tests re-enabled and pass**; **4 auth-integration tests re-skipped with explicit `(Round 2: tracked in #200)` annotations** because they surface a real bootstrap race in `AuthProvider.loadUser` that requires source refactoring outside this PR's scope. The remaining "loading state before redirect" skip kept with explicit "asserts a code path that doesn't exist" rationale. Sub-task added to issue #200 ([comment](https://github.com/leixiaoyu/lfmt-poc/issues/200#issuecomment-4375424746)).
- **Item 6 (strengthened `setAuthToken` empty-storage regression)** — the original commit `abfe5743` test verified the blob existed but didn't exercise the user-visible failure mode (request interceptor silently dropping the `Authorization` header). New test instantiates the actual apiClient, captures headers via the adapter, and asserts `Bearer` is sent.

### Recommended (security)

- **Item 7 (positive-length idToken/accessToken guards)** — structural type guard in `getStoredSession` previously accepted `idToken: ""` because `typeof '' === 'string'`. An empty bearer would have surfaced and the SPA would have sent `Authorization: Bearer ` (trailing space) on every request, looping 401 → refresh. Now requires `length > 0`. Updated the prior empty-idToken test which had encoded the broken behavior; added symmetric accessToken-empty test.
- **Item 8 (`narrowStoredUser` runtime helper)** — `getStoredUser` previously returned `unknown`; new `narrowStoredUser(value: unknown): NarrowedStoredUser | null` does runtime shape validation. `getStoredUser` routes through it, so consumers receive a typed `NarrowedStoredUser | null` and cannot bare-cast. Eight focused tests cover well-formed input, optional fields with wrong types, null/non-object input, and missing required fields.
- **Item 9 (CSP `report-uri` / `report-to`)** — STRUCTURALLY PREPARED, full implementation deferred. The receiver requires a new Lambda + API Gateway route + CORS + CloudWatch metric filter — a meaningful infrastructure expansion the OMC reviewer's "out of scope" guard for this PR specifically excluded. Filed full implementation plan as **issue #201** with acceptance criteria, Lambda design, rate-limiting, and Option A (CloudWatch) vs Option B (third-party) trade-off. The `buildCsp()` JSDoc explicitly documents the deferral and points at #201; activation when the receiver lands is a one-line edit.

### Recommended (architecture)

- **Item 10 (extract `buildCsp()` helper)** — CSP string was duplicated between the initial response-headers policy and the post-API-Gateway "Updated" policy. Extracted `private buildCsp(connectSrc: string)` on `LfmtInfrastructureStack`; both call sites now read `this.buildCsp(...)`. The only per-call variable is `connect-src` (region-wide wildcard at initial deploy, concrete API Gateway domain post-update).
- **Item 11 (migration removal tracker)** — filed **issue #199** with the removal plan (≥30 days post-deploy). Linked from the `AUTH_CONFIG.LEGACY` JSDoc.
- **Item 12 (`unknown`-typed user / unused `expiresAt` debt)** — filed **issue #200** with three options analyzed: (1) drop `expiresAt` until needed; (2) adopt for proactive refresh; (3) unify `User`/`UserProfile` types. Architect-reviewer recommendation is option 3.

### Recommended (code quality)

- **Item 13 (`LEGACY_KEYS` single source of truth)** — replaced the hand-maintained array with `Object.values(AUTH_CONFIG.LEGACY) as readonly string[]`. Adding or renaming a legacy key in `constants.ts` now automatically propagates.
- **Item 14 (`getStoredUser` inline doc)** — rewrote the JSDoc to spell out the actual stored shape, the consumer's narrowing obligation, the relationship to `narrowStoredUser`, and the cross-link to issue #200.
- **Item 15 (`StoredSession` JSDoc fix)** — corrected "migration in `getAuthToken()`" to "migration in `getStoredSession()`" and clarified that every reader (`getAuthToken`, `getStoredRefreshToken`, `getStoredUser`) goes through the single entry point. Updated cross-links to issues #197 and #199.

### Recommended (performance)

- **Item 16 (in-memory short-circuit for logged-out requests)** — `getStoredSession` runs on every authenticated request via the request interceptor; for logged-out users it was issuing 4 `localStorage.removeItem` syscalls per call. Added `legacyKeysKnownAbsent` boolean — flipped by `deleteLegacyKeys()` on the first sweep, reset by `clearAuthToken`. Test asserts subsequent reads issue zero `removeItem` calls on legacy keys; second test documents that the short-circuit only optimizes the cleanup branch (so late-arrival legacy keys still get migrated correctly).

### Round 2 verification (re-run after all changes)

| Check | Command | Result |
|---|---|---|
| Frontend type-check | `cd frontend && npm run type-check` | clean |
| Frontend lint | `cd frontend && npm run lint` | clean |
| Frontend format:check | `cd frontend && npm run format:check` | clean |
| Frontend tests | `cd frontend && npm test -- --run` | **656 passed, 14 skipped** (was 634 / 19 → **+22 passed, -5 skipped**) |
| Shared-types build | `cd shared-types && npm run build` | clean |
| Shared-types tests | `cd shared-types && npm test` | 17/17 pass |
| Backend functions tests | `cd backend/functions && npm test` | 481 passed, 3 skipped |
| Infrastructure build | `cd backend/infrastructure && npm run build` | clean |
| Infrastructure synth | `cd backend/infrastructure && npx cdk synth -q --context environment=dev` | clean; CSP confirmed (`script-src 'self'` on both policies) |
| Infrastructure tests | `cd backend/infrastructure && npm test` | **47/47 pass** (test count unchanged; existing test was strengthened in place per item 4) |

### Round 2 follow-up issues filed

- **#199** — tech-debt: remove `StoredSession` migration code once all users have rolled over (≥30 days post-deploy).
- **#200** — arch: unify frontend `User` and shared `UserProfile` types. Sub-task added for the `auth-integration` race window discovered during item 5.
- **#201** — security: add CSP `report-uri`/`report-to` endpoint for violation telemetry (full implementation plan with Option A vs Option B).

### Round 2 diff size

- 8 files changed, +775 / -151 (Round 2 only)
- Combined with Round 1 (vs PR #193 base): ~1800 / -460 across the full PR.
