### PR TITLE
fix(e2e): hoist uploadPage const above first use (TDZ ReferenceError)

### DIFF
--- a/frontend/e2e/tests/smoke/production-smoke.spec.ts
+++ b/frontend/e2e/tests/smoke/production-smoke.spec.ts
@@ -167,6 +167,18 @@ test.describe('Production Smoke Tests @smoke', () => {
     // approach used by every other E2E spec — see complete-workflow.spec.ts,
     // translation-progress.spec.ts).  We then assert the URL and wait for the
     // wizard heading ("New Translation") which is unique to that route.
+    //
+    // The page object is instantiated here, BEFORE the navigation step that
+    // uses it. PR #202 introduced `uploadPage.goto()` in the navigation step
+    // closure but left the `const uploadPage = ...` declaration further down
+    // (alongside the wizard step blocks). The closure executes asynchronously,
+    // hits the Temporal Dead Zone, and throws
+    // `ReferenceError: Cannot access 'uploadPage' before initialization`.
+    // The bug was masked by earlier failure modes (CJS analysis blocked the
+    // bundle from loading, the navigation step never executed) until PR #203
+    // resolved them; the TDZ then surfaced on the first deploy run after #203.
+    const uploadPage = new TranslationUploadPage(page);
+
     await test.step('User can navigate to upload page', async () => {
       await uploadPage.goto();
       await expect(page).toHaveURL(/translation\/upload/i, { timeout: 10000 });
@@ -189,7 +201,6 @@ test.describe('Production Smoke Tests @smoke', () => {
     // (PR #184 review follow-up) so wizard navigation lives in exactly one
     // place. The smoke test still owns its `test.step()` framing and its
     // post-submit translation-completion polling.
-    const uploadPage = new TranslationUploadPage(page);
 
     // Step 3a: Complete legal attestation (wizard step 0)
     await test.step('Complete legal attestation step', async () => {


### PR DESCRIPTION
## Summary
Hotfix for the production-smoke TDZ bug that surfaced post-PR #203.

## Bug
PR #202 introduced `uploadPage.goto()` in the navigation `test.step` closure, but left the `const uploadPage = new TranslationUploadPage(page)` declaration further down (around line 192, alongside the wizard step blocks). The closure executes asynchronously, hits the Temporal Dead Zone, and throws:

```
ReferenceError: Cannot access 'uploadPage' before initialization
```

## Why now
The bug was masked by upstream failure modes:
- **Pre-#203**: CJS named-export resolution issue prevented the bundle from loading. Smoke never reached the navigation step.
- **Post-#203** (Node 22 + ESM migration): bundle loads cleanly; navigation step executes for the first time and surfaces the TDZ.

Failing CI run: https://github.com/leixiaoyu/lfmt-poc/actions/runs/25466223914 (job 74720268639)

## Fix
Moved the `const uploadPage = ...` declaration above the navigation `test.step` block so it's initialized before the closure runs. Added an explanatory comment documenting why the order matters.

## Verification
- Format-check: pass
- Lint: cannot run locally (fresh worktree without node_modules); CI will validate
- The change is a pure code reorder (1 line moved + comment update) — no syntax change, no behavioral change beyond fixing the TDZ

## Test plan
- [x] `npm run format:check` passes
- [ ] CI Test Frontend (lint + tests) passes
- [ ] Post-merge production smoke test no longer throws TDZ