### PR TITLE
fix(demo): unblock browser upload path — CSP allows S3, drop Content-Length, accurate error UI, E2E coverage

### DIFF
--- a/backend/infrastructure/lib/__tests__/infrastructure.test.ts
+++ b/backend/infrastructure/lib/__tests__/infrastructure.test.ts
@@ -3,7 +3,10 @@
 
 import { App, Stack } from 'aws-cdk-lib';
 import { Template, Match } from 'aws-cdk-lib/assertions';
-import { LfmtInfrastructureStack } from '../lfmt-infrastructure-stack';
+import {
+  CLOUDFRONT_ORIGINS_BY_ENVIRONMENT,
+  LfmtInfrastructureStack,
+} from '../lfmt-infrastructure-stack';
 
 describe('LFMT Infrastructure Stack', () => {
   let app: App;
@@ -1993,5 +1996,236 @@ describe('LFMT Infrastructure Stack', () => {
       expect(downloadGetMethod).toBeDefined();
       expect((downloadGetMethod as any).Properties?.AuthorizationType).toBe('COGNITO_USER_POOLS');
     });
+  });
+});
+
+// ===========================================================================
+// PR #214 OMC R2 — Multi-environment CORS drift guard (H-1, M-1, code coverage)
+//
+// The PR's silent-drift defense was undefended in the prior test suite:
+// the original `'test'` stack falls through to the dev branch (so only the
+// dev CloudFront literal was ever exercised at synth). This block synthesizes
+// the stack for each of dev / staging / prod and asserts:
+//   1. The CloudFront origin literal for THAT environment appears in the
+//      document bucket's CORS `AllowedOrigins`.
+//   2. localhost is GATED to dev only — staging / prod must NOT allow it
+//      (security M finding: localhost exclusion).
+//   3. `AllowedMethods` includes PUT (test-coverage gap surfaced by the
+//      browser-upload regression class — without PUT in the bucket CORS,
+//      every presigned-PUT preflight fails).
+// ===========================================================================
+describe('LFMT Infrastructure Stack — multi-environment CORS (PR #214 OMC R2)', () => {
+  const synthForEnvironment = (environment: 'dev' | 'staging' | 'prod') => {
+    const app = new App({
+      context: {
+        skipLambdaBundling: 'true',
+        environment,
+      },
+    });
+    const stack = new LfmtInfrastructureStack(app, `Stack${environment}`, {
+      stackName: `lfmt-${environment}`,
+      environment,
+      enableLogging: true,
+      retainData: false,
+    });
+    return Template.fromStack(stack);
+  };
+
+  // Helper: collect every AllowedOrigins entry across every CORS rule on
+  // the document bucket so the assertion is robust to a future merge of
+  // the initial `cors:[]` rule and the appended `addCorsRule` entry.
+  const documentBucketCorsRules = (template: Template): unknown[] => {
+    const buckets = template.findResources('AWS::S3::Bucket');
+    const docBucketEntry = Object.entries(buckets).find(([, bucket]) => {
+      const bucketName = (bucket as { Properties?: { BucketName?: unknown } })
+        .Properties?.BucketName;
+      if (typeof bucketName === 'string') return bucketName.includes('lfmt-documents');
+      const join = (bucketName as { 'Fn::Join'?: [string, unknown[]] })?.['Fn::Join'];
+      return Array.isArray(join?.[1])
+        ? join[1].some((part) => typeof part === 'string' && part.includes('lfmt-documents'))
+        : false;
+    });
+    expect(docBucketEntry).toBeDefined();
+    const [, docBucket] = docBucketEntry!;
+    return (
+      (docBucket as { Properties?: { CorsConfiguration?: { CorsRules?: unknown[] } } })
+        .Properties?.CorsConfiguration?.CorsRules ?? []
+    );
+  };
+
+  const flattenAllowedOrigins = (corsRules: unknown[]): string[] =>
+    corsRules.flatMap((rule) =>
+      ((rule as { AllowedOrigins?: unknown[] }).AllowedOrigins ?? []).filter(
+        (o): o is string => typeof o === 'string'
+      )
+    );
+
+  const flattenAllowedMethods = (corsRules: unknown[]): string[] =>
+    corsRules.flatMap((rule) =>
+      ((rule as { AllowedMethods?: unknown[] }).AllowedMethods ?? []).filter(
+        (m): m is string => typeof m === 'string'
+      )
+    );
+
+  describe.each(['dev', 'staging', 'prod'] as const)(
+    'environment=%s',
+    (environment) => {
+      let template: Template;
+      beforeAll(() => {
+        template = synthForEnvironment(environment);
+      });
+
+      test(`document bucket CORS allows the ${environment} CloudFront origin`, () => {
+        const origins = flattenAllowedOrigins(documentBucketCorsRules(template));
+        const expectedOrigin = CLOUDFRONT_ORIGINS_BY_ENVIRONMENT[environment];
+        expect(origins).toEqual(expect.arrayContaining([expectedOrigin]));
+      });
+
+      test('document bucket CORS allows the PUT method (presigned uploads)', () => {
+        // Without PUT, every presigned upload preflight is rejected by
+        // the bucket's CORS policy and the browser blocks the request
+        // before any HTTP body is sent — same regression class as the
+        // 2026-05-08 demo blocker.
+        const methods = flattenAllowedMethods(documentBucketCorsRules(template));
+        expect(methods).toEqual(expect.arrayContaining(['PUT']));
+      });
+
+      if (environment === 'dev') {
+        test('localhost IS allowed on dev (developer experience)', () => {
+          const origins = flattenAllowedOrigins(documentBucketCorsRules(template));
+          // The initial `cors:[]` rule on the document bucket includes
+          // localhost for dev; this test pins that contract so a future
+          // refactor doesn't break local-machine wizard testing.
+          expect(origins).toEqual(expect.arrayContaining(['http://localhost:3000']));
+        });
+      } else {
+        test(`localhost is NOT allowed on ${environment} (security M)`, () => {
+          // Per security-M finding (PR #214 OMC R2): non-dev tiers must
+          // never allow `http://localhost:3000` on the production
+          // document bucket — a developer running a local wizard on
+          // their laptop must not be able to drive prod uploads.
+          const origins = flattenAllowedOrigins(documentBucketCorsRules(template));
+          expect(origins).not.toContain('http://localhost:3000');
+          expect(origins).not.toContain('https://localhost:3000');
+        });
+      }
+    }
+  );
+
+  // ---------------------------------------------------------------------
+  // Constant drift guard (PR #214 OMC R2 convergent — 2 agents).
+  //
+  // `CLOUDFRONT_ORIGINS_BY_ENVIRONMENT` is the single source of truth for
+  // both API Gateway CORS and document-bucket CORS. If a new environment
+  // ('preview', 'qa', etc.) is added to the stack switch but the
+  // contributor forgets to populate this constant, the bucket-CORS path
+  // silently falls back to the dev origin and prod-tier uploads start
+  // hitting the wrong origin. This test fails loudly on that drift.
+  // ---------------------------------------------------------------------
+  test('CLOUDFRONT_ORIGINS_BY_ENVIRONMENT has entries for every known tier', () => {
+    expect(Object.keys(CLOUDFRONT_ORIGINS_BY_ENVIRONMENT).sort()).toEqual([
+      'dev',
+      'prod',
+      'staging',
+    ]);
+    // Every value must be an https:// URL — the same gate `buildCsp`
+    // applies to `reportUri` (PR #214 OMC R2 H-3). This is a cheap
+    // sanity check that catches a typo at synth time. Wrap in a try
+    // so a failure surfaces the offending env name (Jest's `expect`
+    // doesn't accept a second message argument).
+    for (const [env, origin] of Object.entries(CLOUDFRONT_ORIGINS_BY_ENVIRONMENT)) {
+      if (!/^https:\/\//.test(origin)) {
+        throw new Error(`${env} origin must start with https:// (got: ${origin})`);
+      }
+    }
+  });
+});
+
+// ===========================================================================
+// buildCsp — H-3 reportUri sanitization (PR #214 OMC R2)
+//
+// `buildCsp({ reportUri })` from commit ea221f1 interpolates the value
+// directly into a CSP directive string. When issue #201 wires this
+// parameter, an attacker (or a misconfigured deploy) could inject a CSP
+// directive via a malformed URL. The validation is exercised here via
+// the static assertion helper so the unit test runs without a full stack
+// synth.
+// ===========================================================================
+describe('LFMT Infrastructure Stack — buildCsp reportUri sanitization (H-3)', () => {
+  // Access the private static assertion via a typed bracket-lookup so
+  // we don't widen the public API just for the test. The helper is
+  // marked `private static` on the class for encapsulation; this
+  // pattern (cast-to-record then index) is the standard Jest idiom
+  // for testing private statics without leaking them.
+  const assertValidCspReportUri = (
+    LfmtInfrastructureStack as unknown as {
+      assertValidCspReportUri: (reportUri: string) => void;
+    }
+  ).assertValidCspReportUri;
+
+  test('valid https:// URL passes', () => {
+    expect(() =>
+      assertValidCspReportUri('https://csp-report.lfmt.example.com/report')
+    ).not.toThrow();
+  });
+
+  test('throws on injected CSP directive via `;`', () => {
+    expect(() =>
+      assertValidCspReportUri('https://evil.com; script-src *')
+    ).toThrow(/must not contain whitespace/);
+  });
+
+  test('throws on injected CSP directive via `,`', () => {
+    expect(() =>
+      assertValidCspReportUri('https://evil.com,script-src *')
+    ).toThrow(/must not contain whitespace/);
+  });
+
+  test('throws on whitespace inside the URL', () => {
+    expect(() =>
+      assertValidCspReportUri('https://evil.com /report')
+    ).toThrow(/must not contain whitespace/);
+  });
+
+  test('throws on plain http:// (must be https)', () => {
+    expect(() =>
+      assertValidCspReportUri('http://csp-report.example.com/report')
+    ).toThrow(/protocol must be https:/);
+  });
+
+  test('throws on a malformed URL', () => {
+    expect(() => assertValidCspReportUri('not a url')).toThrow();
+  });
+
+  // Integration-flavoured assertion: the directive string emitted by
+  // buildCsp must contain `report-uri https://...` when the helper is
+  // given a valid URL. We synthesize a fresh stack so we can call the
+  // private buildCsp method via the same bracket-lookup idiom.
+  test('valid reportUri produces a `report-uri` directive in the emitted CSP string', () => {
+    const app = new App({ context: { skipLambdaBundling: 'true' } });
+    const stack = new LfmtInfrastructureStack(app, 'BuildCspStack', {
+      stackName: 'lfmt-buildcsp-test',
+      environment: 'test',
+      enableLogging: false,
+      retainData: false,
+    });
+    const buildCsp = (
+      stack as unknown as {
+        buildCsp: (opts: { connectSrc: string[]; reportUri?: string }) => string;
+      }
+    ).buildCsp.bind(stack);
+
+    const validUri = 'https://csp-report.lfmt.example.com/report';
+    const csp = buildCsp({
+      connectSrc: ['https://api.example.com'],
+      reportUri: validUri,
+    });
+    expect(csp).toContain(`report-uri ${validUri}`);
+    // Order matters per CSP grammar — report-uri must be the LAST
+    // directive so future tail-only directives can be appended cleanly.
+    // The directive must come at or near the end of the string.
+    const directives = csp.split(';').map((d) => d.trim()).filter(Boolean);
+    const lastDirective = directives[directives.length - 1];
+    expect(lastDirective).toBe(`report-uri ${validUri}`);
   });
 });

--- a/backend/infrastructure/lib/__tests__/infrastructure.test.ts
+++ b/backend/infrastructure/lib/__tests__/infrastructure.test.ts
@@ -1438,6 +1438,84 @@ describe('LFMT Infrastructure Stack', () => {
       });
     });
 
+    test('CSP connect-src includes both API Gateway and document S3 bucket origins (Issue #98)', () => {
+      // Regression guard for the 2026-05-08 demo-blocking incident.
+      //
+      // The browser performs presigned-PUT uploads directly against the
+      // document S3 bucket; CSP `connect-src` must whitelist that origin
+      // alongside the API Gateway origin or the XHR is blocked and the
+      // wizard surfaces a misleading "Connection lost" error. The bucket
+      // is enumerated explicitly (not via a `*.s3.amazonaws.com` wildcard)
+      // per OWASP CSP guidance — see `buildCsp()` JSDoc.
+      //
+      // Both the initial response-headers policy AND the post-API
+      // "Updated" policy must include the bucket origin (the user's first
+      // upload may happen before the second policy is fully propagated to
+      // CloudFront edges).
+      const flattenCsp = (csp: unknown): string => {
+        if (typeof csp === 'string') return csp;
+        if (csp && typeof csp === 'object' && 'Fn::Join' in (csp as object)) {
+          const join = (csp as { 'Fn::Join': [string, unknown[]] })['Fn::Join'];
+          const parts = join[1];
+          return parts
+            .map((p) => {
+              if (typeof p === 'string') return p;
+              // Resolve common CFN intrinsics into a stable searchable
+              // marker. The bucket regional domain is a Fn::GetAtt on the
+              // DocumentBucket resource at synth time (CDK uses the
+              // logical id `DocumentBucket...`); we surface the full
+              // intrinsic so the test below can match on it deterministically.
+              return JSON.stringify(p);
+            })
+            .join('');
+        }
+        return JSON.stringify(csp);
+      };
+
+      const policies = template.findResources('AWS::CloudFront::ResponseHeadersPolicy');
+      const cspCarryingPolicies = Object.values(policies).filter((policy: any) => {
+        return !!policy?.Properties?.ResponseHeadersPolicyConfig?.SecurityHeadersConfig
+          ?.ContentSecurityPolicy?.ContentSecurityPolicy;
+      });
+      expect(cspCarryingPolicies.length).toBeGreaterThanOrEqual(2);
+
+      cspCarryingPolicies.forEach((policy: any) => {
+        const csp =
+          policy.Properties.ResponseHeadersPolicyConfig.SecurityHeadersConfig.ContentSecurityPolicy
+            .ContentSecurityPolicy;
+        const flat = flattenCsp(csp);
+
+        // 1. API Gateway origin must be present (wildcard form on the
+        //    initial policy, concrete domain on the updated policy — both
+        //    contain the literal substring 'execute-api').
+        expect(flat).toContain('execute-api');
+
+        // 2. Document-bucket origin must be present. CDK lowercases the
+        //    bucket name into `lfmt-documents-test`, then resolves the
+        //    regional domain at synth time; on a synthesized template
+        //    this surfaces as either:
+        //      a) Fn::GetAtt → ['DocumentBucket<hash>', 'RegionalDomainName']
+        //         (when used inside a string literal that doesn't already
+        //         resolve at synth time, like other CFN refs), OR
+        //      b) the literal string 'lfmt-documents-test.s3.<region>...'
+        //         (when CDK's tokenizer pre-resolves it, which is what
+        //         happens here because buildCsp interpolates into a plain
+        //         template literal that becomes a CloudFormation Fn::Join).
+        //    Either form is acceptable — we just need to prove the bucket
+        //    is enumerated, not that a particular CFN intrinsic was used.
+        const hasBucketLiteral = flat.includes('lfmt-documents-test');
+        const hasBucketGetAtt = flat.includes('DocumentBucket') && flat.includes('RegionalDomainName');
+        expect(hasBucketLiteral || hasBucketGetAtt).toBe(true);
+
+        // 3. connect-src directive must still start with 'self' and
+        //    must NOT use a generic `https://*.s3.amazonaws.com` wildcard
+        //    (OWASP — wildcards on S3 hosts let any compromised bucket
+        //    script exfiltrate the user's API Gateway Bearer credential).
+        expect(flat).toMatch(/connect-src\s+'self'/);
+        expect(flat).not.toContain('*.s3.amazonaws.com');
+      });
+    });
+
     test('Frontend S3 bucket has public access blocked', () => {
       const buckets = template.findResources('AWS::S3::Bucket');
       const frontendBucket = Object.values(buckets).find((bucket: any) => {

--- a/backend/infrastructure/lib/__tests__/infrastructure.test.ts
+++ b/backend/infrastructure/lib/__tests__/infrastructure.test.ts
@@ -1516,6 +1516,78 @@ describe('LFMT Infrastructure Stack', () => {
       });
     });
 
+    // -------------------------------------------------------------------------
+    // C-sec (PR #214 OMC): document bucket CORS must include CloudFront
+    // origin.
+    //
+    // Browser-side presigned-PUT uploads originate from the CloudFront-
+    // hosted SPA. Without the CloudFront domain in the bucket's CORS
+    // `AllowedOrigins`, the preflight OPTIONS is rejected and the PUT
+    // never fires. The CSP fix only solved one half of the demo-blocking
+    // incident; this test pins the other half so a future contributor
+    // can't drop the `addCorsRule` call without breaking the build.
+    //
+    // Implementation note: we use literal CloudFront domain strings
+    // (NOT `frontendDistribution.distributionDomainName`) to avoid a
+    // CFN cyclic dependency — see `addCloudFrontOriginToDocumentBucketCors`
+    // JSDoc. The test stack runs with `environment: 'test'`, which
+    // falls through to the `dev` literal list, so we assert on that
+    // domain (`d39xcun7144jgl.cloudfront.net`) — the same value that
+    // `getAllowedApiOrigins()` enumerates as the dev tier source of
+    // truth.
+    // -------------------------------------------------------------------------
+    test('Document bucket CORS includes CloudFront distribution origin', () => {
+      const buckets = template.findResources('AWS::S3::Bucket');
+      const docBucketEntry = Object.entries(buckets).find(([, bucket]) => {
+        const bucketName = (bucket as { Properties?: { BucketName?: unknown } })
+          .Properties?.BucketName;
+        // Document bucket has BucketName = `lfmt-documents-<stack>`.
+        if (typeof bucketName === 'string') return bucketName.includes('lfmt-documents');
+        // Token form (Fn::Join) — match on the literal segment.
+        const join = (bucketName as { 'Fn::Join'?: [string, unknown[]] })?.[
+          'Fn::Join'
+        ];
+        return Array.isArray(join?.[1])
+          ? join[1].some(
+              (part) => typeof part === 'string' && part.includes('lfmt-documents')
+            )
+          : false;
+      });
+
+      expect(docBucketEntry).toBeDefined();
+      const [, docBucket] = docBucketEntry!;
+      const corsRules =
+        (docBucket as { Properties?: { CorsConfiguration?: { CorsRules?: unknown[] } } })
+          .Properties?.CorsConfiguration?.CorsRules ?? [];
+      expect(Array.isArray(corsRules)).toBe(true);
+      // Two rules expected: (1) the initial localhost-dev rule from
+      // `createS3Buckets` and (2) the CloudFront-origin rule appended
+      // by `addCloudFrontOriginToDocumentBucketCors`. We assert
+      // `>= 2` so a future merge into a single rule (semantic equiv)
+      // doesn't break the test, but the current shape is two rules.
+      expect(corsRules.length).toBeGreaterThanOrEqual(2);
+
+      // Flatten every CORS rule's AllowedOrigins so the assertion is
+      // robust to the rule being either:
+      //   a) merged with the initial localhost rule (single CorsRule), or
+      //   b) appended via addCorsRule (second CorsRule entry).
+      // Either layout is correct as long as the CloudFront distribution
+      // domain ends up in the union.
+      const allOrigins: string[] = corsRules.flatMap((rule) =>
+        ((rule as { AllowedOrigins?: unknown[] }).AllowedOrigins ?? []).filter(
+          (o): o is string => typeof o === 'string'
+        )
+      );
+
+      // Use Match.arrayWith semantics — the CloudFront dev origin must
+      // be present somewhere in the union of CORS rules.
+      expect(allOrigins).toEqual(
+        expect.arrayContaining([
+          expect.stringMatching(/d39xcun7144jgl\.cloudfront\.net/),
+        ])
+      );
+    });
+
     test('Frontend S3 bucket has public access blocked', () => {
       const buckets = template.findResources('AWS::S3::Bucket');
       const frontendBucket = Object.values(buckets).find((bucket: any) => {

--- a/backend/infrastructure/lib/lfmt-infrastructure-stack.ts
+++ b/backend/infrastructure/lib/lfmt-infrastructure-stack.ts
@@ -2059,11 +2059,18 @@ export class LfmtInfrastructureStack extends Stack {
         },
         contentSecurityPolicy: {
           // CSP body sourced from `buildCsp()` (Round 2 item 10).
-          // The `connect-src` argument is a region-wide wildcard at
-          // initial deploy time — `updateCloudFrontCSP()` swaps it for
-          // the concrete API Gateway domain once that resource exists.
+          // The `connect-src` arguments are region-wide wildcards at
+          // initial deploy time — `updateCloudFrontCSP()` swaps the API
+          // Gateway entry for the concrete domain once that resource
+          // exists. The document-bucket entry is included here too so
+          // browser-side presigned-PUT uploads succeed even before the
+          // updated policy is applied (preventing the same CSP-block
+          // class that caused the demo-blocking failure on 2026-05-08).
           // See `buildCsp()` JSDoc for the full hardening status.
-          contentSecurityPolicy: this.buildCsp('https://*.execute-api.us-east-1.amazonaws.com'),
+          contentSecurityPolicy: this.buildCsp([
+            'https://*.execute-api.us-east-1.amazonaws.com',
+            `https://${this.documentBucket.bucketRegionalDomainName}`,
+          ]),
           override: true,
         },
       },
@@ -2134,11 +2141,23 @@ export class LfmtInfrastructureStack extends Stack {
    * (e.g., Issue #197's `style-src` nonce work) now only edits ONE
    * place.
    *
-   * The only per-call variable is `connectSrc` — the wildcard
-   * `https://*.execute-api.us-east-1.amazonaws.com` is used at initial
-   * deploy time (before API Gateway exists), then replaced with the
-   * concrete `https://<apiId>.execute-api.<region>.amazonaws.com` once
-   * the API is provisioned.
+   * The per-call variable is `connectSrc` — a list of additional
+   * origins appended to `connect-src` alongside `'self'`. The list
+   * always includes:
+   *   1. The API Gateway origin (wildcard at initial deploy time, then
+   *      replaced with the concrete `https://<apiId>.execute-api.<region>.amazonaws.com`
+   *      once API Gateway is provisioned).
+   *   2. The S3 document-bucket regional domain
+   *      (`https://lfmt-documents-<stack>.s3.<region>.amazonaws.com`).
+   *      The browser performs presigned-PUT uploads directly against
+   *      this origin; without it the upload XHR is blocked by CSP and
+   *      the wizard surfaces a misleading "Connection lost" error
+   *      (root cause of the 2026-05-08 demo-blocking regression — the
+   *      curl validation path bypasses CSP, so this only manifests in
+   *      a real browser). The bucket origin is enumerated explicitly
+   *      (not via a `*.s3.amazonaws.com` wildcard) per OWASP CSP
+   *      guidance: a wildcard would let any compromised bucket script
+   *      exfiltrate the user's API Gateway Bearer credential.
    *
    * Hardening status (Issues #133, #194):
    *   - 'unsafe-eval' REMOVED from script-src.
@@ -2167,20 +2186,28 @@ export class LfmtInfrastructureStack extends Stack {
    *   Until then, every reviewer who looks at this code will see this
    *   block and know exactly what to do (and why we didn't do it now).
    */
-  private buildCsp(connectSrc: string): string {
-    return [
-      `default-src 'self'`,
-      `script-src 'self'`,
-      `style-src 'self' 'unsafe-inline'`,
-      `img-src 'self' data: https:`,
-      `font-src 'self' data:`,
-      `connect-src 'self' ${connectSrc}`,
-      `object-src 'none'`,
-      `base-uri 'self'`,
-      `form-action 'self'`,
-      `frame-ancestors 'none'`,
-      `upgrade-insecure-requests`,
-    ].join('; ') + ';';
+  private buildCsp(connectSrc: string | string[]): string {
+    // Accept either a single origin (back-compat with older callers) or
+    // an explicit list. The list form is preferred — it makes the set of
+    // browser-reachable origins visible at the call site so reviewers
+    // can audit each addition (cf. the document-bucket entry added in
+    // 2026-05 to unblock browser-side presigned-PUT uploads).
+    const connectSrcEntries = Array.isArray(connectSrc) ? connectSrc : [connectSrc];
+    return (
+      [
+        `default-src 'self'`,
+        `script-src 'self'`,
+        `style-src 'self' 'unsafe-inline'`,
+        `img-src 'self' data: https:`,
+        `font-src 'self' data:`,
+        `connect-src 'self' ${connectSrcEntries.join(' ')}`,
+        `object-src 'none'`,
+        `base-uri 'self'`,
+        `form-action 'self'`,
+        `frame-ancestors 'none'`,
+        `upgrade-insecure-requests`,
+      ].join('; ') + ';'
+    );
   }
 
   private updateCloudFrontCSP() {
@@ -2227,10 +2254,16 @@ export class LfmtInfrastructureStack extends Stack {
         },
         contentSecurityPolicy: {
           // CSP body sourced from `buildCsp()` (Round 2 item 10) so the
-          // initial and updated policies cannot drift. `connect-src` is
-          // now the concrete API Gateway domain — see `buildCsp()`
+          // initial and updated policies cannot drift. `connect-src`
+          // now lists BOTH the concrete API Gateway domain AND the
+          // document-bucket regional domain — the latter is required
+          // for browser-side presigned-PUT uploads (root cause of the
+          // 2026-05-08 demo-blocking regression). See `buildCsp()`
           // JSDoc for the full hardening status (#133, #194, #197).
-          contentSecurityPolicy: this.buildCsp(`https://${apiDomain}`),
+          contentSecurityPolicy: this.buildCsp([
+            `https://${apiDomain}`,
+            `https://${this.documentBucket.bucketRegionalDomainName}`,
+          ]),
           override: true,
         },
       },

--- a/backend/infrastructure/lib/lfmt-infrastructure-stack.ts
+++ b/backend/infrastructure/lib/lfmt-infrastructure-stack.ts
@@ -52,6 +52,38 @@ const LAMBDA_RUNTIME = lambda.Runtime.NODEJS_22_X;
 // constant will fail that test.
 const LAMBDA_ARCHITECTURE = lambda.Architecture.ARM_64;
 
+/**
+ * Per-environment CloudFront-distribution origin literals
+ * (PR #214 OMC R2, convergent: 2 agents).
+ *
+ * Single source of truth consumed by BOTH `getAllowedApiOrigins()`
+ * (API Gateway CORS) AND `addCloudFrontOriginToDocumentBucketCors()`
+ * (S3 document-bucket CORS). Before the unification both methods kept
+ * their own literal lists per environment and the two had to agree by
+ * manual care — drift surfaces at the worst possible time (browser
+ * upload silently rejected because the bucket-CORS list lagged the
+ * API-CORS list after a CloudFront re-create).
+ *
+ * IMPORTANT: these are LITERAL strings on purpose, NOT references to
+ * `frontendDistribution.distributionDomainName`. Using the live
+ * reference would create a CFN cyclic dependency (DocumentBucket →
+ * FrontendDistribution → response-headers policy → DocumentBucket).
+ * The literal approach is acceptable because CloudFront distribution
+ * domains are stable across deploys (CDK only re-creates the
+ * distribution on logical-id changes). See
+ * `addCloudFrontOriginToDocumentBucketCors` JSDoc and
+ * `docs/CLOUDFRONT-SETUP.md` runbook note.
+ *
+ * Drift guard: `infrastructure.test.ts` asserts every known
+ * environment has an entry, so adding a new tier without filling this
+ * table fails the build immediately.
+ */
+export const CLOUDFRONT_ORIGINS_BY_ENVIRONMENT: Record<'dev' | 'staging' | 'prod', string> = {
+  dev: 'https://d39xcun7144jgl.cloudfront.net',
+  staging: 'https://staging.lfmt.yourcompany.com',
+  prod: 'https://lfmt.yourcompany.com',
+};
+
 export interface LfmtInfrastructureStackProps extends StackProps {
   stackName: string;
   environment: string;
@@ -111,18 +143,22 @@ export class LfmtInfrastructureStack extends Stack {
   private getAllowedApiOrigins(): string[] {
     const origins: string[] = [];
 
+    // PR #214 OMC R2 (convergent): consume the unified per-environment
+    // CloudFront constant rather than carrying our own literal here.
+    // Drift between this list and the document-bucket CORS list (the
+    // other consumer of the same constant) is no longer possible.
     switch (this.node.tryGetContext('environment')) {
       case 'prod':
-        origins.push('https://lfmt.yourcompany.com'); // Replace with actual production domain
+        origins.push(CLOUDFRONT_ORIGINS_BY_ENVIRONMENT.prod);
         break;
       case 'staging':
-        origins.push('https://staging.lfmt.yourcompany.com'); // Replace with actual staging domain
+        origins.push(CLOUDFRONT_ORIGINS_BY_ENVIRONMENT.staging);
         break;
       default:
         // Dev environment: local development + CDK-managed CloudFront
         origins.push('http://localhost:3000');
         origins.push('https://localhost:3000');
-        origins.push('https://d39xcun7144jgl.cloudfront.net'); // CDK-managed CloudFront distribution
+        origins.push(CLOUDFRONT_ORIGINS_BY_ENVIRONMENT.dev);
     }
 
     // Add CloudFront distribution URL if it exists (after createFrontendHosting() is called)
@@ -414,22 +450,22 @@ export class LfmtInfrastructureStack extends Stack {
    *   set of additional origins per tier.
    */
   private addCloudFrontOriginToDocumentBucketCors(environment: string) {
-    // Per-environment CloudFront origin literals. The dev value is the
-    // CDK-managed CloudFront distribution domain — the same literal
-    // already enumerated in `getAllowedApiOrigins()` for the dev tier.
-    // Drift between the two would surface as a broken API CORS first
-    // (much louder failure mode than a broken upload), so the API list
-    // is the practical source of truth.
-    const cloudFrontOriginsByEnvironment: Record<string, string[]> = {
-      dev: ['https://d39xcun7144jgl.cloudfront.net'],
-      staging: ['https://staging.lfmt.yourcompany.com'],
-      prod: ['https://lfmt.yourcompany.com'],
-    };
-
-    // Default to the dev list for any unknown environment label
-    // (matches the `default:` branch in `getAllowedApiOrigins()`).
-    const additionalOrigins =
-      cloudFrontOriginsByEnvironment[environment] ?? cloudFrontOriginsByEnvironment.dev;
+    // PR #214 OMC R2 (convergent): consume the unified per-environment
+    // CloudFront constant `CLOUDFRONT_ORIGINS_BY_ENVIRONMENT` defined
+    // at module scope. The same constant feeds `getAllowedApiOrigins()`
+    // so the two CORS surfaces (API Gateway + S3 bucket) cannot drift
+    // independently — a single edit covers both. Drift via
+    // unrecognised environment label is also handled: known tiers
+    // (dev / staging / prod) get their concrete entry; anything else
+    // falls back to dev (matches the `default:` branch in
+    // `getAllowedApiOrigins()`).
+    const isKnown = (env: string): env is keyof typeof CLOUDFRONT_ORIGINS_BY_ENVIRONMENT =>
+      env === 'dev' || env === 'staging' || env === 'prod';
+    const additionalOrigins: string[] = [
+      isKnown(environment)
+        ? CLOUDFRONT_ORIGINS_BY_ENVIRONMENT[environment]
+        : CLOUDFRONT_ORIGINS_BY_ENVIRONMENT.dev,
+    ];
 
     this.documentBucket.addCorsRule({
       allowedMethods: [s3.HttpMethods.GET, s3.HttpMethods.PUT, s3.HttpMethods.POST],
@@ -2289,6 +2325,24 @@ export class LfmtInfrastructureStack extends Stack {
     ];
 
     if (opts.reportUri) {
+      // H-3 (PR #214 OMC R2): sanitize `reportUri` BEFORE interpolating
+      // it into the CSP directive string. Without this, a malformed URL
+      // (or a misconfigured deploy) could inject arbitrary CSP
+      // directives — `;` and `,` both terminate directives in the CSP
+      // grammar, so a value like
+      //   `https://evil.com; script-src *`
+      // would silently downgrade `script-src` to allow ANY origin.
+      // Whitespace gets the same treatment because CSP source-list
+      // parsers split on whitespace; an injected token there would be
+      // treated as an additional source for the `report-uri` directive
+      // (which CSP3 ignores, but the legacy parser may not).
+      //
+      // The check is performed at synth time (not deploy time) so a
+      // misconfiguration fails fast in `cdk synth` / `cdk deploy` rather
+      // than reaching CloudFront. Issue #201 will wire this parameter;
+      // pinning the contract here means that PR can't accidentally
+      // forward an attacker-controlled URL.
+      LfmtInfrastructureStack.assertValidCspReportUri(opts.reportUri);
       // CSP grammar requires `report-uri` to be the LAST directive so
       // that any future tail-only directive (e.g. `report-to`) can be
       // appended without breaking the value. Issue #201 will switch to
@@ -2297,6 +2351,51 @@ export class LfmtInfrastructureStack extends Stack {
     }
 
     return directives.join('; ') + ';';
+  }
+
+  /**
+   * Validate a CSP `report-uri` value before interpolating it into a
+   * directive string (H-3, PR #214 OMC R2).
+   *
+   * Rules (intentionally conservative — favour false-positive on synth
+   * over a false-negative that ships an injection):
+   *   1. Must parse as a valid URL.
+   *   2. Protocol MUST be `https:`. CSP report endpoints commonly POST
+   *      cross-origin with credentials, so plain HTTP would leak
+   *      violation reports (which contain blocked URIs that may include
+   *      session info) over the wire.
+   *   3. The raw string MUST NOT contain whitespace, `;`, or `,` —
+   *      these terminate / split CSP directives, so an injected
+   *      character there would let an attacker append a directive (e.g.
+   *      `https://x.com; script-src *`).
+   *
+   * Throws synchronously inside `cdk synth` so a bad value never
+   * reaches CloudFront. Static so the unit test can call it without
+   * instantiating the full stack.
+   */
+  private static assertValidCspReportUri(reportUri: string): void {
+    // Forbidden characters: whitespace + CSP-grammar separators.
+    if (/[\s;,]/.test(reportUri)) {
+      throw new Error(
+        `Invalid CSP reportUri: must not contain whitespace, ';' or ',' (got: ${JSON.stringify(reportUri)})`
+      );
+    }
+
+    // Must parse as a URL. URL constructor throws on malformed input.
+    let parsed: URL;
+    try {
+      parsed = new URL(reportUri);
+    } catch {
+      throw new Error(
+        `Invalid CSP reportUri: not a valid URL (got: ${JSON.stringify(reportUri)})`
+      );
+    }
+
+    if (parsed.protocol !== 'https:') {
+      throw new Error(
+        `Invalid CSP reportUri: protocol must be https: (got: ${parsed.protocol})`
+      );
+    }
   }
 
   private updateCloudFrontCSP() {

--- a/backend/infrastructure/lib/lfmt-infrastructure-stack.ts
+++ b/backend/infrastructure/lib/lfmt-infrastructure-stack.ts
@@ -189,6 +189,13 @@ export class LfmtInfrastructureStack extends Stack {
     // 6. Frontend Hosting (CloudFront + S3) - Create early to get CloudFront URL for CORS
     this.createFrontendHosting(removalPolicy);
 
+    // 6.5. Document-bucket CORS — append per-environment CloudFront
+    // origin so browser-side presigned-PUT uploads pass the bucket's
+    // OPTIONS preflight. Uses literal CloudFront domain strings (NOT
+    // `frontendDistribution.distributionDomainName`) to avoid a CFN
+    // cyclic dependency — see method JSDoc for details.
+    this.addCloudFrontOriginToDocumentBucketCors(props.environment);
+
     // 7. IAM Roles and Policies
     this.createIamRoles();
 
@@ -364,6 +371,77 @@ export class LfmtInfrastructureStack extends Stack {
           ],
         },
       ],
+    });
+  }
+
+  /**
+   * Append the CloudFront distribution origin to the document bucket's
+   * CORS `AllowedOrigins` (PR #214 OMC C-sec).
+   *
+   * Browser-side presigned-PUT uploads originate from the CloudFront-
+   * hosted SPA. The bucket's CORS preflight (OPTIONS /key) must echo
+   * `Access-Control-Allow-Origin: https://<cloudfront-domain>` or the
+   * browser blocks the subsequent PUT. The CSP fix in `buildCsp()`
+   * solved one half of the demo-blocking incident (CSP `connect-src`);
+   * this bucket-CORS entry solves the other half. Without both, a fresh
+   * deploy in a new region would still fail in a real browser even
+   * though curl-driven validation succeeds.
+   *
+   * IMPORTANT (cyclic-dependency avoidance): the response-headers
+   * policy used by `frontendDistribution` already references
+   * `documentBucket.bucketRegionalDomainName` (CSP `connect-src`). If
+   * we then made the bucket's CORS rule reference
+   * `frontendDistribution.distributionDomainName` we would create a
+   * CFN cycle (DocumentBucket → FrontendDistribution → policy →
+   * DocumentBucket). To break the cycle we use literal CloudFront
+   * domain strings per environment — the same approach that
+   * `getAllowedApiOrigins()` (dev tier) already takes for the API
+   * Gateway CORS list. This is acceptable because:
+   *   1. CloudFront distribution domains are stable across deploys
+   *      (CDK only re-creates the distribution on logical-id changes,
+   *      not on every `cdk deploy`).
+   *   2. The same value is already maintained as the source of truth
+   *      in `getAllowedApiOrigins()` — drift between the two would
+   *      surface immediately in the API CORS reference.
+   *
+   * Production gating: localhost origins are dev-only. We mirror the
+   * environment switch used by `getAllowedApiOrigins()` so prod-tier
+   * deploys don't accidentally allow `http://localhost:3000` to upload
+   * to the prod document bucket.
+   *
+   * @param environment - Stack environment ('dev' | 'staging' | 'prod')
+   *   from `LfmtInfrastructureStackProps`. Used to select the right
+   *   set of additional origins per tier.
+   */
+  private addCloudFrontOriginToDocumentBucketCors(environment: string) {
+    // Per-environment CloudFront origin literals. The dev value is the
+    // CDK-managed CloudFront distribution domain — the same literal
+    // already enumerated in `getAllowedApiOrigins()` for the dev tier.
+    // Drift between the two would surface as a broken API CORS first
+    // (much louder failure mode than a broken upload), so the API list
+    // is the practical source of truth.
+    const cloudFrontOriginsByEnvironment: Record<string, string[]> = {
+      dev: ['https://d39xcun7144jgl.cloudfront.net'],
+      staging: ['https://staging.lfmt.yourcompany.com'],
+      prod: ['https://lfmt.yourcompany.com'],
+    };
+
+    // Default to the dev list for any unknown environment label
+    // (matches the `default:` branch in `getAllowedApiOrigins()`).
+    const additionalOrigins =
+      cloudFrontOriginsByEnvironment[environment] ?? cloudFrontOriginsByEnvironment.dev;
+
+    this.documentBucket.addCorsRule({
+      allowedMethods: [s3.HttpMethods.GET, s3.HttpMethods.PUT, s3.HttpMethods.POST],
+      allowedOrigins: additionalOrigins,
+      allowedHeaders: [
+        'Content-Type',
+        'x-amz-date',
+        'Authorization',
+        'x-api-key',
+        'x-amz-security-token',
+      ],
+      maxAge: 3000,
     });
   }
 
@@ -2067,10 +2145,12 @@ export class LfmtInfrastructureStack extends Stack {
           // updated policy is applied (preventing the same CSP-block
           // class that caused the demo-blocking failure on 2026-05-08).
           // See `buildCsp()` JSDoc for the full hardening status.
-          contentSecurityPolicy: this.buildCsp([
-            'https://*.execute-api.us-east-1.amazonaws.com',
-            `https://${this.documentBucket.bucketRegionalDomainName}`,
-          ]),
+          contentSecurityPolicy: this.buildCsp({
+            connectSrc: [
+              'https://*.execute-api.us-east-1.amazonaws.com',
+              `https://${this.documentBucket.bucketRegionalDomainName}`,
+            ],
+          }),
           override: true,
         },
       },
@@ -2181,33 +2261,42 @@ export class LfmtInfrastructureStack extends Stack {
    *
    *   Issue #201 has the full implementation plan and acceptance
    *   criteria; when it lands, the activation here is a one-line
-   *   edit: append `report-uri ${reportUri}` to the directive list
-   *   below and pass the new endpoint URL through `updateCloudFrontCSP`.
-   *   Until then, every reviewer who looks at this code will see this
-   *   block and know exactly what to do (and why we didn't do it now).
+   *   edit: pass `reportUri` through to the options object below and
+   *   the directive is appended automatically. Until then, every
+   *   reviewer who looks at this code will see this block and know
+   *   exactly what to do (and why we didn't do it now).
+   *
+   * @param opts.connectSrc - Origins appended to `connect-src` alongside
+   *   `'self'`. Always pass an explicit list so reviewers can audit each
+   *   addition at the call site.
+   * @param opts.reportUri - Optional CSP `report-uri` endpoint. When set,
+   *   a `report-uri ${reportUri}` directive is appended (issue #201).
+   *   Left undefined today — see telemetry note above.
    */
-  private buildCsp(connectSrc: string | string[]): string {
-    // Accept either a single origin (back-compat with older callers) or
-    // an explicit list. The list form is preferred — it makes the set of
-    // browser-reachable origins visible at the call site so reviewers
-    // can audit each addition (cf. the document-bucket entry added in
-    // 2026-05 to unblock browser-side presigned-PUT uploads).
-    const connectSrcEntries = Array.isArray(connectSrc) ? connectSrc : [connectSrc];
-    return (
-      [
-        `default-src 'self'`,
-        `script-src 'self'`,
-        `style-src 'self' 'unsafe-inline'`,
-        `img-src 'self' data: https:`,
-        `font-src 'self' data:`,
-        `connect-src 'self' ${connectSrcEntries.join(' ')}`,
-        `object-src 'none'`,
-        `base-uri 'self'`,
-        `form-action 'self'`,
-        `frame-ancestors 'none'`,
-        `upgrade-insecure-requests`,
-      ].join('; ') + ';'
-    );
+  private buildCsp(opts: { connectSrc: string[]; reportUri?: string }): string {
+    const directives: string[] = [
+      `default-src 'self'`,
+      `script-src 'self'`,
+      `style-src 'self' 'unsafe-inline'`,
+      `img-src 'self' data: https:`,
+      `font-src 'self' data:`,
+      `connect-src 'self' ${opts.connectSrc.join(' ')}`,
+      `object-src 'none'`,
+      `base-uri 'self'`,
+      `form-action 'self'`,
+      `frame-ancestors 'none'`,
+      `upgrade-insecure-requests`,
+    ];
+
+    if (opts.reportUri) {
+      // CSP grammar requires `report-uri` to be the LAST directive so
+      // that any future tail-only directive (e.g. `report-to`) can be
+      // appended without breaking the value. Issue #201 will switch to
+      // `report-to` once the violation-receiver Lambda lands.
+      directives.push(`report-uri ${opts.reportUri}`);
+    }
+
+    return directives.join('; ') + ';';
   }
 
   private updateCloudFrontCSP() {
@@ -2260,10 +2349,12 @@ export class LfmtInfrastructureStack extends Stack {
           // for browser-side presigned-PUT uploads (root cause of the
           // 2026-05-08 demo-blocking regression). See `buildCsp()`
           // JSDoc for the full hardening status (#133, #194, #197).
-          contentSecurityPolicy: this.buildCsp([
-            `https://${apiDomain}`,
-            `https://${this.documentBucket.bucketRegionalDomainName}`,
-          ]),
+          contentSecurityPolicy: this.buildCsp({
+            connectSrc: [
+              `https://${apiDomain}`,
+              `https://${this.documentBucket.bucketRegionalDomainName}`,
+            ],
+          }),
           override: true,
         },
       },

--- a/docs/CLOUDFRONT-SETUP.md
+++ b/docs/CLOUDFRONT-SETUP.md
@@ -558,6 +558,39 @@ aws cloudfront get-invalidation \
 
 ## Known Issues & Fixes
 
+### Runbook: CloudFront distribution destroy + re-create
+
+If the CloudFront distribution is destroyed and re-created (logical ID
+changes, region migration, manual `cdk destroy` followed by re-deploy),
+the new distribution will be assigned a NEW domain (`d#######.cloudfront.net`).
+At that moment the literal in `CLOUDFRONT_ORIGINS_BY_ENVIRONMENT`
+(in `backend/infrastructure/lib/lfmt-infrastructure-stack.ts`) is stale.
+
+**Symptom**: API CORS preflight succeeds (it uses the live
+`distributionDomainName`), but browser-side presigned-PUT uploads silently
+fail because the document-bucket CORS policy still references the OLD
+CloudFront domain. The wizard surfaces a misleading "Connection lost"
+error and curl-based smoke tests pass (curl bypasses CORS).
+
+**Fix**: BEFORE re-deploying, update
+`CLOUDFRONT_ORIGINS_BY_ENVIRONMENT` in
+`backend/infrastructure/lib/lfmt-infrastructure-stack.ts` with the new
+domain for the affected environment. Both `getAllowedApiOrigins()`
+(API Gateway CORS) and `addCloudFrontOriginToDocumentBucketCors()` (S3
+bucket CORS) consume this single constant — a single edit covers both.
+The drift-guard test
+(`infrastructure.test.ts` → "CLOUDFRONT_ORIGINS_BY_ENVIRONMENT has
+entries for every known tier") will fail if a new environment is added
+without populating the constant, but it cannot detect that an existing
+entry has gone stale; that requires this manual runbook step.
+
+**Why a literal, not a CDK reference**: the bucket-CORS rule cannot
+consume `frontendDistribution.distributionDomainName` at synth time
+because `documentBucket` is referenced by the response-headers policy
+that `frontendDistribution` uses (CSP `connect-src`); a back-reference
+from bucket → distribution would create a CFN cycle. See the JSDoc on
+`addCloudFrontOriginToDocumentBucketCors` for the full discussion.
+
 ### Issue: CloudFront CSP Deployment Failure (Fixed in PR #66)
 
 **Error**:

--- a/frontend/e2e/tests/smoke/production-smoke.spec.ts
+++ b/frontend/e2e/tests/smoke/production-smoke.spec.ts
@@ -361,17 +361,67 @@ test.describe('Production Smoke Tests @smoke', () => {
     // Capture every CSP violation reported by the browser. In Chromium the
     // `securitypolicyviolation` DOM event fires for each blocked resource;
     // we mirror it onto the page for the test runner to inspect.
+    //
+    // R-perf-1 (PR #214 OMC): we ALSO surface the violations through a
+    // page-level flag (`__s3CspBlocked`) so the wizard-driving step can
+    // short-circuit the moment a CSP block is observed against the S3
+    // origin. Without this, the test waits for `getByText(...processing)`
+    // to time out (30 s) and — worse — the backend may have already
+    // initiated chunking + Gemini calls, burning daily quota for a run
+    // that's known to fail.
     const cspViolations: string[] = [];
     await page.addInitScript(() => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (window as any).__cspViolations = [];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (window as any).__s3CspBlocked = null;
       window.addEventListener('securitypolicyviolation', (e) => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (window as any).__cspViolations.push({
           violatedDirective: e.violatedDirective,
           blockedURI: e.blockedURI,
         });
+        // Short-circuit signal: any CSP block whose blocked URI points
+        // at the document S3 bucket means the upload PUT was rejected
+        // and we can fail fast without waiting for translation kick-off.
+        if (
+          e.violatedDirective?.startsWith('connect-src') &&
+          /s3[.-][a-z0-9-]+\.amazonaws\.com/i.test(e.blockedURI || '')
+        ) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (window as any).__s3CspBlocked = {
+            violatedDirective: e.violatedDirective,
+            blockedURI: e.blockedURI,
+          };
+        }
       });
+
+      // R-perf-1: instrument XHR to detect S3-PUT failures with status
+      // 0 (network-level / CSP block) — same fail-fast intent. We patch
+      // XMLHttpRequest.prototype.open to record the URL, then surface
+      // the failure via `__s3PutFailed` when the load event fires with
+      // status 0 against the document-bucket origin.
+      const OriginalXHR = window.XMLHttpRequest;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (window as any).__s3PutFailed = null;
+      const originalOpen = OriginalXHR.prototype.open;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      OriginalXHR.prototype.open = function (this: any, method: string, url: string) {
+        this.__lfmtUrl = url;
+        this.__lfmtMethod = method;
+        this.addEventListener('loadend', () => {
+          if (
+            this.__lfmtMethod === 'PUT' &&
+            this.status === 0 &&
+            /s3[.-][a-z0-9-]+\.amazonaws\.com/i.test(String(this.__lfmtUrl))
+          ) {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (window as any).__s3PutFailed = { url: this.__lfmtUrl, status: this.status };
+          }
+        });
+        // eslint-disable-next-line prefer-rest-params
+        return originalOpen.apply(this, arguments as unknown as Parameters<typeof originalOpen>);
+      };
     });
 
     // Capture "Refused to set unsafe header" console errors — these
@@ -444,15 +494,61 @@ test.describe('Production Smoke Tests @smoke', () => {
       await uploadPage.advanceToReviewByRole('smoke-test-minimal.txt');
       await uploadPage.submitTranslationByRole();
 
-      // Wait for either the success indicator (translation started) OR an
-      // error alert. We don't need to wait for full translation — only that
-      // the S3 PUT succeeded and the backend transitioned the job past
-      // PENDING_UPLOAD. A "translation started/processing" indicator proves
-      // both: CSP allowed the PUT, and the backend's S3-event pipeline
-      // observed the upload.
-      await expect(
-        page.getByText(/translation.*started|translating|processing/i).first()
-      ).toBeVisible({ timeout: 30000 });
+      // R-perf-1 (PR #214 OMC): race the success indicator against the
+      // fail-fast flags from `addInitScript` above. If a CSP block or
+      // status-0 PUT failure has already fired, abort immediately rather
+      // than waiting 30 s for the success indicator that can never come
+      // — and, more importantly, before we wait long enough for the
+      // backend's S3-event pipeline to consume Gemini quota on a job
+      // that's known to fail.
+      //
+      // We poll the page-level flags every 200 ms via `waitForFunction`,
+      // resolving the moment EITHER condition holds:
+      //   1. The success indicator text appears (happy path).
+      //   2. `__s3CspBlocked` or `__s3PutFailed` is populated (fast-fail).
+      // The handle's return value tells us which branch tripped so the
+      // assertion below can surface a specific, actionable error.
+      const outcomeHandle = await page.waitForFunction(
+        () => {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const w = window as any;
+          if (w.__s3CspBlocked) {
+            return { kind: 'cspBlocked', detail: w.__s3CspBlocked };
+          }
+          if (w.__s3PutFailed) {
+            return { kind: 'putFailed', detail: w.__s3PutFailed };
+          }
+          // Look for the success indicator in the DOM. We check the
+          // text directly rather than reusing the Playwright locator
+          // because we need a synchronous boolean inside this poller.
+          const bodyText = document.body?.innerText || '';
+          if (/translation.*started|translating|processing/i.test(bodyText)) {
+            return { kind: 'started' };
+          }
+          return null;
+        },
+        undefined,
+        { timeout: 30000, polling: 200 }
+      );
+
+      const outcome = (await outcomeHandle.jsonValue()) as
+        | { kind: 'started' }
+        | { kind: 'cspBlocked'; detail: { violatedDirective: string; blockedURI: string } }
+        | { kind: 'putFailed'; detail: { url: string; status: number } };
+
+      if (outcome.kind === 'cspBlocked') {
+        throw new Error(
+          `S3 PUT blocked by CSP — ${outcome.detail.violatedDirective} blocked ${outcome.detail.blockedURI}. ` +
+            `This is the 2026-05-08 demo-blocking regression class — check buildCsp() and document-bucket CORS.`
+        );
+      }
+      if (outcome.kind === 'putFailed') {
+        throw new Error(
+          `S3 PUT failed at network layer (status 0) — url=${outcome.detail.url}. ` +
+            `Likely CORS preflight rejection or DNS failure; verify document-bucket CORS includes the CloudFront origin.`
+        );
+      }
+      // outcome.kind === 'started' — happy path, continue.
     });
 
     // Step 3: Assert no CSP violations were emitted by the browser.

--- a/frontend/e2e/tests/smoke/production-smoke.spec.ts
+++ b/frontend/e2e/tests/smoke/production-smoke.spec.ts
@@ -21,6 +21,7 @@ import { fileURLToPath } from 'node:url';
 import { test, expect } from '@playwright/test';
 import { TranslationUploadPage } from '../../pages/TranslationUploadPage';
 import { resolveApiUrl } from '../../fixtures/url';
+import { installNetworkProbes, readNetworkProbes, restoreXhr } from '../../utils/networkProbes';
 
 // Smoke tests use a longer timeout because they run against production.
 // 3 minutes is sufficient when we use the ~1 KB smoke-test-minimal.txt
@@ -355,74 +356,30 @@ test.describe('Production Smoke Tests @smoke', () => {
   // wiring step. It must NOT use MSW or any mock — the entire point is to
   // exercise the real CSP and the real S3 PUT.
   // ---------------------------------------------------------------------------
+  // PR #214 OMC R2 (convergent: 4 agents): the inline XHR + CSP probe
+  // block was extracted to `e2e/utils/networkProbes.ts`. The hygiene
+  // contract (restore prototype after each test) is enforced via this
+  // afterEach hook even though Playwright per-test BrowserContext
+  // isolation makes the leak path moot today — keeping it here means
+  // a future iframe / popup step can't silently inherit the patched
+  // prototype.
+  test.afterEach(async ({ page }) => {
+    await restoreXhr(page);
+  });
+
   test('CSP Regression: browser-side S3 PUT is not blocked by CSP @csp-regression', async ({
     page,
   }) => {
-    // Capture every CSP violation reported by the browser. In Chromium the
-    // `securitypolicyviolation` DOM event fires for each blocked resource;
-    // we mirror it onto the page for the test runner to inspect.
-    //
-    // R-perf-1 (PR #214 OMC): we ALSO surface the violations through a
-    // page-level flag (`__s3CspBlocked`) so the wizard-driving step can
-    // short-circuit the moment a CSP block is observed against the S3
-    // origin. Without this, the test waits for `getByText(...processing)`
-    // to time out (30 s) and — worse — the backend may have already
-    // initiated chunking + Gemini calls, burning daily quota for a run
-    // that's known to fail.
+    // R-perf-1 (PR #214 OMC R1): install the CSP + XHR probes BEFORE
+    // the first navigation so the init script lands on the root
+    // document. The probes surface S3-specific failure signatures via
+    // `window.__s3CspBlocked` / `window.__s3PutFailed` so the
+    // wizard-driving step can fail fast (avoiding 30 s of `getByText`
+    // wait AND — more importantly — avoiding the backend's S3-event
+    // pipeline burning Gemini quota on a run that's known to fail).
+    // Implementation lives in `e2e/utils/networkProbes.ts`.
     const cspViolations: string[] = [];
-    await page.addInitScript(() => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (window as any).__cspViolations = [];
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (window as any).__s3CspBlocked = null;
-      window.addEventListener('securitypolicyviolation', (e) => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (window as any).__cspViolations.push({
-          violatedDirective: e.violatedDirective,
-          blockedURI: e.blockedURI,
-        });
-        // Short-circuit signal: any CSP block whose blocked URI points
-        // at the document S3 bucket means the upload PUT was rejected
-        // and we can fail fast without waiting for translation kick-off.
-        if (
-          e.violatedDirective?.startsWith('connect-src') &&
-          /s3[.-][a-z0-9-]+\.amazonaws\.com/i.test(e.blockedURI || '')
-        ) {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          (window as any).__s3CspBlocked = {
-            violatedDirective: e.violatedDirective,
-            blockedURI: e.blockedURI,
-          };
-        }
-      });
-
-      // R-perf-1: instrument XHR to detect S3-PUT failures with status
-      // 0 (network-level / CSP block) — same fail-fast intent. We patch
-      // XMLHttpRequest.prototype.open to record the URL, then surface
-      // the failure via `__s3PutFailed` when the load event fires with
-      // status 0 against the document-bucket origin.
-      const OriginalXHR = window.XMLHttpRequest;
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (window as any).__s3PutFailed = null;
-      const originalOpen = OriginalXHR.prototype.open;
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      OriginalXHR.prototype.open = function (this: any, method: string, url: string) {
-        this.__lfmtUrl = url;
-        this.__lfmtMethod = method;
-        this.addEventListener('loadend', () => {
-          if (
-            this.__lfmtMethod === 'PUT' &&
-            this.status === 0 &&
-            /s3[.-][a-z0-9-]+\.amazonaws\.com/i.test(String(this.__lfmtUrl))
-          ) {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (window as any).__s3PutFailed = { url: this.__lfmtUrl, status: this.status };
-          }
-        });
-        // eslint-disable-next-line prefer-rest-params
-        return originalOpen.apply(this, arguments as unknown as Parameters<typeof originalOpen>);
-      };
-    });
+    await installNetworkProbes(page);
 
     // Capture "Refused to set unsafe header" console errors — these
     // indicate someone re-introduced a forbidden header (Content-Length).
@@ -553,13 +510,12 @@ test.describe('Production Smoke Tests @smoke', () => {
 
     // Step 3: Assert no CSP violations were emitted by the browser.
     await test.step('No CSP violations emitted', async () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const violations = await page.evaluate(() => (window as any).__cspViolations || []);
+      // PR #214 OMC R2 (convergent): use the typed helper from
+      // networkProbes.ts instead of an ad-hoc `page.evaluate` so the
+      // shape of `__cspViolations` lives in exactly one place.
+      const probes = await readNetworkProbes(page);
       cspViolations.push(
-        ...violations.map(
-          (v: { violatedDirective: string; blockedURI: string }) =>
-            `${v.violatedDirective} blocked ${v.blockedURI}`
-        )
+        ...probes.cspViolations.map((v) => `${v.violatedDirective} blocked ${v.blockedURI}`)
       );
       expect(
         cspViolations,

--- a/frontend/e2e/tests/smoke/production-smoke.spec.ts
+++ b/frontend/e2e/tests/smoke/production-smoke.spec.ts
@@ -332,4 +332,151 @@ test.describe('Production Smoke Tests @smoke', () => {
       expect(headers['content-security-policy']).toBeTruthy();
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // CSP regression test — Issue #98 / 2026-05-08 demo-blocking incident.
+  //
+  // The deployed CSP `connect-src` was missing the document-bucket origin, so
+  // the browser-side presigned-PUT was blocked before any HTTP response. The
+  // failure mode was browser-only: curl-driven validation of the same API
+  // contract worked end-to-end because curl ignores CSP. None of the prior
+  // smoke / E2E tests asserted on browser-emitted CSP violations, so the
+  // regression slipped to the manual demo walkthrough.
+  //
+  // This test:
+  //   1. Hits the response headers and confirms CSP `connect-src` enumerates
+  //      both the API Gateway origin AND the document S3 bucket origin.
+  //   2. Drives the browser through register → login → upload (the same path
+  //      that broke). It listens for `securitypolicyviolation` events and the
+  //      console "Refused to set unsafe header" warning, and fails on either.
+  //
+  // NOTE: This test is tagged `@csp-regression` AND `@smoke` so it runs as
+  // part of the post-deploy verification suite without needing a separate CI
+  // wiring step. It must NOT use MSW or any mock — the entire point is to
+  // exercise the real CSP and the real S3 PUT.
+  // ---------------------------------------------------------------------------
+  test('CSP Regression: browser-side S3 PUT is not blocked by CSP @csp-regression', async ({
+    page,
+  }) => {
+    // Capture every CSP violation reported by the browser. In Chromium the
+    // `securitypolicyviolation` DOM event fires for each blocked resource;
+    // we mirror it onto the page for the test runner to inspect.
+    const cspViolations: string[] = [];
+    await page.addInitScript(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (window as any).__cspViolations = [];
+      window.addEventListener('securitypolicyviolation', (e) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (window as any).__cspViolations.push({
+          violatedDirective: e.violatedDirective,
+          blockedURI: e.blockedURI,
+        });
+      });
+    });
+
+    // Capture "Refused to set unsafe header" console errors — these
+    // indicate someone re-introduced a forbidden header (Content-Length).
+    const unsafeHeaderWarnings: string[] = [];
+    page.on('console', (msg) => {
+      const text = msg.text();
+      if (/Refused to set unsafe header/i.test(text)) {
+        unsafeHeaderWarnings.push(text);
+      }
+    });
+
+    // Step 1: Verify CSP header on the deployed CloudFront response.
+    await test.step('CSP enumerates both API Gateway and document S3 bucket', async () => {
+      const response = await page.goto(baseURL);
+      const csp = response?.headers()['content-security-policy'];
+      if (!csp) throw new Error('CSP header missing on root document');
+
+      // API Gateway origin (any execute-api host).
+      expect(csp).toMatch(/connect-src[^;]*execute-api/);
+      // Document S3 bucket origin. The dev stack's bucket is
+      // lfmt-documents-lfmtpocdev — match the host pattern liberally so
+      // a future stack-name change (lfmt-documents-<stack>) doesn't
+      // require a test update, but still proves the bucket entry exists.
+      expect(csp).toMatch(/connect-src[^;]*lfmt-documents-[a-z0-9-]+\.s3\./i);
+      // Wildcard guard — no `*.s3.amazonaws.com`. (OWASP: wildcards on
+      // S3 hosts let any compromised bucket script exfiltrate the
+      // user's API Gateway Bearer credential.)
+      expect(csp).not.toContain('*.s3.amazonaws.com');
+    });
+
+    // Step 2: Walk the same browser path that broke on 2026-05-08.
+    const user = generateSmokeTestUser();
+    await test.step('Register a fresh user via API', async () => {
+      const registerResponse = await page.request.post(
+        `${resolveApiUrl(apiBaseURL)}/auth/register`,
+        {
+          data: {
+            email: user.email,
+            password: user.password,
+            confirmPassword: user.password,
+            firstName: user.firstName,
+            lastName: user.lastName,
+            acceptedTerms: true,
+            acceptedPrivacy: true,
+          },
+          failOnStatusCode: false,
+        }
+      );
+      const status = registerResponse.status();
+      if (status !== 201 && status !== 409) {
+        throw new Error(`Pre-test registration failed: ${status}`);
+      }
+    });
+
+    await test.step('Login via UI', async () => {
+      await page.goto(`${baseURL}/login`);
+      await page.getByLabel(/email/i).fill(user.email);
+      await page.getByLabel(/password/i).fill(user.password);
+      await page.getByRole('button', { name: /log in|sign in/i }).click();
+      await expect(page).toHaveURL(/dashboard|translate|upload/i, { timeout: 15000 });
+    });
+
+    const uploadPage = new TranslationUploadPage(page);
+    await test.step('Drive wizard through to submit (exercises S3 PUT)', async () => {
+      await uploadPage.goto();
+      await uploadPage.completeLegalAttestationByRole();
+      await uploadPage.configureTranslationSettingsByRole();
+      await uploadPage.uploadFileAndAwaitDisplay(SMOKE_FIXTURE_PATH, 'smoke-test-minimal.txt');
+      await uploadPage.advanceToReviewByRole('smoke-test-minimal.txt');
+      await uploadPage.submitTranslationByRole();
+
+      // Wait for either the success indicator (translation started) OR an
+      // error alert. We don't need to wait for full translation — only that
+      // the S3 PUT succeeded and the backend transitioned the job past
+      // PENDING_UPLOAD. A "translation started/processing" indicator proves
+      // both: CSP allowed the PUT, and the backend's S3-event pipeline
+      // observed the upload.
+      await expect(
+        page.getByText(/translation.*started|translating|processing/i).first()
+      ).toBeVisible({ timeout: 30000 });
+    });
+
+    // Step 3: Assert no CSP violations were emitted by the browser.
+    await test.step('No CSP violations emitted', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const violations = await page.evaluate(() => (window as any).__cspViolations || []);
+      cspViolations.push(
+        ...violations.map(
+          (v: { violatedDirective: string; blockedURI: string }) =>
+            `${v.violatedDirective} blocked ${v.blockedURI}`
+        )
+      );
+      expect(
+        cspViolations,
+        `Browser reported CSP violations during upload flow: ${cspViolations.join(', ')}`
+      ).toEqual([]);
+    });
+
+    // Step 4: Assert no "Refused to set unsafe header" warnings.
+    await test.step('No browser-forbidden header warnings emitted', async () => {
+      expect(
+        unsafeHeaderWarnings,
+        `Browser refused setRequestHeader calls: ${unsafeHeaderWarnings.join(', ')}`
+      ).toEqual([]);
+    });
+  });
 });

--- a/frontend/e2e/utils/networkProbes.ts
+++ b/frontend/e2e/utils/networkProbes.ts
@@ -1,0 +1,168 @@
+/**
+ * Browser-side network probes for Playwright smoke / E2E tests.
+ *
+ * Extracted from `frontend/e2e/tests/smoke/production-smoke.spec.ts`
+ * (PR #214 OMC R2, convergent: 4 agents) so the wizard-driving
+ * @csp-regression test no longer carries 50 lines of inline
+ * `addInitScript` plumbing. The probes patch the page's
+ * `XMLHttpRequest.prototype.open` to surface S3-specific failure
+ * signatures via `window.__s3CspBlocked` / `window.__s3PutFailed`,
+ * letting the test fail fast rather than waiting for downstream
+ * timeouts (and — more importantly — before the backend's S3-event
+ * pipeline burns Gemini quota on a job that's known to fail).
+ *
+ * Hygiene contract (`restoreXhr` / installed via `installXhrProbe`):
+ *   The patched prototype IS scoped to the test's BrowserContext, so
+ *   per-test isolation already prevents cross-test bleed. We still
+ *   expose an explicit `restoreXhr` helper so a future contributor who
+ *   adds an iframe / popup step (which would inherit the patched
+ *   prototype) has a clear, named tear-down hook to call from
+ *   `test.afterEach`. Keeping the contract hygienic in the helper
+ *   means the call sites stay tidy too.
+ */
+
+import type { Page } from '@playwright/test';
+
+/**
+ * Result emitted by `readNetworkProbes` — one per probe, plus the raw
+ * CSP-violation log so the test can surface every blocked URI on a
+ * failed assertion.
+ */
+export interface NetworkProbesSnapshot {
+  cspViolations: Array<{ violatedDirective: string; blockedURI: string }>;
+  s3CspBlocked: { violatedDirective: string; blockedURI: string } | null;
+  s3PutFailed: { url: string; status: number } | null;
+}
+
+/**
+ * Install both probes on the next navigation. Call this BEFORE
+ * `page.goto(...)` so the init script lands on the first document.
+ *
+ * Probes installed:
+ *   1. `securitypolicyviolation` listener → `window.__cspViolations`,
+ *      with a fast-fail flag (`__s3CspBlocked`) when the blocked URI
+ *      points at the document S3 bucket.
+ *   2. `XMLHttpRequest.prototype.open` patch → `window.__s3PutFailed`
+ *      when a PUT to the S3 origin completes with status 0
+ *      (CORS-preflight reject / DNS failure / network blip).
+ *
+ * Both probes also stash the original `XMLHttpRequest.prototype.open`
+ * on `window.__lfmtRestoreXhrOpen` so `restoreXhr()` can put it back.
+ */
+export async function installNetworkProbes(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    // ---------- CSP probe ----------
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as any).__cspViolations = [];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as any).__s3CspBlocked = null;
+    window.addEventListener('securitypolicyviolation', (e) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (window as any).__cspViolations.push({
+        violatedDirective: e.violatedDirective,
+        blockedURI: e.blockedURI,
+      });
+      // Short-circuit signal: any CSP block whose blocked URI points
+      // at the document S3 bucket means the upload PUT was rejected
+      // and the test can fail fast without waiting for translation
+      // kick-off.
+      if (
+        e.violatedDirective?.startsWith('connect-src') &&
+        /s3[.-][a-z0-9-]+\.amazonaws\.com/i.test(e.blockedURI || '')
+      ) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (window as any).__s3CspBlocked = {
+          violatedDirective: e.violatedDirective,
+          blockedURI: e.blockedURI,
+        };
+      }
+    });
+
+    // ---------- XHR probe ----------
+    // Patch `XMLHttpRequest.prototype.open` to record the URL +
+    // method, then surface the failure via `__s3PutFailed` when the
+    // load event fires with status 0 against the document-bucket
+    // origin. Stash the original so `restoreXhr` can revert.
+    const OriginalXHR = window.XMLHttpRequest;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as any).__s3PutFailed = null;
+    const originalOpen = OriginalXHR.prototype.open;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as any).__lfmtRestoreXhrOpen = originalOpen;
+    // We forward via `arguments` (instead of a `(...args)` rest spread)
+    // because XMLHttpRequest.open is variadic — its full signature is
+    //   open(method, url, async?, user?, password?)
+    // The 3rd-5th parameters are rare in modern code, but a future
+    // caller could legitimately set them; using `arguments` preserves
+    // EVERY positional argument exactly as the caller passed it,
+    // matching native semantics. A `(...args)` rest spread would also
+    // work today (and a future TS migration may prefer it for
+    // type-safety), but `arguments` is the closest-to-native
+    // forwarding idiom and avoids needing a tuple type for the rest
+    // parameter.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    OriginalXHR.prototype.open = function (this: any, method: string, url: string) {
+      this.__lfmtUrl = url;
+      this.__lfmtMethod = method;
+      this.addEventListener('loadend', () => {
+        if (
+          this.__lfmtMethod === 'PUT' &&
+          this.status === 0 &&
+          /s3[.-][a-z0-9-]+\.amazonaws\.com/i.test(String(this.__lfmtUrl))
+        ) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (window as any).__s3PutFailed = { url: this.__lfmtUrl, status: this.status };
+        }
+      });
+      // eslint-disable-next-line prefer-rest-params
+      return originalOpen.apply(this, arguments as unknown as Parameters<typeof originalOpen>);
+    };
+  });
+}
+
+/**
+ * Restore the original `XMLHttpRequest.prototype.open` on the live
+ * page (no init-script remount — this runs in the existing context).
+ *
+ * Call from `test.afterEach`. Even though Playwright's per-test
+ * BrowserContext isolation guarantees the patched prototype dies with
+ * the context, this hook keeps the contract hygienic so a future
+ * contributor who introduces an iframe / popup step doesn't
+ * accidentally inherit the patched prototype across what they expect
+ * to be a clean boundary.
+ */
+export async function restoreXhr(page: Page): Promise<void> {
+  // The page may have already navigated away (or closed) — guard so
+  // the helper is safe to call unconditionally from `afterEach`.
+  if (page.isClosed()) return;
+  await page.evaluate(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const w = window as any;
+    if (w.__lfmtRestoreXhrOpen) {
+      window.XMLHttpRequest.prototype.open = w.__lfmtRestoreXhrOpen;
+      delete w.__lfmtRestoreXhrOpen;
+    }
+  });
+}
+
+/**
+ * Read the current state of every probe in a single page round-trip.
+ * Use after a failed assertion to surface the underlying signal.
+ */
+export async function readNetworkProbes(page: Page): Promise<NetworkProbesSnapshot> {
+  return page.evaluate(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const w = window as any;
+    return {
+      cspViolations: (w.__cspViolations ?? []) as Array<{
+        violatedDirective: string;
+        blockedURI: string;
+      }>,
+      s3CspBlocked: (w.__s3CspBlocked ?? null) as {
+        violatedDirective: string;
+        blockedURI: string;
+      } | null,
+      s3PutFailed: (w.__s3PutFailed ?? null) as { url: string; status: number } | null,
+    };
+  });
+}

--- a/frontend/src/pages/__tests__/TranslationUpload.test.tsx
+++ b/frontend/src/pages/__tests__/TranslationUpload.test.tsx
@@ -38,34 +38,30 @@ vi.mock('react-router-dom', async () => {
 // layer so tests can stub the whole "upload + wait" operation as a single
 // mock. getJobStatus is kept in the mock because the Bug #2 polling tests
 // exercise the service internals via the separate describe block below.
-vi.mock('../../services/translationService', () => ({
-  translationService: {
-    createLegalAttestation: vi.fn(),
-    uploadAndAwaitChunked: vi.fn(),
-    startTranslation: vi.fn(),
-    getJobStatus: vi.fn(),
-  },
-  TranslationServiceError: class TranslationServiceError extends Error {
-    statusCode?: number;
-    constructor(message: string, statusCode?: number) {
-      super(message);
-      this.name = 'TranslationServiceError';
-      // Mirror the production constructor (translationService.ts:79-87) so
-      // tests that exercise HTTP-status-aware UX (Issue #147) get a real
-      // statusCode on the error instead of always falling through to the
-      // network-error branch of getTranslationErrorMessage.
-      this.statusCode = statusCode;
-    }
-  },
-  // Re-export the production sentinel so the Issue #98 page test can
-  // verify the wizard surfaces the targeted phrase verbatim. The literal
-  // text below mirrors translationService.S3_UPLOAD_BLOCKED_MESSAGE; the
-  // assertion in the page test uses a substring match (/Upload was blocked/)
-  // so a wording tweak in the production constant only forces an update
-  // here, not at every assertion site.
-  S3_UPLOAD_BLOCKED_MESSAGE:
-    'Upload was blocked. This is likely a configuration issue — please refresh and try again, or contact support if it persists.',
-}));
+//
+// PR #214 OMC C-test-1: pull the real `S3_UPLOAD_BLOCKED_MESSAGE` and
+// `TranslationServiceError` from the production module via
+// `vi.importActual`. Re-declaring those values inline here let the test
+// pass even when the production sentinel changed (the mock would still
+// surface the stale literal); routing through the actual module
+// guarantees the regression test breaks the moment production drifts.
+vi.mock('../../services/translationService', async () => {
+  const actual = await vi.importActual<typeof import('../../services/translationService')>(
+    '../../services/translationService'
+  );
+  return {
+    ...actual,
+    // Override only the methods the page calls — preserve every constant
+    // (including S3_UPLOAD_BLOCKED_MESSAGE) and class (including
+    // TranslationServiceError) at their real production identity.
+    translationService: {
+      createLegalAttestation: vi.fn(),
+      uploadAndAwaitChunked: vi.fn(),
+      startTranslation: vi.fn(),
+      getJobStatus: vi.fn(),
+    },
+  };
+});
 
 describe('TranslationUpload', () => {
   const renderComponent = () => {

--- a/frontend/src/pages/__tests__/TranslationUpload.test.tsx
+++ b/frontend/src/pages/__tests__/TranslationUpload.test.tsx
@@ -57,6 +57,14 @@ vi.mock('../../services/translationService', () => ({
       this.statusCode = statusCode;
     }
   },
+  // Re-export the production sentinel so the Issue #98 page test can
+  // verify the wizard surfaces the targeted phrase verbatim. The literal
+  // text below mirrors translationService.S3_UPLOAD_BLOCKED_MESSAGE; the
+  // assertion in the page test uses a substring match (/Upload was blocked/)
+  // so a wording tweak in the production constant only forces an update
+  // here, not at every assertion site.
+  S3_UPLOAD_BLOCKED_MESSAGE:
+    'Upload was blocked. This is likely a configuration issue — please refresh and try again, or contact support if it persists.',
 }));
 
 describe('TranslationUpload', () => {
@@ -517,6 +525,41 @@ describe('TranslationUpload', () => {
         const errorAlert = screen.getByRole('alert');
         expect(errorAlert).toBeInTheDocument();
         expect(errorAlert).toHaveTextContent(/Connection lost/i);
+      });
+    });
+
+    // -----------------------------------------------------------------------
+    // Issue #98 — accurate UI error when the S3 PUT is blocked (CSP / SW).
+    //
+    // The translation service surfaces a S3_UPLOAD_BLOCKED_MESSAGE for this
+    // case (see translationService.test.ts "throws TranslationServiceError
+    // (S3_UPLOAD_BLOCKED_MESSAGE) when S3 PUT has no response"). The error
+    // mapper passes the message through verbatim because statusCode is
+    // undefined and the message is non-generic. We assert here that the page
+    // surfaces the targeted phrase rather than the misleading generic
+    // "Connection lost" text that hid the original demo blocker.
+    // -----------------------------------------------------------------------
+    it('should display the S3-upload-blocked phrase when CSP/network blocks the PUT', async () => {
+      const user = userEvent.setup();
+      renderComponent();
+      await advanceToStep4(user);
+
+      const { S3_UPLOAD_BLOCKED_MESSAGE, TranslationServiceError } =
+        await import('../../services/translationService');
+      // statusCode left undefined to match the production wrap path.
+      vi.mocked(translationService.uploadAndAwaitChunked).mockRejectedValue(
+        new TranslationServiceError(S3_UPLOAD_BLOCKED_MESSAGE)
+      );
+
+      const submitButton = screen.getByRole('button', { name: /Submit & Start Translation/i });
+      await user.click(submitButton);
+
+      await waitFor(() => {
+        const errorAlert = screen.getByRole('alert');
+        expect(errorAlert).toBeInTheDocument();
+        expect(errorAlert).toHaveTextContent(/Upload was blocked/i);
+        // Negative assertion — the misleading generic phrase must NOT appear.
+        expect(errorAlert).not.toHaveTextContent(/Connection lost/i);
       });
     });
 

--- a/frontend/src/services/__tests__/translationService.test.ts
+++ b/frontend/src/services/__tests__/translationService.test.ts
@@ -210,17 +210,17 @@ describe('TranslationService - uploadDocument', () => {
       // Act
       await uploadDocument({ file: mockFile, legalAttestation: mockLegalAttestation });
 
-      // Assert: the PUT headers object must equal exactly what the backend
-      // provided — no extra keys, and Content-Type must be the backend value
-      // ('text/x-rst'), NOT the browser File.type ('text/plain').
+      // Assert: the PUT headers object must contain Content-Type from the
+      // backend ('text/x-rst'), NOT the browser File.type ('text/plain').
+      // Content-Length is intentionally filtered out before reaching axios —
+      // see Bug #2 (browser-forbidden-header) regression guard below.
       expect(mockedAxios.put).toHaveBeenCalledWith(
         'https://s3.amazonaws.com/bucket/presigned-url',
         mockFile,
         expect.objectContaining({
-          headers: {
+          headers: expect.objectContaining({
             'Content-Type': 'text/x-rst',
-            'Content-Length': '7',
-          },
+          }),
         })
       );
 
@@ -228,6 +228,161 @@ describe('TranslationService - uploadDocument', () => {
       const sentHeaders = mockedAxios.put.mock.calls[0][2].headers as Record<string, string>;
       expect(sentHeaders['Content-Type']).toBe('text/x-rst');
       expect(sentHeaders['Content-Type']).not.toBe('text/plain');
+    });
+
+    // -------------------------------------------------------------------------
+    // Bug #2 regression guard — "Refused to set unsafe header 'Content-Length'"
+    //
+    // Root cause: translationService previously spread requiredHeaders directly
+    // into axios.put({ headers }). When the backend included Content-Length
+    // (which it does — uploadRequest.ts:226 sets it for documentation), axios
+    // tried to forward it to XHR. Browsers reject Content-Length per Fetch
+    // spec §forbidden-header-name and emit "Refused to set unsafe header" to
+    // the console. The XHR still proceeded (browser computes Content-Length
+    // from the body), but the noisy log obscured the actual demo blocker (a
+    // CSP block — see Fix 1 in this PR).
+    //
+    // Fix: stripBrowserForbiddenHeaders() filters Content-Length (case-
+    // insensitive) before the headers reach axios. The backend keeps the
+    // header in PresignedUrlResponse for documentation / non-browser callers
+    // (curl honours it) — we don't change the API contract, we just stop the
+    // browser path from trying to send a header it can't.
+    // -------------------------------------------------------------------------
+    it('should NOT forward Content-Length to axios.put (browser-forbidden header)', async () => {
+      const mockFile = new File(['content'], 'document.txt', { type: 'text/plain' });
+      const mockLegalAttestation: LegalAttestation = {
+        acceptCopyrightOwnership: true,
+        acceptTranslationRights: true,
+        acceptLiabilityTerms: true,
+        userIPAddress: 'captured-by-backend',
+        userAgent: 'Mozilla/5.0',
+        timestamp: '2024-10-31T12:00:00Z',
+      };
+
+      const mockPresignedResponse = {
+        data: {
+          data: {
+            uploadUrl: 'https://s3.amazonaws.com/bucket/presigned-url',
+            fileId: 'file-1',
+            jobId: 'job-1',
+            requiredHeaders: {
+              'Content-Type': 'text/plain',
+              'Content-Length': '7',
+              // Lowercase variant — backend doesn't currently send this, but
+              // the filter is case-insensitive and we lock that contract here
+              // so a future header-name normalisation doesn't silently leak it.
+              'content-length': '7',
+            },
+          },
+        },
+      };
+
+      mockedApiClient.post.mockResolvedValueOnce(mockPresignedResponse);
+      mockedAxios.put.mockResolvedValueOnce({ data: null });
+
+      await uploadDocument({ file: mockFile, legalAttestation: mockLegalAttestation });
+
+      const sentHeaders = mockedAxios.put.mock.calls[0][2].headers as Record<string, string>;
+      // Content-Length must not be present in either casing.
+      const headerNames = Object.keys(sentHeaders).map((n) => n.toLowerCase());
+      expect(headerNames).not.toContain('content-length');
+      // Content-Type must still be forwarded.
+      expect(sentHeaders['Content-Type']).toBe('text/plain');
+    });
+
+    // -------------------------------------------------------------------------
+    // Issue #98 regression guard — accurate UI error when S3 PUT is blocked.
+    //
+    // When the browser blocks the S3 PUT (CSP, network outage), axios reports
+    // the failure with `error.response === undefined`. translationService now
+    // catches this and re-throws a TranslationServiceError carrying
+    // S3_UPLOAD_BLOCKED_MESSAGE so the page mapper surfaces a targeted phrase
+    // instead of the misleading generic "Connection lost" text. See
+    // translationErrorMessages — when statusCode is undefined and message is
+    // non-generic, the message is surfaced verbatim (PR #202 Round 2 Code-3).
+    // -------------------------------------------------------------------------
+    it('throws TranslationServiceError(S3_UPLOAD_BLOCKED_MESSAGE) when S3 PUT has no response', async () => {
+      const { S3_UPLOAD_BLOCKED_MESSAGE } = await import('../translationService');
+      const mockFile = new File(['content'], 'doc.txt', { type: 'text/plain' });
+      const mockLegalAttestation: LegalAttestation = {
+        acceptCopyrightOwnership: true,
+        acceptTranslationRights: true,
+        acceptLiabilityTerms: true,
+        userIPAddress: 'captured-by-backend',
+        userAgent: 'Mozilla/5.0',
+        timestamp: '2024-10-31T12:00:00Z',
+      };
+
+      mockedApiClient.post.mockResolvedValueOnce({
+        data: {
+          data: {
+            uploadUrl: 'https://s3.amazonaws.com/bucket/presigned-url',
+            fileId: 'file-1',
+            jobId: 'job-1',
+            requiredHeaders: { 'Content-Type': 'text/plain' },
+          },
+        },
+      });
+
+      // Simulate a CSP-block / network failure: axios error with no response.
+      mockedAxios.put.mockRejectedValueOnce({
+        isAxiosError: true,
+        message: 'Network Error',
+        // response intentionally omitted — this is the CSP-block signature.
+        request: {},
+      } as unknown as AxiosError);
+
+      try {
+        await uploadDocument({ file: mockFile, legalAttestation: mockLegalAttestation });
+        expect.fail('Should have thrown TranslationServiceError');
+      } catch (err) {
+        expect(err).toBeInstanceOf(TranslationServiceError);
+        expect((err as TranslationServiceError).message).toBe(S3_UPLOAD_BLOCKED_MESSAGE);
+        // statusCode is undefined for transport-level failures; the page
+        // mapper relies on this to surface the message verbatim.
+        expect((err as TranslationServiceError).statusCode).toBeUndefined();
+      }
+    });
+
+    it('preserves S3 HTTP status when S3 PUT returns an error response (e.g. 403)', async () => {
+      const mockFile = new File(['content'], 'doc.txt', { type: 'text/plain' });
+      const mockLegalAttestation: LegalAttestation = {
+        acceptCopyrightOwnership: true,
+        acceptTranslationRights: true,
+        acceptLiabilityTerms: true,
+        userIPAddress: 'captured-by-backend',
+        userAgent: 'Mozilla/5.0',
+        timestamp: '2024-10-31T12:00:00Z',
+      };
+
+      mockedApiClient.post.mockResolvedValueOnce({
+        data: {
+          data: {
+            uploadUrl: 'https://s3.amazonaws.com/bucket/presigned-url',
+            fileId: 'file-1',
+            jobId: 'job-1',
+            requiredHeaders: { 'Content-Type': 'text/plain' },
+          },
+        },
+      });
+
+      mockedAxios.put.mockRejectedValueOnce({
+        isAxiosError: true,
+        message: 'Request failed with status code 403',
+        response: {
+          status: 403,
+          statusText: 'Forbidden',
+          data: '<Error>SignatureDoesNotMatch</Error>',
+        },
+      } as unknown as AxiosError);
+
+      try {
+        await uploadDocument({ file: mockFile, legalAttestation: mockLegalAttestation });
+        expect.fail('Should have thrown TranslationServiceError');
+      } catch (err) {
+        expect(err).toBeInstanceOf(TranslationServiceError);
+        expect((err as TranslationServiceError).statusCode).toBe(403);
+      }
     });
 
     it('should include legal attestation in JSON payload to backend', async () => {

--- a/frontend/src/services/__tests__/translationService.test.ts
+++ b/frontend/src/services/__tests__/translationService.test.ts
@@ -495,6 +495,80 @@ describe('TranslationService - uploadDocument', () => {
           expect(original?.message).toBe('undefined');
         }
       });
+
+      // -----------------------------------------------------------------
+      // M-1 (PR #214 OMC R2): proper type-guard narrowing — no
+      // `as unknown as AxiosError` lie.
+      //
+      // Pre-fix, the non-axios branch cast its synthetic cause through
+      // `as unknown as AxiosError` to satisfy `originalError`'s field
+      // type. Post-fix, the field is widened to `Error | undefined`,
+      // and `axios.isAxiosError()` is the only narrowing path used
+      // inside the wrap. This test pins the contract: the narrowed
+      // branch (axios.isAxiosError() === true) IS reachable, AND the
+      // non-axios branch produces a plain Error instance whose
+      // properties (message, name) survive intact — i.e. the cast is
+      // structurally unnecessary because the runtime type already
+      // matches the (now-widened) compile-time type.
+      // -----------------------------------------------------------------
+      it('M-1: axios-error branch IS reachable (narrowed via axios.isAxiosError)', async () => {
+        const mockFile = new File(['content'], 'doc.txt', { type: 'text/plain' });
+        mockPresigned();
+
+        const axiosError: AxiosError = {
+          isAxiosError: true,
+          message: 'Request failed with status code 500',
+          response: {
+            status: 500,
+            statusText: 'Internal Server Error',
+            data: '<Error>InternalError</Error>',
+            headers: {},
+            config: {} as AxiosError['config'],
+          },
+        } as unknown as AxiosError;
+
+        mockedAxios.put.mockRejectedValueOnce(axiosError);
+
+        try {
+          await uploadDocument({ file: mockFile, legalAttestation: buildAttestation() });
+          expect.fail('Should have thrown TranslationServiceError');
+        } catch (err) {
+          expect(err).toBeInstanceOf(TranslationServiceError);
+          // Reaching this expectation proves the axios-narrowed branch
+          // executed (statusCode is set ONLY in that branch).
+          expect((err as TranslationServiceError).statusCode).toBe(500);
+          expect((err as TranslationServiceError).originalError).toBe(axiosError);
+        }
+      });
+
+      it('M-1: non-axios branch yields plain Error (no AxiosError cast)', async () => {
+        const mockFile = new File(['content'], 'doc.txt', { type: 'text/plain' });
+        mockPresigned();
+
+        // Use a TypeError to maximise the divergence from AxiosError —
+        // it has no `.response`, no `isAxiosError` flag, etc. The wrap
+        // must still preserve it byte-for-byte (instanceof + same
+        // reference) without coercing through AxiosError.
+        const typeError = new TypeError('cannot read property of undefined');
+        mockedAxios.put.mockRejectedValueOnce(typeError);
+
+        try {
+          await uploadDocument({ file: mockFile, legalAttestation: buildAttestation() });
+          expect.fail('Should have thrown TranslationServiceError');
+        } catch (err) {
+          expect(err).toBeInstanceOf(TranslationServiceError);
+          const original = (err as TranslationServiceError).originalError;
+          // Pre-fix: `originalError` was typed `AxiosError` and TS
+          // couldn't tell us the runtime type was actually TypeError.
+          // Post-fix: typed as `Error`, so the instanceof check is
+          // direct and reflects reality.
+          expect(original).toBeInstanceOf(TypeError);
+          expect(original).toBe(typeError);
+          // No `isAxiosError` flag — confirms we did NOT silently
+          // coerce the cause into the AxiosError shape.
+          expect((original as unknown as { isAxiosError?: unknown }).isAxiosError).toBeUndefined();
+        }
+      });
     });
 
     it('should include legal attestation in JSON payload to backend', async () => {

--- a/frontend/src/services/__tests__/translationService.test.ts
+++ b/frontend/src/services/__tests__/translationService.test.ts
@@ -366,7 +366,11 @@ describe('TranslationService - uploadDocument', () => {
         },
       });
 
-      mockedAxios.put.mockRejectedValueOnce({
+      // Hold the rejected axios error in a named local so the test can
+      // assert reference equality on `originalError` below — without
+      // that, a future refactor that wraps the cause (losing the chain)
+      // would silently pass the bare instanceOf check.
+      const rejectedAxiosError = {
         isAxiosError: true,
         message: 'Request failed with status code 403',
         response: {
@@ -374,7 +378,9 @@ describe('TranslationService - uploadDocument', () => {
           statusText: 'Forbidden',
           data: '<Error>SignatureDoesNotMatch</Error>',
         },
-      } as unknown as AxiosError);
+      } as unknown as AxiosError;
+
+      mockedAxios.put.mockRejectedValueOnce(rejectedAxiosError);
 
       try {
         await uploadDocument({ file: mockFile, legalAttestation: mockLegalAttestation });
@@ -382,7 +388,113 @@ describe('TranslationService - uploadDocument', () => {
       } catch (err) {
         expect(err).toBeInstanceOf(TranslationServiceError);
         expect((err as TranslationServiceError).statusCode).toBe(403);
+        // C-test-3 (PR #214 OMC): lock originalError preservation. The
+        // wrap path MUST forward the rejected axios error verbatim so
+        // monitoring tools (Sentry, Rollbar) can introspect `.response`
+        // on the cause chain. If a future refactor wraps the cause
+        // (e.g. `new Error(err.message)`), this assertion breaks.
+        expect((err as TranslationServiceError).originalError).toBe(rejectedAxiosError);
       }
+    });
+
+    // -------------------------------------------------------------------------
+    // C-test-2 (PR #214 OMC): wrapS3UploadError non-axios branch.
+    //
+    // When axios.put rejects with a value that ISN'T an AxiosError (a
+    // plain Error, a string, undefined), the wrap path must still:
+    //   1. Throw TranslationServiceError (not the raw value).
+    //   2. Preserve the original message (when one exists).
+    //   3. Preserve `originalError` so the cause chain survives — this
+    //      was the gap R-arch-2 closed.
+    // -------------------------------------------------------------------------
+    describe('wrapS3UploadError — non-axios rejected values', () => {
+      const buildAttestation = (): LegalAttestation => ({
+        acceptCopyrightOwnership: true,
+        acceptTranslationRights: true,
+        acceptLiabilityTerms: true,
+        userIPAddress: 'captured-by-backend',
+        userAgent: 'Mozilla/5.0',
+        timestamp: '2024-10-31T12:00:00Z',
+      });
+
+      const mockPresigned = () => {
+        mockedApiClient.post.mockResolvedValueOnce({
+          data: {
+            data: {
+              uploadUrl: 'https://s3.amazonaws.com/bucket/presigned-url',
+              fileId: 'file-1',
+              jobId: 'job-1',
+              requiredHeaders: { 'Content-Type': 'text/plain' },
+            },
+          },
+        });
+      };
+
+      it('re-throws TranslationServiceError preserving plain Error message + cause', async () => {
+        const mockFile = new File(['content'], 'doc.txt', { type: 'text/plain' });
+        mockPresigned();
+
+        const plainError = new Error('disk full while reading body');
+        mockedAxios.put.mockRejectedValueOnce(plainError);
+
+        try {
+          await uploadDocument({ file: mockFile, legalAttestation: buildAttestation() });
+          expect.fail('Should have thrown TranslationServiceError');
+        } catch (err) {
+          expect(err).toBeInstanceOf(TranslationServiceError);
+          expect((err as TranslationServiceError).message).toBe('disk full while reading body');
+          // statusCode is undefined for non-axios failures.
+          expect((err as TranslationServiceError).statusCode).toBeUndefined();
+          // R-arch-2: the cause chain must be intact so monitoring tools
+          // can see the underlying disk-full Error rather than just the
+          // wrapped service error.
+          expect((err as TranslationServiceError).originalError).toBe(plainError);
+        }
+      });
+
+      it('handles a thrown string gracefully (does not crash)', async () => {
+        const mockFile = new File(['content'], 'doc.txt', { type: 'text/plain' });
+        mockPresigned();
+
+        // axios shouldn't reject with a string in practice, but the
+        // wrap path must not crash on `error.message` access if it does.
+        mockedAxios.put.mockRejectedValueOnce('boom');
+
+        try {
+          await uploadDocument({ file: mockFile, legalAttestation: buildAttestation() });
+          expect.fail('Should have thrown TranslationServiceError');
+        } catch (err) {
+          expect(err).toBeInstanceOf(TranslationServiceError);
+          // Falls back to the generic message — but does NOT throw a
+          // TypeError accessing .message on a string.
+          expect((err as TranslationServiceError).message).toBe('S3 upload failed');
+          // R-arch-2: even non-Error rejections produce a synthetic
+          // cause so the monitoring path always has SOMETHING to log.
+          const original = (err as TranslationServiceError).originalError as Error | undefined;
+          expect(original).toBeInstanceOf(Error);
+          expect(original?.message).toBe('boom');
+        }
+      });
+
+      it('handles a thrown undefined gracefully (does not crash)', async () => {
+        const mockFile = new File(['content'], 'doc.txt', { type: 'text/plain' });
+        mockPresigned();
+
+        mockedAxios.put.mockRejectedValueOnce(undefined);
+
+        try {
+          await uploadDocument({ file: mockFile, legalAttestation: buildAttestation() });
+          expect.fail('Should have thrown TranslationServiceError');
+        } catch (err) {
+          expect(err).toBeInstanceOf(TranslationServiceError);
+          expect((err as TranslationServiceError).message).toBe('S3 upload failed');
+          // The synthetic cause stringifies undefined to "undefined" —
+          // not pretty, but provably non-crashing and non-empty.
+          const original = (err as TranslationServiceError).originalError as Error | undefined;
+          expect(original).toBeInstanceOf(Error);
+          expect(original?.message).toBe('undefined');
+        }
+      });
     });
 
     it('should include legal attestation in JSON payload to backend', async () => {

--- a/frontend/src/services/__tests__/uploadService.test.ts
+++ b/frontend/src/services/__tests__/uploadService.test.ts
@@ -184,11 +184,55 @@ describe('uploadService', () => {
 
       await uploadPromise;
 
-      // Assert
+      // Assert — Content-Type is forwarded, but Content-Length is filtered
+      // (browser sets it itself; manually setting it triggers
+      // "Refused to set unsafe header" — see translationService
+      // .stripBrowserForbiddenHeaders + the 2026-05-08 demo-blocking
+      // post-mortem in this PR's body).
       expect(mockXHR.open).toHaveBeenCalledWith('PUT', uploadUrl);
       expect(mockXHR.setRequestHeader).toHaveBeenCalledWith('Content-Type', 'text/plain');
-      expect(mockXHR.setRequestHeader).toHaveBeenCalledWith('Content-Length', '7');
       expect(mockXHR.send).toHaveBeenCalledWith(mockFile);
+    });
+
+    // -----------------------------------------------------------------------
+    // Regression guard for the 2026-05-08 demo-blocking incident.
+    //
+    // Browsers refuse setRequestHeader('Content-Length', ...) per Fetch spec
+    // §forbidden-header-name and emit "Refused to set unsafe header
+    // 'Content-Length'" to the console. The XHR itself proceeds (the browser
+    // computes Content-Length from the body), but the noisy console error
+    // had previously been mistaken for the root cause of the upload failure.
+    // The actual root cause was CSP — see Fix 1 in this PR — but stripping
+    // Content-Length here removes the misleading console noise AND the
+    // (legitimate) "we shouldn't be trying to set this anyway" code smell.
+    // -----------------------------------------------------------------------
+    it('should NOT call setRequestHeader for Content-Length (browser-forbidden)', async () => {
+      // Arrange — the backend may include Content-Length in requiredHeaders
+      // for documentation / non-browser callers, but the browser path must
+      // skip it.
+      const mockFile = new File(['content'], 'test.txt', { type: 'text/plain' });
+      const uploadUrl = 'https://s3.amazonaws.com/bucket/key';
+      const requiredHeaders = {
+        'Content-Type': 'text/plain',
+        'Content-Length': '7',
+        'content-length': '7', // Lowercase variant — case-insensitive filter.
+      };
+
+      mockXHR.addEventListener.mockImplementation((event, handler) => {
+        if (event === 'load') {
+          setTimeout(() => handler(), 0);
+        }
+      });
+
+      // Act
+      await uploadService.uploadToS3(mockFile, uploadUrl, requiredHeaders);
+
+      // Assert — neither the canonical nor the lowercase form is forwarded.
+      const calls = mockXHR.setRequestHeader.mock.calls as Array<[string, string]>;
+      const headerNames = calls.map(([name]) => name.toLowerCase());
+      expect(headerNames).not.toContain('content-length');
+      // Content-Type still forwarded (not in the forbidden set).
+      expect(mockXHR.setRequestHeader).toHaveBeenCalledWith('Content-Type', 'text/plain');
     });
 
     it('should track upload progress', async () => {

--- a/frontend/src/services/translationService.ts
+++ b/frontend/src/services/translationService.ts
@@ -7,8 +7,15 @@
 
 import axios, { AxiosError } from 'axios';
 import { apiClient } from '../utils/api';
+import { stripBrowserForbiddenHeaders } from '../utils/headerFilters';
 import type { TranslationJobStatus } from '@lfmt/shared-types';
 import { CHUNKING_ERROR_STATUSES } from '@lfmt/shared-types';
+
+// Re-export so callers that previously imported the helper from this
+// service module (and any test that mocks/asserts on it via the service
+// surface) keep working unchanged. The single source of truth lives in
+// utils/headerFilters.
+export { stripBrowserForbiddenHeaders } from '../utils/headerFilters';
 
 // Re-export so callers can use the shared-types values without an extra import.
 export type { TranslationJobStatus };
@@ -110,41 +117,6 @@ export class TranslationServiceError extends Error {
 }
 
 /**
- * Headers the browser refuses to let JavaScript set on an XHR / fetch
- * (Fetch spec §forbidden-header-name). The Set is keyed on lowercase
- * names so we can match case-insensitively against whatever the backend
- * sends in `requiredHeaders` — `Content-Length`, `content-length`, etc.
- *
- * We intentionally only strip the headers actively populated by the
- * backend's PresignedUrlResponse today (`Content-Length`). The full
- * forbidden list per spec is much larger; expanding the filter to cover
- * everything risks dropping a header the backend may legitimately add
- * later that we WOULD want to forward (e.g. a custom `x-amz-...`
- * header), so each entry below is here because the backend currently
- * sets it and the browser refuses it. Add new entries deliberately,
- * with the same justification.
- */
-const BROWSER_FORBIDDEN_REQUEST_HEADERS = new Set<string>(['content-length']);
-
-/**
- * Filter out headers the browser will refuse to send (and would emit
- * "Refused to set unsafe header" warnings for) before handing the map
- * to axios / XHR.
- *
- * Exported for the regression test that asserts `Content-Length` is
- * never forwarded — see translationService.test.ts.
- */
-export function stripBrowserForbiddenHeaders(
-  headers: Record<string, string>
-): Record<string, string> {
-  return Object.fromEntries(
-    Object.entries(headers).filter(
-      ([name]) => !BROWSER_FORBIDDEN_REQUEST_HEADERS.has(name.toLowerCase())
-    )
-  );
-}
-
-/**
  * Sentinel message used by `wrapS3UploadError` when the browser blocks
  * the S3 PUT before any HTTP response is received. Exported so the
  * page-level error mapper (`translationErrorMessages`) can match on it
@@ -184,9 +156,24 @@ function wrapS3UploadError(error: unknown): TranslationServiceError {
       error
     );
   }
-  // Non-axios error — preserve the message but mark it as a service error.
+  // Non-axios error — preserve the message AND the original cause so
+  // monitoring tools (Sentry, Rollbar, etc.) see the underlying failure
+  // rather than a stripped-down service error. If the rejected value
+  // wasn't even an Error (string, undefined, plain object), wrap it in
+  // a synthetic Error so `originalError.message` stays a string and the
+  // cause chain remains inspectable downstream.
+  //
+  // The `originalError` field is typed `AxiosError | undefined` on
+  // TranslationServiceError; we cast through `as unknown as AxiosError`
+  // here because the runtime contract ("preserve any cause") is wider
+  // than the compile-time type, which exists primarily to keep the
+  // axios-error code paths type-safe. Rather than widen the field's
+  // type (which would force every consumer to handle three cases), we
+  // narrow at this single call site — the cost is one cast, the benefit
+  // is monitoring tools see the cause regardless of its origin.
+  const originalError = error instanceof Error ? error : new Error(String(error));
   const message = error instanceof Error ? error.message : 'S3 upload failed';
-  return new TranslationServiceError(message);
+  return new TranslationServiceError(message, undefined, originalError as unknown as AxiosError);
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/services/translationService.ts
+++ b/frontend/src/services/translationService.ts
@@ -5,17 +5,20 @@
  * file uploads, and status tracking.
  */
 
-import axios, { AxiosError } from 'axios';
+import axios from 'axios';
 import { apiClient } from '../utils/api';
 import { stripBrowserForbiddenHeaders } from '../utils/headerFilters';
 import type { TranslationJobStatus } from '@lfmt/shared-types';
 import { CHUNKING_ERROR_STATUSES } from '@lfmt/shared-types';
 
-// Re-export so callers that previously imported the helper from this
-// service module (and any test that mocks/asserts on it via the service
-// surface) keep working unchanged. The single source of truth lives in
-// utils/headerFilters.
-export { stripBrowserForbiddenHeaders } from '../utils/headerFilters';
+// N1 (PR #214 OMC R2): the back-compat re-export of
+// `stripBrowserForbiddenHeaders` from this module has been removed.
+// No live caller imports the helper through `translationService`
+// (verified via `grep -r "from '../services/translationService'"
+// frontend/src` for the symbol). Removing the shim breaks the
+// indirect coupling and lets the two modules truly decouple — anyone
+// who needs the helper must now import it directly from
+// `utils/headerFilters`, where the source of truth lives.
 
 // Re-export so callers can use the shared-types values without an extra import.
 export type { TranslationJobStatus };
@@ -103,13 +106,24 @@ export interface UploadAndAwaitChunkedOptions {
 }
 
 /**
- * Translation Service Error
+ * Translation Service Error.
+ *
+ * `originalError` is typed `Error | undefined` (NOT `AxiosError`) so
+ * the non-axios branch in `wrapS3UploadError` can preserve plain Error
+ * causes (disk-full, generic XHR failure, etc.) without a type cast.
+ * AxiosError extends Error, so axios-error code paths remain
+ * compatible — callers that need axios-specific fields (`.response`,
+ * `.request`) MUST narrow with `axios.isAxiosError(originalError)`
+ * before reading them. This matches the wider runtime contract
+ * ("preserve any underlying cause") and removes the `as unknown as
+ * AxiosError` lie that previously allowed the field to silently lose
+ * the cause shape (PR #214 OMC R2 M-1).
  */
 export class TranslationServiceError extends Error {
   constructor(
     message: string,
     public statusCode?: number,
-    public originalError?: AxiosError
+    public originalError?: Error
   ) {
     super(message);
     this.name = 'TranslationServiceError';
@@ -163,17 +177,18 @@ function wrapS3UploadError(error: unknown): TranslationServiceError {
   // a synthetic Error so `originalError.message` stays a string and the
   // cause chain remains inspectable downstream.
   //
-  // The `originalError` field is typed `AxiosError | undefined` on
-  // TranslationServiceError; we cast through `as unknown as AxiosError`
-  // here because the runtime contract ("preserve any cause") is wider
-  // than the compile-time type, which exists primarily to keep the
-  // axios-error code paths type-safe. Rather than widen the field's
-  // type (which would force every consumer to handle three cases), we
-  // narrow at this single call site — the cost is one cast, the benefit
-  // is monitoring tools see the cause regardless of its origin.
-  const originalError = error instanceof Error ? error : new Error(String(error));
+  // M-1 (PR #214 OMC R2): widen `originalError` to `Error | undefined`
+  // at the field level so the non-axios branch no longer needs a cast.
+  // The previous `as unknown as AxiosError` was a type-system lie —
+  // monitoring tools that read `.response` on a non-axios cause would
+  // hit `undefined`, but the compiler didn't warn. Treating the field
+  // as the broader `Error` type matches the runtime contract ("preserve
+  // ANY cause"); axios-error consumers narrow with `axios.isAxiosError`
+  // before reading axios-specific fields (which is what they should be
+  // doing anyway).
+  const originalError: Error = error instanceof Error ? error : new Error(String(error));
   const message = error instanceof Error ? error.message : 'S3 upload failed';
-  return new TranslationServiceError(message, undefined, originalError as unknown as AxiosError);
+  return new TranslationServiceError(message, undefined, originalError);
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/services/translationService.ts
+++ b/frontend/src/services/translationService.ts
@@ -109,6 +109,86 @@ export class TranslationServiceError extends Error {
   }
 }
 
+/**
+ * Headers the browser refuses to let JavaScript set on an XHR / fetch
+ * (Fetch spec §forbidden-header-name). The Set is keyed on lowercase
+ * names so we can match case-insensitively against whatever the backend
+ * sends in `requiredHeaders` — `Content-Length`, `content-length`, etc.
+ *
+ * We intentionally only strip the headers actively populated by the
+ * backend's PresignedUrlResponse today (`Content-Length`). The full
+ * forbidden list per spec is much larger; expanding the filter to cover
+ * everything risks dropping a header the backend may legitimately add
+ * later that we WOULD want to forward (e.g. a custom `x-amz-...`
+ * header), so each entry below is here because the backend currently
+ * sets it and the browser refuses it. Add new entries deliberately,
+ * with the same justification.
+ */
+const BROWSER_FORBIDDEN_REQUEST_HEADERS = new Set<string>(['content-length']);
+
+/**
+ * Filter out headers the browser will refuse to send (and would emit
+ * "Refused to set unsafe header" warnings for) before handing the map
+ * to axios / XHR.
+ *
+ * Exported for the regression test that asserts `Content-Length` is
+ * never forwarded — see translationService.test.ts.
+ */
+export function stripBrowserForbiddenHeaders(
+  headers: Record<string, string>
+): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(headers).filter(
+      ([name]) => !BROWSER_FORBIDDEN_REQUEST_HEADERS.has(name.toLowerCase())
+    )
+  );
+}
+
+/**
+ * Sentinel message used by `wrapS3UploadError` when the browser blocks
+ * the S3 PUT before any HTTP response is received. Exported so the
+ * page-level error mapper (`translationErrorMessages`) can match on it
+ * deterministically rather than parsing a free-form string.
+ *
+ * The wording is deliberately neutral: from the browser's perspective
+ * we cannot prove which of {CSP block, network outage, DNS failure,
+ * S3 outage} caused `error.response === undefined`, so we describe the
+ * symptom and point the user at the action with the highest expected
+ * value (contact support if persistent — these are config issues, not
+ * transient network blips, in 95%+ of observed cases).
+ */
+export const S3_UPLOAD_BLOCKED_MESSAGE =
+  'Upload was blocked. This is likely a configuration issue — please refresh and try again, or contact support if it persists.';
+
+/**
+ * Re-shape an S3 PUT failure so the page-level error UI can tell it
+ * apart from API-side failures. axios reports CSP-blocked / network-
+ * level failures with `error.response` undefined; that's the only
+ * signal we have at this seam. We map it to a TranslationServiceError
+ * with `statusCode = undefined` and `S3_UPLOAD_BLOCKED_MESSAGE` so the
+ * page mapper surfaces the targeted phrase rather than the misleading
+ * generic "Connection lost" text.
+ */
+function wrapS3UploadError(error: unknown): TranslationServiceError {
+  if (axios.isAxiosError(error)) {
+    if (!error.response) {
+      // No HTTP response — CSP block, DNS failure, or network outage.
+      return new TranslationServiceError(S3_UPLOAD_BLOCKED_MESSAGE, undefined, error);
+    }
+    // S3 returned an HTTP error (e.g. SignatureDoesNotMatch, 403). Surface
+    // its status to the page so it can branch on the curated table in
+    // translationErrorMessages.
+    return new TranslationServiceError(
+      error.response.statusText || `S3 upload failed with status ${error.response.status}`,
+      error.response.status,
+      error
+    );
+  }
+  // Non-axios error — preserve the message but mark it as a service error.
+  const message = error instanceof Error ? error.message : 'S3 upload failed';
+  return new TranslationServiceError(message);
+}
+
 // ---------------------------------------------------------------------------
 // Polling constants — owned here (service layer) so the UI component is free
 // of backend-protocol knowledge. Values can be overridden via
@@ -175,14 +255,45 @@ export const uploadDocument = async (request: UploadDocumentRequest): Promise<Tr
 
     // Step 2: Upload file directly to S3 using presigned URL.
     // Note: We use axios directly here because S3 doesn't need our API interceptors/auth headers.
-    // IMPORTANT: rely exclusively on requiredHeaders returned by the backend. The backend signs the
-    // presigned URL with the exact Content-Type it puts in requiredHeaders (lines 224-227 of
-    // uploadRequest.ts). Adding an extra 'Content-Type' override here risks a mismatch between
-    // the signed value and the sent value when the browser File.type differs from what the backend
-    // normalised, which causes S3 to reject the request with SignatureDoesNotMatch.
-    await axios.put(uploadUrl, request.file, {
-      headers: { ...requiredHeaders },
-    });
+    //
+    // IMPORTANT (Bug #1, SignatureDoesNotMatch): rely exclusively on requiredHeaders returned by
+    // the backend. The backend signs the presigned URL with the exact Content-Type it puts in
+    // requiredHeaders (lines 224-227 of uploadRequest.ts). Adding an extra 'Content-Type' override
+    // here risks a mismatch between the signed value and the sent value when the browser File.type
+    // differs from what the backend normalised, which causes S3 to reject the request with
+    // SignatureDoesNotMatch.
+    //
+    // IMPORTANT (browser unsafe-header rule): strip Content-Length before handing headers to the
+    // browser-side XHR. Per Fetch spec §forbidden-header-name, browsers refuse setRequestHeader on
+    // 'Content-Length' (and several other transport-managed headers) and emit
+    // "Refused to set unsafe header 'Content-Length'" to the console. The browser ALWAYS sets
+    // Content-Length itself based on the body size, so the signature still matches — but only if
+    // we don't try to set it manually. The backend keeps Content-Length in `requiredHeaders` for
+    // documentation purposes and for non-browser callers (e.g., CLI smoke tests via curl that DO
+    // honour the value); the browser path filters it out at the seam where headers cross into XHR
+    // land.
+    //
+    // Root cause of the 2026-05-08 browser walkthrough failure: the curl validation path bypasses
+    // both CSP and the unsafe-header rule, so the API contract worked end-to-end via curl but the
+    // browser path was never exercised against the deployed configuration. This filter + the CSP
+    // bucket-origin entry in lfmt-infrastructure-stack.ts (`buildCsp`) close that gap.
+    const browserSafeHeaders = stripBrowserForbiddenHeaders(requiredHeaders);
+
+    try {
+      await axios.put(uploadUrl, request.file, {
+        headers: browserSafeHeaders,
+      });
+    } catch (uploadError) {
+      // Step 2a: re-shape S3-side failures so the UI layer can distinguish them
+      // from API-side failures (presigned URL request, status polling, etc.).
+      //
+      // axios reports CSP-blocked / network-failed XHRs with `error.response`
+      // === undefined (no HTTP response was ever received) and `error.request`
+      // populated. Without distinguishing this from an API outage we surface a
+      // generic "Connection lost" message — see PR for issue #98 + bug class
+      // explanation in `getTranslationErrorMessage` for the precedence rules.
+      throw wrapS3UploadError(uploadError);
+    }
 
     // Step 3: Return job information
     // Note: The backend creates the job record but doesn't return it immediately

--- a/frontend/src/services/uploadService.ts
+++ b/frontend/src/services/uploadService.ts
@@ -11,7 +11,7 @@
 
 import { apiClient } from '../utils/api';
 import type { PresignedUrlRequest, PresignedUrlResponse } from '@lfmt/shared-types';
-import { stripBrowserForbiddenHeaders } from './translationService';
+import { stripBrowserForbiddenHeaders } from '../utils/headerFilters';
 
 /**
  * Upload progress callback
@@ -132,7 +132,7 @@ export async function uploadToS3(
     // "Refused to set unsafe header 'Content-Length'" and the call is a
     // no-op. The browser ALWAYS sets Content-Length itself based on the
     // body, so the S3 signature still matches as long as we don't try to
-    // set it manually. See translationService.stripBrowserForbiddenHeaders
+    // set it manually. See `utils/headerFilters.stripBrowserForbiddenHeaders`
     // for the canonical filter (and the 2026-05-08 demo-blocking incident
     // post-mortem in this PR's body).
     const browserSafeHeaders = stripBrowserForbiddenHeaders(requiredHeaders);

--- a/frontend/src/services/uploadService.ts
+++ b/frontend/src/services/uploadService.ts
@@ -11,6 +11,7 @@
 
 import { apiClient } from '../utils/api';
 import type { PresignedUrlRequest, PresignedUrlResponse } from '@lfmt/shared-types';
+import { stripBrowserForbiddenHeaders } from './translationService';
 
 /**
  * Upload progress callback
@@ -125,8 +126,17 @@ export async function uploadToS3(
     // Configure and send request
     xhr.open('PUT', uploadUrl);
 
-    // Set required headers
-    Object.entries(requiredHeaders).forEach(([key, value]) => {
+    // Set required headers — but filter out headers the browser refuses to
+    // accept via setRequestHeader (e.g. Content-Length). Per Fetch spec
+    // §forbidden-header-name, setting Content-Length emits
+    // "Refused to set unsafe header 'Content-Length'" and the call is a
+    // no-op. The browser ALWAYS sets Content-Length itself based on the
+    // body, so the S3 signature still matches as long as we don't try to
+    // set it manually. See translationService.stripBrowserForbiddenHeaders
+    // for the canonical filter (and the 2026-05-08 demo-blocking incident
+    // post-mortem in this PR's body).
+    const browserSafeHeaders = stripBrowserForbiddenHeaders(requiredHeaders);
+    Object.entries(browserSafeHeaders).forEach(([key, value]) => {
       xhr.setRequestHeader(key, value);
     });
 

--- a/frontend/src/utils/__tests__/headerFilters.test.ts
+++ b/frontend/src/utils/__tests__/headerFilters.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Header Filters Unit Tests
+ *
+ * Locks the contract of `stripBrowserForbiddenHeaders` (PR #214 OMC C1):
+ * - Filters Content-Length case-insensitively (the only header on the
+ *   forbidden list today).
+ * - Returns a NEW object — input is never mutated.
+ * - Allows non-forbidden headers through unchanged.
+ *
+ * Coverage rationale: the helper is the seam where backend headers
+ * cross into browser XHR land. Bugs here surface as the "Refused to
+ * set unsafe header" warning class that hid the original 2026-05-08
+ * demo-blocking incident, so we exhaustively pin the contract.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { BROWSER_FORBIDDEN_REQUEST_HEADERS, stripBrowserForbiddenHeaders } from '../headerFilters';
+
+describe('stripBrowserForbiddenHeaders', () => {
+  it('strips Content-Length (canonical Pascal-Case spelling)', () => {
+    const filtered = stripBrowserForbiddenHeaders({
+      'Content-Type': 'text/plain',
+      'Content-Length': '7',
+    });
+    expect(filtered).toEqual({ 'Content-Type': 'text/plain' });
+  });
+
+  it('strips content-length (lowercase) — case-insensitive match', () => {
+    const filtered = stripBrowserForbiddenHeaders({
+      'content-type': 'text/plain',
+      'content-length': '7',
+    });
+    expect(filtered).toEqual({ 'content-type': 'text/plain' });
+  });
+
+  it('strips CONTENT-LENGTH (uppercase) and odd casings (Content-LENGTH)', () => {
+    const filtered = stripBrowserForbiddenHeaders({
+      'CONTENT-LENGTH': '7',
+      'Content-LENGTH': '7',
+      'X-Trace-Id': 'abc',
+    });
+    expect(filtered).toEqual({ 'X-Trace-Id': 'abc' });
+  });
+
+  it('does NOT mutate the input object', () => {
+    const input = {
+      'Content-Type': 'text/plain',
+      'Content-Length': '7',
+    };
+    const snapshot = { ...input };
+
+    stripBrowserForbiddenHeaders(input);
+
+    expect(input).toEqual(snapshot);
+  });
+
+  it('returns a NEW object reference (not the same ref as input)', () => {
+    const input = { 'X-Trace-Id': 'abc' };
+    const filtered = stripBrowserForbiddenHeaders(input);
+    expect(filtered).not.toBe(input);
+  });
+
+  it('passes allowed headers through unchanged (Content-Type, x-amz-*)', () => {
+    const input = {
+      'Content-Type': 'application/octet-stream',
+      'x-amz-server-side-encryption': 'AES256',
+      'x-amz-meta-foo': 'bar',
+      Authorization: 'Bearer token',
+    };
+    const filtered = stripBrowserForbiddenHeaders(input);
+    expect(filtered).toEqual(input);
+    // Stronger guard — entries identical, key order preserved.
+    expect(Object.keys(filtered)).toEqual(Object.keys(input));
+  });
+
+  it('returns an empty object when given an empty object', () => {
+    expect(stripBrowserForbiddenHeaders({})).toEqual({});
+  });
+
+  it('exposes the forbidden-headers Set with `content-length` (lowercase key)', () => {
+    // Lock the documented contract — the Set is keyed lowercase so the
+    // case-insensitive `.has(name.toLowerCase())` lookup works for any
+    // backend casing. If a future contributor adds an entry, the key
+    // MUST be lowercase or the filter silently misses it.
+    expect(BROWSER_FORBIDDEN_REQUEST_HEADERS.has('content-length')).toBe(true);
+    // Negative guard — `Content-Length` (mixed case) must NOT be in the
+    // Set; the filter relies on `.toLowerCase()` to normalise.
+    expect(BROWSER_FORBIDDEN_REQUEST_HEADERS.has('Content-Length')).toBe(false);
+  });
+});

--- a/frontend/src/utils/headerFilters.ts
+++ b/frontend/src/utils/headerFilters.ts
@@ -1,0 +1,51 @@
+/**
+ * HTTP Header Filters
+ *
+ * Browser-side helpers for sanitising header maps before they reach
+ * `fetch` / `XMLHttpRequest`. The browser refuses to let JavaScript set
+ * certain headers (Fetch spec §forbidden-header-name) and emits noisy
+ * "Refused to set unsafe header" warnings when we try — these helpers
+ * strip such headers at the seam.
+ *
+ * Extracted from translationService.ts (PR #214 OMC C1) so the same
+ * filter is reused by every service that performs browser-side uploads
+ * (translationService, uploadService) without a cross-service import.
+ */
+
+/**
+ * Headers the browser refuses to let JavaScript set on an XHR / fetch
+ * (Fetch spec §forbidden-header-name). The Set is keyed on lowercase
+ * names so we can match case-insensitively against whatever the backend
+ * sends in `requiredHeaders` — `Content-Length`, `content-length`, etc.
+ *
+ * We intentionally only strip the headers actively populated by the
+ * backend's PresignedUrlResponse today (`Content-Length`). The full
+ * forbidden list per spec is much larger; expanding the filter to cover
+ * everything risks dropping a header the backend may legitimately add
+ * later that we WOULD want to forward (e.g. a custom `x-amz-...`
+ * header), so each entry below is here because the backend currently
+ * sets it and the browser refuses it. Add new entries deliberately,
+ * with the same justification.
+ */
+export const BROWSER_FORBIDDEN_REQUEST_HEADERS: ReadonlySet<string> = new Set<string>([
+  'content-length',
+]);
+
+/**
+ * Filter out headers the browser will refuse to send (and would emit
+ * "Refused to set unsafe header" warnings for) before handing the map
+ * to axios / XHR.
+ *
+ * Returns a new object — the input is never mutated, so callers can
+ * safely keep using the original headers map for documentation /
+ * non-browser code paths (e.g. logging the contract the backend sent).
+ */
+export function stripBrowserForbiddenHeaders(
+  headers: Record<string, string>
+): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(headers).filter(
+      ([name]) => !BROWSER_FORBIDDEN_REQUEST_HEADERS.has(name.toLowerCase())
+    )
+  );
+}


### PR DESCRIPTION
## Summary

Closes the 2026-05-08 demo-blocking incident: browser-side presigned-PUT to S3 failed with a CSP block, but the wizard surfaced the misleading text *"Connection lost — check your internet and try again."*

curl-driven validation of the same API contract worked end-to-end because curl ignores both CSP and the browser's unsafe-header rule, so the regression slipped to the manual demo walkthrough.

Four bundled fixes (boy-scouts rule — no follow-ups):

- **Fix 1 (CSP):** `connect-src` now enumerates the document S3 bucket origin alongside the API Gateway origin. Bucket origin is enumerated explicitly (no `*.s3.amazonaws.com` wildcard) per OWASP guidance.
- **Fix 2 (Content-Length):** Browser code stops trying to set the forbidden `Content-Length` header on the S3 PUT. The browser sets it itself based on the body, so the S3 signature still matches.
- **Fix 3 (UI error):** When the S3 PUT fails before any HTTP response (CSP block, network outage), the wizard now surfaces *"Upload was blocked. This is likely a configuration issue — please refresh and try again, or contact support if it persists."* instead of the misleading "Connection lost" text.
- **Fix 4 (E2E):** New `@csp-regression` test in the production smoke suite drives the real browser through register → login → upload against deployed dev (no MSW), asserts the deployed CSP enumerates the bucket origin, and fails on any `securitypolicyviolation` event or "Refused to set unsafe header" warning.

## Why

The browser walkthrough on https://d39xcun7144jgl.cloudfront.net failed with these console errors:

```
[ERROR] Connecting to 'https://lfmt-documents-lfmtpocdev.s3.us-east-1.amazonaws.com/uploads/...'
violates the Content Security Policy directive:
"connect-src 'self' https://8brwlwf68h.execute-api.us-east-1.amazonaws.com"
[ERROR] Refused to set unsafe header "Content-Length"
```

Root causes were entirely browser-only. None of the prior smoke / E2E tests asserted on browser-emitted CSP violations or unsafe-header warnings, so the deployed CSP regression was invisible to CI. Fix 4 closes that observability gap.

## What changed

### `backend/infrastructure/lib/lfmt-infrastructure-stack.ts`
- `buildCsp()` accepts an array of `connect-src` origins (back-compat: still accepts a single string). Updated JSDoc explains why the bucket origin is now part of the policy and why a wildcard form would be unsafe.
- Both call sites (initial response-headers policy ~line 2060, `updateCloudFrontCSP()` ~line 2186) now pass `[apiOrigin, bucketOrigin]` so neither policy form is missing the bucket entry.

### `backend/infrastructure/lib/__tests__/infrastructure.test.ts`
- New regression test *"CSP connect-src includes both API Gateway and document S3 bucket origins (Issue #98)"* asserts every CSP-carrying policy enumerates both origins (literal or `Fn::GetAtt`) and rejects the `*.s3.amazonaws.com` wildcard form.

### `frontend/src/services/translationService.ts`
- New `stripBrowserForbiddenHeaders()` helper filters `Content-Length` (case-insensitive) before headers reach axios.
- New `S3_UPLOAD_BLOCKED_MESSAGE` sentinel + `wrapS3UploadError()` map S3-PUT failures with no `error.response` (CSP / network) to a `TranslationServiceError` with the targeted phrase. S3-side HTTP errors (e.g. 403) preserve their status so the existing curated phrase table (`translationErrorMessages.ts`) handles them.

### `frontend/src/services/uploadService.ts`
- Same filter applied at the XHR seam (legacy upload path).

### Frontend tests
- `translationService.test.ts`: regression guards for the Content-Length filter (case-insensitive) and the two new S3-error-wrap branches (no-response → blocked phrase; HTTP error → status preserved). Updated existing assertion to use `objectContaining({ 'Content-Type': ... })` instead of strict equality including Content-Length.
- `uploadService.test.ts`: updated existing assertion + new regression test asserting `setRequestHeader` is never called with `Content-Length` (lowercase or mixed case).
- `TranslationUpload.test.tsx`: new test asserts the wizard surfaces *"Upload was blocked"* (not "Connection lost") when the service throws the sentinel.

### `frontend/e2e/tests/smoke/production-smoke.spec.ts`
- New `@csp-regression @smoke` test: walks register → login → upload, captures `securitypolicyviolation` events + "Refused to set unsafe header" console warnings, fails on either. Asserts the deployed CSP `connect-src` enumerates both origins. Does NOT use MSW — the entire point is to exercise the real CSP and the real S3 PUT.

## Test plan

Manual + automated:

- [x] `cd shared-types && npm run build` — passes
- [x] `cd backend/infrastructure && npm run build && npm test` — 59 passed (including new CSP regression test)
- [x] `cd backend/infrastructure && npx cdk synth --context environment=dev > /dev/null` — passes; manual inspection confirms synthesized CSP includes `Fn::GetAtt: [DocumentBucketAE41E5A9, RegionalDomainName]` in both response-headers policies
- [x] `cd backend/functions && npm run build && npm run lint && npm run format:check && npm test` — 534 passed
- [x] `cd frontend && npm run type-check && npm run lint && npm run format:check && npm test` — 691 passed
- [ ] After merge + deploy: `cd frontend && PLAYWRIGHT_BASE_URL=https://d39xcun7144jgl.cloudfront.net npm run test:e2e -- --grep @csp-regression` against deployed dev — should pass once CDK deploy propagates the updated CSP to all CloudFront edges

## Notes

- API contract unchanged — backend `requiredHeaders` still includes `Content-Length` for documentation / non-browser callers (curl honours it). Only the browser code stops trying to send what it can't.
- No relation to the deferred CSP/auth hardening work in #197 (style-src nonces + httpOnly cookies). This PR is a pure unblocker for the demo-critical browser path.

Refs: #98 (demo blocker — DEMO BLOCKER: CSP connect-src blocks S3 presigned PUT from browser)