### PR TITLE
fix(hotfix): API envelope mismatch — unblock browser demo path

### DIFF
--- a/backend/functions/auth/auth.test.ts
+++ b/backend/functions/auth/auth.test.ts
@@ -338,8 +338,13 @@ describe('Auth Service', () => {
       const result = await refreshTokenHandler(event);
       const body = JSON.parse(result.body);
       expect(result.statusCode).toBe(200);
-      expect(body.data.accessToken).toBe('newaccesstoken');
-      expect(body.data.idToken).toBe('newidtoken');
+      // Flat envelope (no `data` wrapper) — matches the rest of the auth
+      // handlers and the frontend reader (`authService.refreshToken`),
+      // which dereferences `response.data.accessToken` directly. The
+      // previous `{message, data: {...}}` shape was the inconsistency
+      // that the 2026-05-09 hotfix collapsed (see refreshToken.ts comment).
+      expect(body.accessToken).toBe('newaccesstoken');
+      expect(body.idToken).toBe('newidtoken');
     });
 
     it('should return 401 for an invalid refresh token', async () => {

--- a/backend/functions/auth/getCurrentUser.ts
+++ b/backend/functions/auth/getCurrentUser.ts
@@ -4,7 +4,7 @@
  */
 
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
-import { createSuccessResponse, createErrorResponse } from '../shared/api-response';
+import { createFlatResponse, createErrorResponse } from '../shared/api-response';
 import Logger from '../shared/logger';
 
 const logger = new Logger('lfmt-auth-getCurrentUser');
@@ -51,7 +51,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
       lastName: authorizerClaims.family_name || '',
     };
 
-    return createSuccessResponse(
+    return createFlatResponse(
       200,
       {
         user,

--- a/backend/functions/auth/login.ts
+++ b/backend/functions/auth/login.ts
@@ -14,7 +14,7 @@ import {
   TooManyRequestsException,
 } from '@aws-sdk/client-cognito-identity-provider';
 import { loginRequestSchema } from '@lfmt/shared-types';
-import { createErrorResponse, getCorsHeaders } from '../shared/api-response';
+import { createErrorResponse, createFlatResponse } from '../shared/api-response';
 import Logger from '../shared/logger';
 import { getRequiredEnv } from '../shared/env';
 import { decodeJwtPayload } from '../shared/jwt-utils';
@@ -101,17 +101,21 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
       userId: user.id,
     });
 
-    // Return response matching AuthResponse interface using getCorsHeaders
-    return {
-      statusCode: 200,
-      headers: getCorsHeaders(requestOrigin),
-      body: JSON.stringify({
+    // Flat envelope (matches refreshToken/register/getCurrentUser); the reader
+    // in `frontend/src/services/authService.ts` accesses these fields directly
+    // off `response.data` (no `.data.data` wrapper). Convention enforced at
+    // compile time via `createFlatResponse` (see api-response.ts:108).
+    return createFlatResponse(
+      200,
+      {
         user,
         accessToken: response.AuthenticationResult.AccessToken,
         refreshToken: response.AuthenticationResult.RefreshToken,
         idToken: response.AuthenticationResult.IdToken,
-      }),
-    };
+      },
+      requestId,
+      requestOrigin
+    );
   } catch (error) {
     if (error instanceof NotAuthorizedException) {
       logger.warn('Login failed: invalid credentials', {

--- a/backend/functions/auth/refreshToken.ts
+++ b/backend/functions/auth/refreshToken.ts
@@ -75,15 +75,21 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
 
     logger.info('Tokens refreshed successfully', { requestId });
 
+    // Flat response shape (no `data` wrapper) so the frontend
+    // (`authService.refreshToken`) can read `response.data.accessToken`
+    // directly. This matches every other auth handler (login, register,
+    // getCurrentUser) — the previous `{message, data: {...}}` envelope
+    // was an inconsistency that would have surfaced the same wire-shape
+    // bug as the 2026-05-09 demo blocker the moment refresh was exercised
+    // against the real backend (the hotfix audit found that the frontend
+    // expected a flat shape, not the wrapped one this handler returned).
     return createSuccessResponse(
       200,
       {
         message: 'Tokens refreshed successfully',
-        data: {
-          accessToken: response.AuthenticationResult.AccessToken,
-          idToken: response.AuthenticationResult.IdToken,
-          expiresIn: response.AuthenticationResult.ExpiresIn,
-        },
+        accessToken: response.AuthenticationResult.AccessToken,
+        idToken: response.AuthenticationResult.IdToken,
+        expiresIn: response.AuthenticationResult.ExpiresIn,
       },
       requestId,
       requestOrigin

--- a/backend/functions/auth/refreshToken.ts
+++ b/backend/functions/auth/refreshToken.ts
@@ -11,7 +11,7 @@ import {
   TooManyRequestsException,
 } from '@aws-sdk/client-cognito-identity-provider';
 import { refreshTokenRequestSchema } from '@lfmt/shared-types';
-import { createSuccessResponse, createErrorResponse } from '../shared/api-response';
+import { createFlatResponse, createErrorResponse } from '../shared/api-response';
 import Logger from '../shared/logger';
 import { getRequiredEnv } from '../shared/env';
 
@@ -83,7 +83,10 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     // bug as the 2026-05-09 demo blocker the moment refresh was exercised
     // against the real backend (the hotfix audit found that the frontend
     // expected a flat shape, not the wrapped one this handler returned).
-    return createSuccessResponse(
+    //
+    // Convention enforced at the type level via `createFlatResponse`
+    // (PR #218 OMC R1 H1-arch).
+    return createFlatResponse(
       200,
       {
         message: 'Tokens refreshed successfully',

--- a/backend/functions/auth/register.ts
+++ b/backend/functions/auth/register.ts
@@ -21,7 +21,7 @@ import {
   NotAuthorizedException,
 } from '@aws-sdk/client-cognito-identity-provider';
 import { registerRequestSchema } from '@lfmt/shared-types';
-import { createSuccessResponse, createErrorResponse } from '../shared/api-response';
+import { createFlatResponse, createErrorResponse } from '../shared/api-response';
 import Logger from '../shared/logger';
 import { getRequiredEnv, getOptionalEnv } from '../shared/env';
 
@@ -162,7 +162,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
       autoConfirmed: AUTO_CONFIRM_USERS,
     });
 
-    return createSuccessResponse(
+    return createFlatResponse(
       201,
       {
         message: AUTO_CONFIRM_USERS

--- a/backend/functions/auth/resetPassword.ts
+++ b/backend/functions/auth/resetPassword.ts
@@ -12,7 +12,7 @@ import {
   LimitExceededException,
 } from '@aws-sdk/client-cognito-identity-provider';
 import { forgotPasswordRequestSchema } from '@lfmt/shared-types';
-import { createSuccessResponse, createErrorResponse } from '../shared/api-response';
+import { createFlatResponse, createErrorResponse } from '../shared/api-response';
 import Logger from '../shared/logger';
 import { getRequiredEnv } from '../shared/env';
 
@@ -65,7 +65,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
       email: email.toLowerCase(),
     });
 
-    return createSuccessResponse(
+    return createFlatResponse(
       200,
       {
         message: 'If an account with this email exists, a password reset link has been sent.',
@@ -80,7 +80,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
         error: error.message,
       });
 
-      return createSuccessResponse(
+      return createFlatResponse(
         200,
         {
           message: 'If an account with this email exists, a password reset link has been sent.',

--- a/backend/functions/jobs/deleteJob.ts
+++ b/backend/functions/jobs/deleteJob.ts
@@ -45,7 +45,7 @@ import { marshall, unmarshall } from '@aws-sdk/util-dynamodb';
 import { DynamoDBJob, DeleteJobApiResponse } from '@lfmt/shared-types';
 import Logger from '../shared/logger';
 import { getRequiredEnv } from '../shared/env';
-import { createSuccessResponse, createErrorResponse } from '../shared/api-response';
+import { createFlatResponse, createErrorResponse } from '../shared/api-response';
 
 const logger = new Logger('lfmt-delete-job');
 const dynamoClient = new DynamoDBClient({});
@@ -206,7 +206,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
       ...(s3Warning ? { warning: s3Warning } : {}),
     };
 
-    return createSuccessResponse(200, responseBody, requestId, requestOrigin);
+    return createFlatResponse(200, responseBody, requestId, requestOrigin);
   } catch (error) {
     logger.error('Failed to delete job', {
       requestId,

--- a/backend/functions/jobs/getJob.ts
+++ b/backend/functions/jobs/getJob.ts
@@ -19,7 +19,7 @@ import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { GetJobApiResponse } from '@lfmt/shared-types';
 import Logger from '../shared/logger';
 import { getRequiredEnv } from '../shared/env';
-import { createSuccessResponse, createErrorResponse } from '../shared/api-response';
+import { createFlatResponse, createErrorResponse } from '../shared/api-response';
 import { loadJobForUser } from '../shared/jobRepository';
 
 const logger = new Logger('lfmt-get-job');
@@ -80,7 +80,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
 
     logger.info('Job retrieved', { requestId, jobId, status: job.status });
 
-    return createSuccessResponse(200, responseBody, requestId, requestOrigin);
+    return createFlatResponse(200, responseBody, requestId, requestOrigin);
   } catch (error) {
     logger.error('Failed to get job', {
       requestId,

--- a/backend/functions/jobs/getTranslationStatus.ts
+++ b/backend/functions/jobs/getTranslationStatus.ts
@@ -7,7 +7,7 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { DynamoDBClient, GetItemCommand, GetItemCommandOutput } from '@aws-sdk/client-dynamodb';
 import { marshall, unmarshall } from '@aws-sdk/util-dynamodb';
-import { DynamoDBJob } from '@lfmt/shared-types';
+import { DynamoDBJob, TranslationStatusApiResponse } from '@lfmt/shared-types';
 import Logger from '../shared/logger';
 import { getRequiredEnv } from '../shared/env';
 import { createSuccessResponse, createErrorResponse } from '../shared/api-response';
@@ -23,45 +23,24 @@ const dynamoClient = new DynamoDBClient({});
 
 const JOBS_TABLE = getRequiredEnv('JOBS_TABLE');
 
-/**
- * Translation status response
- */
-interface TranslationStatusResponse {
-  jobId: string;
-  // R3 (OMC review follow-up): the frontend's `TranslationDetail.tsx`
-  // renders `userId`, `fileSize`, and `contentType` from this response
-  // (lines 239, 246 — fileSize and contentType in particular). They
-  // were absent from the real Lambda response, so the demo bug fixed
-  // by PR #166 on the mock side (Issue #144 — "0 Bytes") would have
-  // reappeared in production once the mock was disabled. The fields
-  // are already persisted on the DDB job record at upload time
-  // (uploadRequest.ts:124-126), so surfacing them here is a pure
-  // wire-shape catch-up with no schema migration needed.
-  userId?: string;
-  fileName?: string;
-  fileSize?: number;
-  contentType?: string;
-  status: string; // Overall job status (PENDING_UPLOAD, UPLOADED, CHUNKED, etc.)
-  translationStatus: string;
-  targetLanguage?: string;
-  tone?: string;
-  totalChunks: number;
-  chunksTranslated: number;
-  progressPercentage: number;
-  tokensUsed?: number;
-  estimatedCost?: number;
-  // createdAt is the server-side ISO timestamp recorded when the job record
-  // was first persisted (during upload/request). It represents the true start
-  // of a user's wait time, and benchmark tooling uses it as the anchor for
-  // end-to-end duration measurements so results aren't skewed by client-side
-  // clock drift or upload timing. See backend/tests/performance/performance-benchmark.ts.
-  createdAt?: string;
-  translationStartedAt?: string;
-  translationCompletedAt?: string;
-  estimatedCompletion?: string;
-  error?: string;
-  [key: string]: unknown;
-}
+// Translation status response shape now lives in @lfmt/shared-types
+// (TranslationStatusApiResponse) so the backend Lambda and the frontend
+// service (translationService.getJobStatus) share a single source of
+// truth. Drift between the two — like the 2026-05-09 demo blocker
+// where the frontend read response.data.data on a flat envelope — is
+// now caught at compile time on either side.
+//
+// History notes preserved from the previous local interface:
+//   - R3 (OMC review follow-up): userId, fileSize, contentType were
+//     surfaced here so TranslationDetail.tsx could render them. The
+//     fields are persisted on the DDB job record at upload time
+//     (uploadRequest.ts:124-126) so surfacing them is a pure wire-shape
+//     catch-up with no schema migration.
+//   - createdAt is the server-side ISO timestamp recorded when the job
+//     record was first persisted (during upload/request). Benchmark
+//     tooling uses it as the anchor for end-to-end duration measurements
+//     so results aren't skewed by client-side clock drift or upload
+//     timing. See backend/tests/performance/performance-benchmark.ts.
 
 /**
  * Lambda handler for getting translation status
@@ -101,8 +80,9 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
       );
     }
 
-    // Build response
-    const response: TranslationStatusResponse = {
+    // Build response — typed with the shared DTO so any drift between
+    // backend and frontend surfaces as a compile error.
+    const response: TranslationStatusApiResponse = {
       jobId,
       // R3: surface the file/owner metadata persisted at upload time so
       // the Translation Details view can render File Size, Content Type,

--- a/backend/functions/jobs/getTranslationStatus.ts
+++ b/backend/functions/jobs/getTranslationStatus.ts
@@ -10,7 +10,7 @@ import { marshall, unmarshall } from '@aws-sdk/util-dynamodb';
 import { DynamoDBJob, TranslationStatusApiResponse } from '@lfmt/shared-types';
 import Logger from '../shared/logger';
 import { getRequiredEnv } from '../shared/env';
-import { createSuccessResponse, createErrorResponse } from '../shared/api-response';
+import { createFlatResponse, createErrorResponse } from '../shared/api-response';
 // Note: getTranslationStatus does NOT use loadJobForUser from jobRepository.ts.
 // It retains ConsistentRead: true (inline below) because it is polled tightly
 // during an active translation — the UI updates on every poll response, so a
@@ -128,7 +128,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
       progressPercentage: response.progressPercentage,
     });
 
-    return createSuccessResponse(200, response, undefined, requestOrigin);
+    return createFlatResponse(200, response, undefined, requestOrigin);
   } catch (error) {
     logger.error('Failed to get translation status', {
       error: error instanceof Error ? error.message : 'Unknown error',

--- a/backend/functions/jobs/startTranslation.ts
+++ b/backend/functions/jobs/startTranslation.ts
@@ -13,7 +13,12 @@ import {
 } from '@aws-sdk/client-dynamodb';
 import { SFNClient, StartExecutionCommand, StartExecutionCommandOutput } from '@aws-sdk/client-sfn';
 import { marshall, unmarshall } from '@aws-sdk/util-dynamodb';
-import { DynamoDBJob, TRANSLATION_TONE_VALUES, TranslationTone } from '@lfmt/shared-types';
+import {
+  DynamoDBJob,
+  StartTranslationApiResponse,
+  TRANSLATION_TONE_VALUES,
+  TranslationTone,
+} from '@lfmt/shared-types';
 import Logger from '../shared/logger';
 import { getRequiredEnv } from '../shared/env';
 import { createSuccessResponse, createErrorResponse } from '../shared/api-response';
@@ -198,22 +203,22 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
       executionArn,
     });
 
-    return createSuccessResponse(
-      200,
-      {
-        message: 'Translation started successfully',
-        jobId,
-        translationStatus: 'IN_PROGRESS',
-        targetLanguage: body.targetLanguage,
-        totalChunks: job.totalChunks,
-        chunksTranslated: 0,
-        estimatedCompletion,
-        estimatedCost: calculateEstimatedCost(job.totalChunks, 3500), // Assume 3500 tokens per chunk
-        executionArn, // Step Functions execution ARN for tracking
-      },
-      undefined,
-      requestOrigin
-    );
+    // Type the response with the shared DTO so any drift from the
+    // frontend reader (translationService.startTranslation) surfaces
+    // at compile time.
+    const responseBody: StartTranslationApiResponse = {
+      message: 'Translation started successfully',
+      jobId,
+      translationStatus: 'IN_PROGRESS',
+      targetLanguage: body.targetLanguage,
+      totalChunks: job.totalChunks,
+      chunksTranslated: 0,
+      estimatedCompletion,
+      estimatedCost: calculateEstimatedCost(job.totalChunks, 3500), // Assume 3500 tokens per chunk
+      executionArn, // Step Functions execution ARN for tracking
+    };
+
+    return createSuccessResponse(200, responseBody, undefined, requestOrigin);
   } catch (error) {
     logger.error('Failed to start translation', {
       error: error instanceof Error ? error.message : 'Unknown error',

--- a/backend/functions/jobs/startTranslation.ts
+++ b/backend/functions/jobs/startTranslation.ts
@@ -21,7 +21,7 @@ import {
 } from '@lfmt/shared-types';
 import Logger from '../shared/logger';
 import { getRequiredEnv } from '../shared/env';
-import { createSuccessResponse, createErrorResponse } from '../shared/api-response';
+import { createFlatResponse, createErrorResponse } from '../shared/api-response';
 import { isValidTargetLanguage, TargetLanguage } from '../translation/types';
 
 const logger = new Logger('lfmt-start-translation');
@@ -218,7 +218,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
       executionArn, // Step Functions execution ARN for tracking
     };
 
-    return createSuccessResponse(200, responseBody, undefined, requestOrigin);
+    return createFlatResponse(200, responseBody, undefined, requestOrigin);
   } catch (error) {
     logger.error('Failed to start translation', {
       error: error instanceof Error ? error.message : 'Unknown error',

--- a/backend/functions/jobs/uploadRequest.ts
+++ b/backend/functions/jobs/uploadRequest.ts
@@ -16,7 +16,7 @@ import {
   legalAttestationPayloadSchema,
   LegalAttestationPayload,
 } from '@lfmt/shared-types';
-import { createSuccessResponse, createErrorResponse } from '../shared/api-response';
+import { createWrappedResponse, createErrorResponse } from '../shared/api-response';
 import Logger from '../shared/logger';
 import { getRequiredEnv } from '../shared/env';
 import {
@@ -235,13 +235,16 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     //
     // Note: this endpoint deliberately wraps the payload in `{message, data}`
     // (uniquely among the job-side endpoints) — see PresignedUrlApiResponse
-    // in shared-types for the rationale.
+    // in shared-types for the rationale. We use `createWrappedResponse`
+    // (PR #218 OMC R1 H1-arch) which enforces the `{message, data}` shape
+    // at the type level, so a future maintainer cannot accidentally drop
+    // either field and revert the endpoint to the dominant flat shape.
     const envelope: PresignedUrlApiResponse = {
       message: 'Upload URL generated successfully',
       data: response,
     };
 
-    return createSuccessResponse(200, envelope, requestId, requestOrigin);
+    return createWrappedResponse(200, envelope, requestId, requestOrigin);
   } catch (error) {
     logger.error('Unexpected error during upload request processing', {
       requestId,

--- a/backend/functions/jobs/uploadRequest.ts
+++ b/backend/functions/jobs/uploadRequest.ts
@@ -9,6 +9,7 @@ import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { DynamoDBClient, PutItemCommand } from '@aws-sdk/client-dynamodb';
 import { marshall } from '@aws-sdk/util-dynamodb';
 import {
+  PresignedUrlApiResponse,
   PresignedUrlRequest,
   PresignedUrlResponse,
   fileValidationSchema,
@@ -227,15 +228,20 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
       },
     };
 
-    return createSuccessResponse(
-      200,
-      {
-        message: 'Upload URL generated successfully',
-        data: response,
-      },
-      requestId,
-      requestOrigin
-    );
+    // Type the wire envelope with the shared DTO so any drift from the
+    // frontend reader (translationService.uploadDocument /
+    // uploadService.requestUploadUrl, both of which read
+    // `response.data.data`) surfaces at compile time.
+    //
+    // Note: this endpoint deliberately wraps the payload in `{message, data}`
+    // (uniquely among the job-side endpoints) — see PresignedUrlApiResponse
+    // in shared-types for the rationale.
+    const envelope: PresignedUrlApiResponse = {
+      message: 'Upload URL generated successfully',
+      data: response,
+    };
+
+    return createSuccessResponse(200, envelope, requestId, requestOrigin);
   } catch (error) {
     logger.error('Unexpected error during upload request processing', {
       requestId,

--- a/backend/functions/shared/__tests__/api-response.test.ts
+++ b/backend/functions/shared/__tests__/api-response.test.ts
@@ -1,0 +1,178 @@
+/**
+ * API Response Helpers — wire-shape contract tests.
+ *
+ * These tests pin the exact JSON body produced by `createFlatResponse`
+ * and `createWrappedResponse`. The split into two helpers (PR #218 OMC R1
+ * H1-arch) makes the envelope discoverable at the type level — these
+ * tests make it discoverable at the runtime level too: any future change
+ * to the body shape will fail here BEFORE the change can ship a
+ * `Cannot read properties of undefined (reading 'data')` regression
+ * (the 2026-05-09 demo blocker class).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import {
+  createFlatResponse,
+  createWrappedResponse,
+  createSuccessResponse,
+  createErrorResponse,
+  getCorsHeaders,
+} from '../api-response';
+
+describe('api-response — envelope helpers', () => {
+  const ORIGINAL_ENV = process.env;
+
+  beforeEach(() => {
+    // Reset CORS env so tests are deterministic regardless of host shell.
+    process.env = { ...ORIGINAL_ENV };
+    delete process.env.ALLOWED_ORIGINS;
+    delete process.env.ALLOWED_ORIGIN;
+  });
+
+  afterEach(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  describe('createFlatResponse', () => {
+    it('serializes the body as `{...body, requestId}` with no `data` wrapper', () => {
+      const response = createFlatResponse(
+        200,
+        {
+          message: 'OK',
+          user: { id: 'u1', email: 'a@b.com' },
+        },
+        'req-123'
+      );
+
+      expect(response.statusCode).toBe(200);
+      const parsed = JSON.parse(response.body);
+      // Critical contract: flat shape — fields live at the top level.
+      expect(parsed).toEqual({
+        message: 'OK',
+        user: { id: 'u1', email: 'a@b.com' },
+        requestId: 'req-123',
+      });
+      // Explicit anti-assertion: no nested `data` wrapper. This is the
+      // exact failure mode of the 2026-05-09 demo blocker — a frontend
+      // reader that expected `response.data.data.foo` would crash on
+      // this shape.
+      expect(parsed).not.toHaveProperty('data');
+    });
+
+    it('omits requestId when not provided (no spurious "requestId":undefined key in output)', () => {
+      const response = createFlatResponse(200, { message: 'OK' });
+      const parsed = JSON.parse(response.body);
+      // JSON.stringify drops undefined values — so the key is absent
+      // from the wire. Lock that contract: omitting requestId must NOT
+      // surface as `"requestId": null` to the frontend.
+      expect(parsed).toEqual({ message: 'OK' });
+      expect(parsed).not.toHaveProperty('requestId');
+    });
+
+    it('includes CORS + Content-Type headers', () => {
+      const response = createFlatResponse(200, { message: 'OK' });
+      expect(response.headers['Content-Type']).toBe('application/json');
+      expect(response.headers['Access-Control-Allow-Origin']).toBe('http://localhost:3000');
+      expect(response.headers['Access-Control-Allow-Credentials']).toBe('true');
+    });
+
+    it('echoes the request origin when allowed by ALLOWED_ORIGINS env', () => {
+      process.env.ALLOWED_ORIGINS = 'https://app.example.com,https://other.example.com';
+      const response = createFlatResponse(
+        200,
+        { message: 'OK' },
+        undefined,
+        'https://app.example.com'
+      );
+      expect(response.headers['Access-Control-Allow-Origin']).toBe('https://app.example.com');
+    });
+
+    it('falls back to the first allowed origin when request origin is not whitelisted', () => {
+      process.env.ALLOWED_ORIGINS = 'https://app.example.com';
+      const response = createFlatResponse(
+        200,
+        { message: 'OK' },
+        undefined,
+        'https://attacker.example'
+      );
+      expect(response.headers['Access-Control-Allow-Origin']).toBe('https://app.example.com');
+    });
+  });
+
+  describe('createWrappedResponse', () => {
+    it('serializes the body as `{message, data, requestId}` with `data` containing the payload', () => {
+      const payload = { uploadUrl: 'https://s3/bucket/key', jobId: 'job-1' };
+      const response = createWrappedResponse(
+        200,
+        { message: 'Upload URL generated', data: payload },
+        'req-456'
+      );
+
+      const parsed = JSON.parse(response.body);
+      // Critical contract: nested `data` wrapper. The frontend reader
+      // for `POST /jobs/upload` (translationService.uploadDocument)
+      // expects this exact shape — `response.data.data.uploadUrl`.
+      expect(parsed).toEqual({
+        message: 'Upload URL generated',
+        data: payload,
+        requestId: 'req-456',
+      });
+      // Anti-assertion: the payload must NOT be spread to the top level
+      // (which would be the flat envelope and break the upload reader).
+      expect(parsed).not.toHaveProperty('uploadUrl');
+      expect(parsed).not.toHaveProperty('jobId');
+    });
+
+    it('preserves nested object identity inside `data`', () => {
+      // Locks the wire shape: `data` carries the payload verbatim,
+      // including nested objects. A future maintainer who replaces
+      // `body.data` with a spread would break the upload reader and
+      // this test would fail loudly.
+      const data = {
+        uploadUrl: 'https://s3/k',
+        requiredHeaders: { 'Content-Type': 'text/plain', 'x-amz-foo': 'bar' },
+      };
+      const response = createWrappedResponse(200, { message: 'OK', data }, 'r1');
+      const parsed = JSON.parse(response.body);
+      expect(parsed.data).toEqual(data);
+    });
+  });
+
+  describe('createSuccessResponse (deprecated alias)', () => {
+    it('produces the same wire shape as createFlatResponse for legacy callers', () => {
+      const flat = createFlatResponse(200, { message: 'OK' }, 'r1');
+      const legacy = createSuccessResponse(200, { message: 'OK' }, 'r1');
+      expect(legacy.body).toBe(flat.body);
+      expect(legacy.statusCode).toBe(flat.statusCode);
+    });
+  });
+
+  describe('createErrorResponse', () => {
+    it('serializes a flat error body', () => {
+      const response = createErrorResponse(400, 'Validation failed', 'r1', {
+        email: ['Invalid'],
+      });
+      const parsed = JSON.parse(response.body);
+      expect(response.statusCode).toBe(400);
+      expect(parsed).toEqual({
+        message: 'Validation failed',
+        requestId: 'r1',
+        errors: { email: ['Invalid'] },
+      });
+    });
+
+    it('omits the errors field when none are supplied', () => {
+      const response = createErrorResponse(500, 'Server error');
+      const parsed = JSON.parse(response.body);
+      expect(parsed).toEqual({ message: 'Server error' });
+    });
+  });
+
+  describe('getCorsHeaders', () => {
+    it('parses comma-separated origins, trimming whitespace', () => {
+      process.env.ALLOWED_ORIGINS = ' https://a.com ,  https://b.com ';
+      const headers = getCorsHeaders('https://b.com');
+      expect(headers['Access-Control-Allow-Origin']).toBe('https://b.com');
+    });
+  });
+});

--- a/backend/functions/shared/api-response.ts
+++ b/backend/functions/shared/api-response.ts
@@ -1,6 +1,27 @@
 /**
  * Shared API Response Utilities
- * Provides consistent response formatting across all Lambda functions
+ * Provides consistent response formatting across all Lambda functions.
+ *
+ * Two helpers — one per envelope convention — so the wire shape is
+ * discoverable at the type level (OMC R1 H1-arch on PR #218):
+ *
+ *   1. `createFlatResponse<T>(statusCode, body, requestId?, origin?)`
+ *      Body is serialized as `{ ...body, requestId }`. Use this for the
+ *      DOMINANT convention — every endpoint except `uploadRequest`. Field
+ *      access on the frontend is `response.data.<field>` directly.
+ *
+ *   2. `createWrappedResponse<T>(statusCode, { message, data }, requestId?, origin?)`
+ *      Body is serialized as `{ message, data, requestId }`. Use this ONLY
+ *      when the endpoint intentionally surfaces a user-visible message
+ *      alongside a structured payload — currently only `POST /jobs/upload`.
+ *
+ * Pre-PR-#218 there was a single passthrough `createSuccessResponse` that
+ * accepted any spread shape — flat, wrapped, or hybrid — which is exactly
+ * what allowed the 2026-05-09 demo blocker (frontend read `response.data.data`,
+ * Lambda emitted a flat body). Splitting the function forces every
+ * Lambda author to make an explicit, type-checked choice. `createSuccessResponse`
+ * remains as a deprecated alias for `createFlatResponse` so existing
+ * callers continue to compile while the codebase migrates.
  */
 
 export interface ApiResponse {
@@ -15,11 +36,27 @@ export interface ApiErrorResponse {
   errors?: Record<string, string[]>;
 }
 
-export interface ApiSuccessResponse<T = unknown> {
+/**
+ * Body shape accepted by `createFlatResponse`. The index signature lets the
+ * caller include any business fields (jobId, user, totalChunks, etc.) and an
+ * optional `message`. `requestId` is appended by the helper, not by the
+ * caller — duplicating it would silently overwrite the per-request value.
+ */
+export interface ApiFlatResponseBody {
   message?: string;
-  data?: T;
-  requestId?: string;
-  [key: string]: unknown; // Allow additional properties
+  [key: string]: unknown;
+}
+
+/**
+ * Body shape accepted by `createWrappedResponse`. Both `message` and `data`
+ * are REQUIRED — that is the entire reason this helper exists separately
+ * from `createFlatResponse`. A future caller that wants only `data` MUST
+ * use `createFlatResponse({ data: ... })`; this signature won't compile
+ * without `message`.
+ */
+export interface ApiWrappedResponseBody<T> {
+  message: string;
+  data: T;
 }
 
 /**
@@ -48,11 +85,29 @@ export function getCorsHeaders(requestOrigin?: string): Record<string, string> {
 }
 
 /**
- * Create a successful API response
+ * Create a successful API response with the FLAT envelope convention.
+ *
+ * Wire body shape:
+ *   `{ ...body, requestId }`
+ *
+ * Use this for every endpoint that does NOT need a `data` wrapper — i.e.,
+ * the dominant convention across LFMT. The frontend reader accesses fields
+ * directly via `response.data.<field>`.
+ *
+ * Example:
+ *   ```ts
+ *   return createFlatResponse(
+ *     200,
+ *     { message: 'OK', user: { id, email } },
+ *     requestId,
+ *     requestOrigin
+ *   );
+ *   // → body: { message: 'OK', user: { id, email }, requestId: '...' }
+ *   ```
  */
-export function createSuccessResponse<T = unknown>(
+export function createFlatResponse<T extends ApiFlatResponseBody>(
   statusCode: number,
-  data: ApiSuccessResponse<T>,
+  body: T,
   requestId?: string,
   requestOrigin?: string
 ): ApiResponse {
@@ -60,10 +115,70 @@ export function createSuccessResponse<T = unknown>(
     statusCode,
     headers: getCorsHeaders(requestOrigin),
     body: JSON.stringify({
-      ...data,
+      ...body,
       requestId,
     }),
   };
+}
+
+/**
+ * Create a successful API response with the WRAPPED envelope convention.
+ *
+ * Wire body shape:
+ *   `{ message, data, requestId }`
+ *
+ * Use this ONLY when the endpoint intentionally pairs a user-facing message
+ * with a structured payload that callers consume as a unit. Currently the
+ * sole live caller is `POST /jobs/upload` (the presigned-URL handoff) — the
+ * `data` field carries the entire `PresignedUrlResponse` and the `message`
+ * is shown verbatim by the upload UI. The frontend reader accesses fields
+ * via `response.data.data.<field>`.
+ *
+ * Example:
+ *   ```ts
+ *   return createWrappedResponse(
+ *     200,
+ *     { message: 'Upload URL generated', data: presignedUrlResponse },
+ *     requestId,
+ *     requestOrigin
+ *   );
+ *   // → body: { message: '...', data: { uploadUrl, jobId, ... }, requestId: '...' }
+ *   ```
+ */
+export function createWrappedResponse<T>(
+  statusCode: number,
+  body: ApiWrappedResponseBody<T>,
+  requestId?: string,
+  requestOrigin?: string
+): ApiResponse {
+  return {
+    statusCode,
+    headers: getCorsHeaders(requestOrigin),
+    body: JSON.stringify({
+      message: body.message,
+      data: body.data,
+      requestId,
+    }),
+  };
+}
+
+/**
+ * @deprecated Use `createFlatResponse` (or `createWrappedResponse` for the
+ * `POST /jobs/upload` style envelope). Kept as an alias for `createFlatResponse`
+ * so legacy call sites continue to compile during migration.
+ *
+ * Background: pre-PR-#218 this function was a passthrough that accepted any
+ * spread body — flat, wrapped, or hybrid. That ambiguity was the root cause
+ * of the 2026-05-09 demo blocker. New code MUST pick one of the explicit
+ * helpers above.
+ */
+export function createSuccessResponse<T extends ApiFlatResponseBody>(
+  statusCode: number,
+  body: T,
+  requestId?: string,
+  requestOrigin?: string
+): ApiResponse {
+  return createFlatResponse(statusCode, body, requestId, requestOrigin);
 }
 
 /**

--- a/frontend/src/__tests__/apiEnvelopeContract.test.ts
+++ b/frontend/src/__tests__/apiEnvelopeContract.test.ts
@@ -1,0 +1,141 @@
+/**
+ * API Envelope Contract Test
+ *
+ * Regression guard for the 2026-05-09 demo blocker:
+ *
+ *   "Cannot read properties of undefined (reading 'status')"
+ *
+ * Root cause: the frontend service `getJobStatus` read `response.data.data`
+ * but the real Lambda `backend/functions/jobs/getTranslationStatus.ts`
+ * returns a FLAT object via `createSuccessResponse`. The MSW mock had
+ * been wrapping responses in `{data: ...}` to match the (wrong) frontend
+ * expectation, hiding the divergence until the deployed walkthrough.
+ *
+ * This file is the primary CONTRACT GUARD against future regressions of
+ * the same class. It exercises the MSW handlers (which now mirror the
+ * real Lambda wire shape) and asserts the frontend services successfully
+ * project the wire body into the local types — i.e., the service does
+ * NOT crash on `undefined.something`. If a Lambda ever changes its
+ * response shape, this test will fail in vitest before the change can
+ * reach the demo.
+ *
+ * Strategy: drive the actual MSW handlers (msw/node) end-to-end through
+ * the real `apiClient` axios instance, with a tiny axios-mock-adapter
+ * shim for the `/__mock-s3/` PUT (since msw/node cannot intercept the
+ * absolute URL the SW would normally handle). Asserts on the SHAPE the
+ * service returns, not on incidental field values.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { setupServer } from 'msw/node';
+import { handlers, resetState } from '../mocks/handlers';
+import { translationService } from '../services/translationService';
+import { apiClient } from '../utils/api';
+import type {
+  PresignedUrlApiResponse,
+  StartTranslationApiResponse,
+  TranslationStatusApiResponse,
+} from '@lfmt/shared-types';
+
+const server = setupServer(...handlers);
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'bypass' }));
+afterAll(() => server.close());
+beforeEach(() => {
+  server.resetHandlers();
+  resetState();
+});
+
+describe('API Envelope Contract — mock vs frontend reader', () => {
+  it('POST /jobs/upload returns {message, data: PresignedUrlResponse} envelope', async () => {
+    // Hits the MSW handler (which mirrors the real Lambda's
+    // PresignedUrlApiResponse shape). The frontend reader in
+    // translationService.uploadDocument /
+    // uploadService.requestUploadUrl dereferences `.data.data` — if
+    // the envelope ever flattens (or vice versa), this test fails.
+    const response = await apiClient.post<PresignedUrlApiResponse>('/jobs/upload', {
+      fileName: 'contract.txt',
+      fileSize: 100,
+      contentType: 'text/plain',
+    });
+
+    expect(response.data).toBeDefined();
+    expect(typeof response.data.message).toBe('string');
+    expect(response.data.data).toBeDefined();
+    expect(typeof response.data.data.uploadUrl).toBe('string');
+    expect(typeof response.data.data.jobId).toBe('string');
+  });
+
+  it('POST /jobs/{jobId}/translate returns flat StartTranslationApiResponse', async () => {
+    // Seed a job through the upload handler so the translate handler
+    // has something to operate on.
+    const upload = await apiClient.post<PresignedUrlApiResponse>('/jobs/upload', {
+      fileName: 'contract.txt',
+      fileSize: 100,
+      contentType: 'text/plain',
+    });
+    const { jobId } = upload.data.data;
+
+    const response = await apiClient.post<StartTranslationApiResponse>(`/jobs/${jobId}/translate`, {
+      targetLanguage: 'es',
+      tone: 'neutral',
+    });
+
+    // Body is FLAT: NO `data` wrapper. The 2026-05-09 hotfix exists
+    // specifically to prevent reading `response.data.data` here.
+    expect(response.data.jobId).toBe(jobId);
+    expect(response.data.translationStatus).toBe('IN_PROGRESS');
+    // Field name is `chunksTranslated`, not `completedChunks` —
+    // mirrors the real Lambda. Frontend service translates at the seam.
+    expect(typeof response.data.chunksTranslated).toBe('number');
+    expect(typeof response.data.totalChunks).toBe('number');
+  });
+
+  it('GET /jobs/{jobId}/translation-status returns flat TranslationStatusApiResponse', async () => {
+    const upload = await apiClient.post<PresignedUrlApiResponse>('/jobs/upload', {
+      fileName: 'contract.txt',
+      fileSize: 100,
+      contentType: 'text/plain',
+    });
+    const { jobId } = upload.data.data;
+
+    const response = await apiClient.get<TranslationStatusApiResponse>(
+      `/jobs/${jobId}/translation-status`
+    );
+
+    // Body is FLAT — this is the EXACT failure mode of the demo
+    // blocker. If `response.data.status` is undefined, the polling
+    // loop in `uploadAndAwaitChunked` crashes with the original
+    // "Cannot read properties of undefined (reading 'status')" error.
+    expect(response.data.jobId).toBe(jobId);
+    expect(typeof response.data.status).toBe('string');
+    expect(typeof response.data.translationStatus).toBe('string');
+    expect(typeof response.data.totalChunks).toBe('number');
+    expect(typeof response.data.chunksTranslated).toBe('number');
+    expect(typeof response.data.progressPercentage).toBe('number');
+  });
+
+  it('translationService.getJobStatus does not crash on the real wire shape', async () => {
+    // End-to-end through the service layer. This is the precise
+    // call site where the demo blocker manifested — the polling loop
+    // in `uploadAndAwaitChunked` invokes `getJobStatus(...)` and then
+    // dereferences `.status` on the result. Service must safely
+    // project the flat wire shape into a `TranslationJob`.
+    const upload = await apiClient.post<PresignedUrlApiResponse>('/jobs/upload', {
+      fileName: 'contract.txt',
+      fileSize: 100,
+      contentType: 'text/plain',
+    });
+    const { jobId } = upload.data.data;
+
+    const job = await translationService.getJobStatus(jobId);
+
+    expect(job).toBeDefined();
+    expect(job.jobId).toBe(jobId);
+    // The bug surfaced as `job.status` being undefined; assert it
+    // is a string so the regression is impossible to merge silently.
+    expect(typeof job.status).toBe('string');
+    expect(typeof job.totalChunks).toBe('number');
+    expect(typeof job.completedChunks).toBe('number');
+  });
+});

--- a/frontend/src/__tests__/apiEnvelopeContract.test.ts
+++ b/frontend/src/__tests__/apiEnvelopeContract.test.ts
@@ -7,8 +7,8 @@
  *
  * Root cause: the frontend service `getJobStatus` read `response.data.data`
  * but the real Lambda `backend/functions/jobs/getTranslationStatus.ts`
- * returns a FLAT object via `createSuccessResponse`. The MSW mock had
- * been wrapping responses in `{data: ...}` to match the (wrong) frontend
+ * returns a FLAT object via `createFlatResponse`. The MSW mock had been
+ * wrapping responses in `{data: ...}` to match the (wrong) frontend
  * expectation, hiding the divergence until the deployed walkthrough.
  *
  * This file is the primary CONTRACT GUARD against future regressions of
@@ -19,17 +19,39 @@
  * response shape, this test will fail in vitest before the change can
  * reach the demo.
  *
+ * ---------------------------------------------------------------------------
+ * ONBOARDING — adding contract tests for new service methods
+ * ---------------------------------------------------------------------------
+ *
+ * When you add a new method to `authService` / `translationService` /
+ * any other API service, add a corresponding test here that asserts:
+ *
+ *   1. The wire body shape matches the corresponding `*ApiResponse`
+ *      interface in `@lfmt/shared-types` (the SSoT — see
+ *      `frontend/src/mocks/handlers.ts` "Wire-shape policy" block).
+ *   2. The shape matches what the real Lambda's `createFlatResponse`
+ *      or `createWrappedResponse` would produce — i.e., flat for
+ *      everything except `POST /jobs/upload`.
+ *   3. The service-layer reader projects the wire shape into the
+ *      frontend type without dereferencing undefined.
+ *
+ * The matrix below covers every method exposed by `authService` and
+ * `translationService` as of PR #218. New endpoints MUST add a row
+ * here in the same PR they ship the handler in.
+ *
  * Strategy: drive the actual MSW handlers (msw/node) end-to-end through
- * the real `apiClient` axios instance, with a tiny axios-mock-adapter
- * shim for the `/__mock-s3/` PUT (since msw/node cannot intercept the
- * absolute URL the SW would normally handle). Asserts on the SHAPE the
- * service returns, not on incidental field values.
+ * the real `apiClient` axios instance. Asserts on the SHAPE the service
+ * returns, not on incidental field values. This file is intentionally
+ * shape-only — semantic behaviour (validation, error mapping) lives in
+ * the per-service unit tests next to the implementation.
  */
 
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
 import { setupServer } from 'msw/node';
+import { http, HttpResponse } from 'msw';
 import { handlers, resetState } from '../mocks/handlers';
 import { translationService } from '../services/translationService';
+import { authService } from '../services/authService';
 import { apiClient } from '../utils/api';
 import type {
   PresignedUrlApiResponse,
@@ -44,9 +66,13 @@ afterAll(() => server.close());
 beforeEach(() => {
   server.resetHandlers();
   resetState();
+  // Clear any session left behind by a previous test — the
+  // refresh-interceptor would otherwise inject Authorization
+  // headers we don't care about here.
+  localStorage.clear();
 });
 
-describe('API Envelope Contract — mock vs frontend reader', () => {
+describe('API Envelope Contract — translation pipeline', () => {
   it('POST /jobs/upload returns {message, data: PresignedUrlResponse} envelope', async () => {
     // Hits the MSW handler (which mirrors the real Lambda's
     // PresignedUrlApiResponse shape). The frontend reader in
@@ -137,5 +163,224 @@ describe('API Envelope Contract — mock vs frontend reader', () => {
     expect(typeof job.status).toBe('string');
     expect(typeof job.totalChunks).toBe('number');
     expect(typeof job.completedChunks).toBe('number');
+  });
+
+  it('GET /jobs returns a flat array (no envelope wrapper)', async () => {
+    // Seed two jobs so the list returns something non-trivial.
+    // We only assert "at least the seeds" rather than an exact count
+    // because earlier tests in the same file may have left jobs in
+    // the closure-scoped store; that's an acceptable cross-test leak
+    // for a contract test (we care about the SHAPE, not the count).
+    await apiClient.post<PresignedUrlApiResponse>('/jobs/upload', {
+      fileName: 'a.txt',
+      fileSize: 50,
+      contentType: 'text/plain',
+    });
+    await apiClient.post<PresignedUrlApiResponse>('/jobs/upload', {
+      fileName: 'b.txt',
+      fileSize: 75,
+      contentType: 'text/plain',
+    });
+
+    const list = await translationService.getTranslationJobs();
+    expect(Array.isArray(list)).toBe(true);
+    expect(list.length).toBeGreaterThanOrEqual(2);
+    // Per-item contract: each entry is the flat TranslationJob shape
+    // the History page expects.
+    expect(typeof list[0].jobId).toBe('string');
+    expect(typeof list[0].status).toBe('string');
+    expect(typeof list[0].fileSize).toBe('number');
+  });
+
+  it('GET /jobs/{jobId}/download returns a Blob with a content-type set', async () => {
+    const upload = await apiClient.post<PresignedUrlApiResponse>('/jobs/upload', {
+      fileName: 'download-me.txt',
+      fileSize: 40,
+      contentType: 'text/plain',
+    });
+    const { jobId } = upload.data.data;
+
+    const blob = await translationService.downloadTranslation(jobId);
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.size).toBeGreaterThan(0);
+  });
+});
+
+describe('API Envelope Contract — auth pipeline', () => {
+  // The auth handlers all return the FLAT envelope. The mock matches
+  // the real backend (post-PR-#218: refreshToken was flattened too).
+
+  it('authService.register returns flat AuthResponse with user + tokens', async () => {
+    const result = await authService.register({
+      email: 'contract@example.com',
+      password: 'TestPass123!',
+      confirmPassword: 'TestPass123!',
+      firstName: 'Contract',
+      lastName: 'Tester',
+      acceptedTerms: true,
+      acceptedPrivacy: true,
+    });
+    // Flat: `user` is a top-level field, NOT `result.data.user`.
+    expect(result.user).toBeDefined();
+    expect(typeof result.user.email).toBe('string');
+    expect(typeof result.accessToken).toBe('string');
+    expect(typeof result.idToken).toBe('string');
+    expect(typeof result.refreshToken).toBe('string');
+  });
+
+  it('authService.login returns flat AuthResponse with user + tokens', async () => {
+    // Register first so the login handler can recover the firstName/lastName
+    // from `registeredUsers` (Issue #142 mock fidelity).
+    await authService.register({
+      email: 'login@example.com',
+      password: 'TestPass123!',
+      confirmPassword: 'TestPass123!',
+      firstName: 'Login',
+      lastName: 'Tester',
+      acceptedTerms: true,
+      acceptedPrivacy: true,
+    });
+    const result = await authService.login({
+      email: 'login@example.com',
+      password: 'TestPass123!',
+    });
+    expect(result.user).toBeDefined();
+    expect(result.user.email).toBe('login@example.com');
+    expect(typeof result.accessToken).toBe('string');
+    expect(typeof result.idToken).toBe('string');
+    expect(typeof result.refreshToken).toBe('string');
+  });
+
+  it('authService.getCurrentUser returns the user inside a flat `user` field', async () => {
+    const registered = await authService.register({
+      email: 'me@example.com',
+      password: 'TestPass123!',
+      confirmPassword: 'TestPass123!',
+      firstName: 'Me',
+      lastName: 'Self',
+      acceptedTerms: true,
+      acceptedPrivacy: true,
+    });
+    // Tokens are auto-stored by `storeAuthTokens` inside the service.
+    expect(registered.user.email).toBe('me@example.com');
+
+    const me = await authService.getCurrentUser();
+    // `getCurrentUser` reads `response.data.user` — the flat envelope.
+    expect(me).toBeDefined();
+    expect(typeof me.email).toBe('string');
+  });
+
+  it('authService.verifyEmail returns a flat MessageResponse', async () => {
+    const result = await authService.verifyEmail('any-token');
+    expect(typeof result.message).toBe('string');
+  });
+
+  it('authService.requestPasswordReset returns a flat MessageResponse', async () => {
+    const result = await authService.requestPasswordReset('reset@example.com');
+    expect(typeof result.message).toBe('string');
+  });
+
+  it('authService.resetPassword returns a flat MessageResponse', async () => {
+    const result = await authService.resetPassword({
+      token: 'tok',
+      newPassword: 'NewPass123!',
+    });
+    expect(typeof result.message).toBe('string');
+  });
+
+  it('authService.refreshToken reads tokens from the FLAT refresh response', async () => {
+    // Ensure a session exists so getStoredRefreshToken() returns a value.
+    const registered = await authService.register({
+      email: 'refresh@example.com',
+      password: 'TestPass123!',
+      confirmPassword: 'TestPass123!',
+      firstName: 'Refresh',
+      lastName: 'Tester',
+      acceptedTerms: true,
+      acceptedPrivacy: true,
+    });
+    expect(registered.refreshToken).toBeDefined();
+
+    // Override the mock to return the EXACT real-backend wire shape:
+    //   { message, accessToken, idToken, expiresIn, requestId }
+    server.use(
+      http.post('*/auth/refresh', () =>
+        HttpResponse.json(
+          {
+            message: 'Tokens refreshed successfully',
+            accessToken: 'flat-access',
+            idToken: 'flat-id',
+            expiresIn: 3600,
+            requestId: 'r-1',
+          },
+          { status: 200 }
+        )
+      )
+    );
+
+    const result = await authService.refreshToken();
+    // Flat: tokens are top-level, NOT under `result.data.accessToken`.
+    expect(result.accessToken).toBe('flat-access');
+    expect(result.idToken).toBe('flat-id');
+  });
+});
+
+describe('API Envelope Contract — single-job CRUD', () => {
+  // GET /jobs/{jobId} and DELETE /jobs/{jobId} both return the FLAT
+  // envelope (createFlatResponse). The MSW handlers don't currently
+  // implement these — register them inline so the contract is locked.
+
+  it('GET /jobs/{jobId} body is FLAT (no `data` wrapper)', async () => {
+    server.use(
+      http.get('*/jobs/job-flat-1', () =>
+        HttpResponse.json(
+          {
+            jobId: 'job-flat-1',
+            userId: 'u',
+            status: 'COMPLETED',
+            filename: 'doc.txt',
+            createdAt: '2026-05-09T00:00:00Z',
+            requestId: 'r-1',
+          },
+          { status: 200 }
+        )
+      )
+    );
+    const response = await apiClient.get<{
+      jobId: string;
+      userId: string;
+      status: string;
+      data?: unknown;
+    }>('/jobs/job-flat-1');
+
+    expect(response.data.jobId).toBe('job-flat-1');
+    expect(response.data.userId).toBe('u');
+    expect(response.data.status).toBe('COMPLETED');
+    // Anti-assertion: no nested wrapper.
+    expect(response.data).not.toHaveProperty('data');
+  });
+
+  it('DELETE /jobs/{jobId} body is FLAT with `message` + `jobId` at top level', async () => {
+    server.use(
+      http.delete('*/jobs/job-del-1', () =>
+        HttpResponse.json(
+          {
+            message: 'Job job-del-1 deleted successfully',
+            jobId: 'job-del-1',
+            requestId: 'r-1',
+          },
+          { status: 200 }
+        )
+      )
+    );
+    const response = await apiClient.delete<{
+      message: string;
+      jobId: string;
+      data?: unknown;
+    }>('/jobs/job-del-1');
+
+    expect(response.data.message).toMatch(/deleted/);
+    expect(response.data.jobId).toBe('job-del-1');
+    expect(response.data).not.toHaveProperty('data');
   });
 });

--- a/frontend/src/mocks/__tests__/handlers.test.ts
+++ b/frontend/src/mocks/__tests__/handlers.test.ts
@@ -138,14 +138,16 @@ describe('resetState()', () => {
     });
 
     // Confirm at least one job is in the store.
+    // GET /jobs returns a flat array (mirrors the mock contract — see
+    // 2026-05-09 hotfix). No `data` envelope to peel off.
     const before = await fetch(`${API_URL}/jobs`).then((r) => r.json());
-    expect(before.data.length).toBeGreaterThan(0);
+    expect(before.length).toBeGreaterThan(0);
 
     // Reset.
     resetState();
 
     const after = await fetch(`${API_URL}/jobs`).then((r) => r.json());
-    expect(after.data.length).toBe(0);
+    expect(after.length).toBe(0);
   });
 });
 
@@ -301,25 +303,31 @@ describe('Translation pipeline (msw/node)', () => {
     expect(put.headers.get('etag')).toMatch(/^"mock-etag-/);
 
     // 3. translate
+    // 3. translate — flat StartTranslationApiResponse envelope
+    // (no `data` wrapper). The 2026-05-09 hotfix flipped the mock to
+    // mirror the real Lambda's shape; tests assert directly on the
+    // top-level fields.
     const start = await fetch(`${API_URL}/jobs/${jobId}/translate`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ targetLanguage: 'es', tone: 'neutral' }),
     }).then((r) => r.json());
-    expect(start.data.status).toBe('IN_PROGRESS');
+    expect(start.translationStatus).toBe('IN_PROGRESS');
 
-    // 4. poll status — instant mode → 4 polls reach 100%.
+    // 4. poll status — flat TranslationStatusApiResponse, instant mode
+    // → 4 polls reach 100%.
     let lastStatus = '';
     for (let i = 0; i < 4; i++) {
       const s = await fetch(`${API_URL}/jobs/${jobId}/translation-status`).then((r) => r.json());
-      lastStatus = s.data.status;
+      lastStatus = s.status;
     }
     expect(lastStatus).toBe('COMPLETED');
 
-    // 5. history
+    // 5. history — flat array (no envelope) so the History page can
+    // dereference `response.data` directly.
     const hist = await fetch(`${API_URL}/jobs`).then((r) => r.json());
-    expect(hist.data.length).toBe(1);
-    expect(hist.data[0].jobId).toBe(jobId);
+    expect(hist.length).toBe(1);
+    expect(hist[0].jobId).toBe(jobId);
 
     // 6. download
     const dl = await fetch(`${API_URL}/jobs/${jobId}/download`);

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -235,7 +235,10 @@ const authHandlers: HttpHandler[] = [
     return HttpResponse.json({ user, ...tokens }, { status: 200 });
   }),
 
-  // POST /auth/refresh
+  // POST /auth/refresh — mirrors the real Lambda's flat shape (no
+  // `{data: ...}` wrapper). The 2026-05-09 hotfix flattened the real
+  // backend's response so frontend reads `response.data.accessToken`
+  // directly; the mock matches that contract here.
   http.post(buildPath('/auth/refresh'), async ({ request }) => {
     const body = (await request.json().catch(() => ({}))) as Record<string, unknown>;
     const refreshToken = typeof body.refreshToken === 'string' ? body.refreshToken : undefined;
@@ -249,7 +252,10 @@ const authHandlers: HttpHandler[] = [
     // never get stuck behind a stale token from a previous page load.
     const user = sessions.get(refreshToken) ?? buildMockUser({});
     const tokens = issueTokens(user);
-    return HttpResponse.json(tokens, { status: 200 });
+    return HttpResponse.json(
+      { message: 'Tokens refreshed successfully', ...tokens },
+      { status: 200 }
+    );
   }),
 
   // POST /auth/logout
@@ -334,9 +340,17 @@ const authHandlers: HttpHandler[] = [
 //   GET  /jobs                                    — job history
 //   GET  /jobs/:jobId/download                    — download translated text
 //
-// All responses are wrapped in `{ data: T }` to match the existing
-// frontend contract (translationService.ts:175, 190, 203, 214 all
-// dereference `response.data.data`).
+// Wire-shape policy (2026-05-09 hotfix):
+//   Mock bodies MIRROR the real Lambda response shape, not the frontend's
+//   reader expectation. POST /jobs/upload uniquely returns
+//   `{message, data: PresignedUrlResponse}` because that is what the live
+//   `uploadRequest` Lambda emits; every other job-side endpoint returns
+//   a flat object — no `{data: ...}` wrapper. Previously the mock wrapped
+//   everything in `{data: ...}` to match a frontend bug, hiding the
+//   divergence until the bug surfaced on the deployed walkthrough. The
+//   mock is now the single source of truth for the wire contract: any
+//   future drift between the mock and the real backend will reproduce
+//   in vitest before it reaches production.
 //
 // On-demand simulation policy (Phase 4) lives inside the status
 // handler — there are NO setInterval/setTimeout calls. The status
@@ -448,10 +462,28 @@ function toWireStatus(state: JobState): string {
 }
 
 /**
- * Project the closure-scoped `JobState` to the wire shape the
- * frontend expects (`TranslationJob` from translationService.ts:14-38).
+ * Project the closure-scoped `JobState` to the wire shape the real
+ * `getTranslationStatus` Lambda returns (the canonical
+ * TranslationStatusApiResponse from @lfmt/shared-types).
+ *
+ * The shape MUST mirror the real Lambda — including the field-name
+ * choice `chunksTranslated` (NOT `completedChunks`). Mismatches here
+ * are exactly what the 2026-05-09 hotfix is preventing: the mock used
+ * to wrap responses in `{data: ...}` and use frontend-side field names,
+ * which masked a class of demo-blocking bugs.
  */
-function toWireJob(state: JobState): Record<string, unknown> {
+function toWireTranslationStatus(state: JobState): Record<string, unknown> {
+  const total = state.totalChunks;
+  const done = state.completedChunks;
+  const progressPercentage = total > 0 ? Math.round((done / total) * 100) : 0;
+  const wireStatus = toWireStatus(state);
+  // Mock translationStatus mirrors job.status for the simulated lifecycle:
+  //   uploaded → NOT_STARTED, translating → IN_PROGRESS, completed → COMPLETED.
+  let translationStatus = 'NOT_STARTED';
+  if (state.status === 'translating') translationStatus = 'IN_PROGRESS';
+  else if (state.status === 'completed') translationStatus = 'COMPLETED';
+  else if (state.status === 'failed') translationStatus = 'TRANSLATION_FAILED';
+
   return {
     jobId: state.jobId,
     // R1: echo the userId captured on the job at upload time. Do NOT
@@ -464,10 +496,40 @@ function toWireJob(state: JobState): Record<string, unknown> {
     // size instead of "0 Bytes".
     fileSize: state.fileSize,
     contentType: 'text/plain',
-    status: toWireStatus(state),
+    status: wireStatus,
+    translationStatus,
     targetLanguage: state.targetLang,
     // Issue #143: was hardcoded to 'neutral'; now echoes whatever the
     // translate request supplied (or the wizard's neutral default).
+    tone: state.tone,
+    totalChunks: total,
+    chunksTranslated: done,
+    progressPercentage,
+    createdAt: state.createdAt,
+    translationStartedAt: state.translateStartedAt
+      ? new Date(state.translateStartedAt).toISOString()
+      : undefined,
+    translationCompletedAt: state.completedAt,
+  };
+}
+
+/**
+ * Project the closure-scoped `JobState` to the History page's expected
+ * `TranslationJob` shape (the type defined in
+ * frontend/src/services/translationService.ts). The dashboard list
+ * endpoint does NOT exist on the live backend yet — this projection is
+ * only consumed by the in-memory mock; see the KNOWN-LIMITATION note on
+ * `getTranslationJobs` in translationService.ts.
+ */
+function toWireJobListItem(state: JobState): Record<string, unknown> {
+  return {
+    jobId: state.jobId,
+    userId: state.userId,
+    fileName: state.fileName,
+    fileSize: state.fileSize,
+    contentType: 'text/plain',
+    status: toWireStatus(state),
+    targetLanguage: state.targetLang,
     tone: state.tone,
     totalChunks: state.totalChunks,
     completedChunks: state.completedChunks,
@@ -608,8 +670,14 @@ const translationHandlers: HttpHandler[] = [
     }
     const uploadUrl = `${pageOrigin}/__mock-s3/${jobId}`;
 
+    // Mirrors the real PresignedUrlApiResponse envelope from
+    // @lfmt/shared-types: POST /jobs/upload is the ONLY job-side
+    // endpoint that wraps in `{message, data}`. Including the
+    // `message` field here keeps the mock the canonical contract for
+    // downstream consumers / contract tests.
     return HttpResponse.json(
       {
+        message: 'Upload URL generated successfully',
         data: {
           uploadUrl,
           fileId: jobId,
@@ -670,7 +738,21 @@ const translationHandlers: HttpHandler[] = [
     job.statusPollCount = 0;
     jobs.set(jobId, job);
 
-    return HttpResponse.json({ data: toWireJob(job) }, { status: 200 });
+    // Mirrors the real `startTranslation` Lambda's flat shape
+    // (StartTranslationApiResponse). Field names match exactly so a
+    // future wire-shape regression in the mock will surface in vitest
+    // before it reaches production.
+    return HttpResponse.json(
+      {
+        message: 'Translation started successfully',
+        jobId: job.jobId,
+        translationStatus: 'IN_PROGRESS',
+        targetLanguage: job.targetLang,
+        totalChunks: job.totalChunks,
+        chunksTranslated: 0,
+      },
+      { status: 200 }
+    );
   }),
 
   // GET /jobs/:jobId/translation-status — on-demand simulation tick.
@@ -701,13 +783,20 @@ const translationHandlers: HttpHandler[] = [
       }
       jobs.set(jobId, job);
     }
-    return HttpResponse.json({ data: toWireJob(job) }, { status: 200 });
+    // Flat envelope (no `data` wrapper) — mirrors the real
+    // getTranslationStatus Lambda. The response uses the canonical
+    // TranslationStatusApiResponse shape from @lfmt/shared-types.
+    return HttpResponse.json(toWireTranslationStatus(job), { status: 200 });
   }),
 
   // GET /jobs — list all jobs in the in-memory store.
+  // The real backend does not yet expose this route (see KNOWN-LIMITATION
+  // note on translationService.getTranslationJobs); the mock projects the
+  // History page's expected shape as a flat array so behaviour is
+  // demoable end-to-end.
   http.get(buildPath('/jobs'), () => {
-    const list = Array.from(jobs.values()).map(toWireJob);
-    return HttpResponse.json({ data: list }, { status: 200 });
+    const list = Array.from(jobs.values()).map(toWireJobListItem);
+    return HttpResponse.json(list, { status: 200 });
   }),
 
   // GET /jobs/:jobId/download — return simulated translated text.

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -340,17 +340,25 @@ const authHandlers: HttpHandler[] = [
 //   GET  /jobs                                    — job history
 //   GET  /jobs/:jobId/download                    — download translated text
 //
-// Wire-shape policy (2026-05-09 hotfix):
+// Wire-shape policy (2026-05-09 hotfix, refined per OMC R1 M1-arch on PR #218):
 //   Mock bodies MIRROR the real Lambda response shape, not the frontend's
 //   reader expectation. POST /jobs/upload uniquely returns
 //   `{message, data: PresignedUrlResponse}` because that is what the live
 //   `uploadRequest` Lambda emits; every other job-side endpoint returns
 //   a flat object — no `{data: ...}` wrapper. Previously the mock wrapped
 //   everything in `{data: ...}` to match a frontend bug, hiding the
-//   divergence until the bug surfaced on the deployed walkthrough. The
-//   mock is now the single source of truth for the wire contract: any
-//   future drift between the mock and the real backend will reproduce
-//   in vitest before it reaches production.
+//   divergence until the bug surfaced on the deployed walkthrough.
+//
+//   The mock is NOT the source of truth — the SSoT for the wire contract
+//   is the set of `*ApiResponse` interfaces in `@lfmt/shared-types`
+//   (`TranslationStatusApiResponse`, `StartTranslationApiResponse`,
+//   `PresignedUrlApiResponse`, etc.). Both the real Lambda and the mock
+//   handlers below import those types so a single rename / addition flows
+//   to both implementations at compile time. The mock's job is to
+//   FAITHFULLY MIRROR that contract; the contract test in
+//   `frontend/src/__tests__/apiEnvelopeContract.test.ts` is what guards
+//   the mirror. If the mock and the real backend ever drift, that test
+//   will fail in vitest before the divergence reaches production.
 //
 // On-demand simulation policy (Phase 4) lives inside the status
 // handler — there are NO setInterval/setTimeout calls. The status

--- a/frontend/src/pages/__tests__/TranslationUpload.test.tsx
+++ b/frontend/src/pages/__tests__/TranslationUpload.test.tsx
@@ -403,17 +403,16 @@ describe('TranslationUpload', () => {
         updatedAt: new Date().toISOString(),
       });
 
+      // PR #218 OMC R1 H1-cq: startTranslation returns the narrow
+      // StartTranslationResult shape (no hollow sentinel TranslationJob
+      // fields). Mirror that contract in the mock.
       vi.mocked(translationService.startTranslation).mockResolvedValue({
         jobId: 'test-job-123',
-        userId: 'user-123',
-        fileName: 'test-document.txt',
-        fileSize: 12,
-        contentType: 'text/plain',
         status: 'IN_PROGRESS',
         targetLanguage: 'es',
-        tone: 'formal',
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
+        totalChunks: 1,
+        completedChunks: 0,
+        message: 'Translation started successfully',
       });
 
       const submitButton = screen.getByRole('button', { name: /Submit & Start Translation/i });
@@ -947,12 +946,14 @@ describe('TranslationUpload', () => {
         ...mockChunkedJob,
         jobId: 'await-job',
       });
+      // PR #218 OMC R1 H1-cq: narrow StartTranslationResult shape.
       vi.mocked(translationService.startTranslation).mockResolvedValue({
-        ...mockChunkedJob,
         jobId: 'await-job',
         status: 'IN_PROGRESS',
         targetLanguage: 'es',
-        tone: 'formal',
+        totalChunks: 1,
+        completedChunks: 0,
+        message: 'Translation started successfully',
       });
 
       await user.click(screen.getByRole('button', { name: /Submit & Start Translation/i }));
@@ -1032,11 +1033,14 @@ describe('TranslationUpload', () => {
           })
       );
 
+      // PR #218 OMC R1 H1-cq: narrow StartTranslationResult shape.
       vi.mocked(translationService.startTranslation).mockResolvedValue({
-        ...mockChunkedJob,
+        jobId: mockChunkedJob.jobId,
         status: 'IN_PROGRESS',
         targetLanguage: 'es',
-        tone: 'formal',
+        totalChunks: 1,
+        completedChunks: 0,
+        message: 'Translation started successfully',
       });
 
       await user.click(screen.getByRole('button', { name: /Submit & Start Translation/i }));

--- a/frontend/src/services/__tests__/translationService.test.ts
+++ b/frontend/src/services/__tests__/translationService.test.ts
@@ -1513,3 +1513,199 @@ describe('TranslationService - uploadAndAwaitChunked', () => {
     ).rejects.toThrow('Network Error');
   });
 });
+
+// ---------------------------------------------------------------------------
+// PR #218 OMC R1 follow-ups
+//
+// C1 (merge blocker): exhaustive coverage of the nullish-coalescing
+//   fallback paths inside `getJobStatus` (and the equivalent shape
+//   handling in `startTranslation`). The hotfix introduced these
+//   fallbacks and they were not branch-covered, dropping the per-file
+//   threshold below the project minimum.
+//
+// H1-cq: pin the narrow `StartTranslationResult` return shape to lock
+//   out a future regression that re-introduces hollow sentinel fields.
+//
+// C4-test: assert mid-translation (non-zero, non-terminal)
+//   `chunksTranslated → completedChunks` translation works correctly,
+//   so the seam doesn't drop intermediate progress.
+// ---------------------------------------------------------------------------
+
+describe('TranslationService - getJobStatus — wire fallback coverage (C1)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getAuthToken as ReturnType<typeof vi.fn>).mockReturnValue('mock-token-123');
+  });
+
+  // The wire shape the real Lambda emits is intentionally permissive:
+  // `userId`, `fileName`, `fileSize`, `contentType`, `tone`,
+  // `chunksTranslated`, `totalChunks`, `targetLanguage`, `createdAt`,
+  // `translationCompletedAt`, and `error` are all optional. The mapper
+  // (`toTranslationJob`) defends against each omission individually —
+  // each branch is covered below.
+
+  it('falls back to "" when wire omits userId / fileName / contentType', async () => {
+    mockedApiClient.get.mockResolvedValueOnce({
+      data: {
+        jobId: 'job-1',
+        status: 'PENDING',
+        // userId, fileName, contentType all absent.
+      },
+    });
+    const job = await getJobStatus('job-1');
+    expect(job.userId).toBe('');
+    expect(job.fileName).toBe('');
+    expect(job.contentType).toBe('');
+  });
+
+  it('falls back to 0 when wire omits fileSize', async () => {
+    mockedApiClient.get.mockResolvedValueOnce({
+      data: { jobId: 'job-1', status: 'PENDING' },
+    });
+    const job = await getJobStatus('job-1');
+    expect(job.fileSize).toBe(0);
+  });
+
+  it('falls back to a synthesized ISO timestamp when wire omits createdAt', async () => {
+    mockedApiClient.get.mockResolvedValueOnce({
+      data: { jobId: 'job-1', status: 'PENDING' },
+    });
+    const job = await getJobStatus('job-1');
+    // The exact value depends on wall-clock; assert shape only.
+    expect(job.createdAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+    expect(job.updatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+  });
+
+  it('uses createdAt as updatedAt when wire omits translationCompletedAt', async () => {
+    const created = '2026-05-08T20:00:00.000Z';
+    mockedApiClient.get.mockResolvedValueOnce({
+      data: { jobId: 'job-1', status: 'PENDING', createdAt: created },
+    });
+    const job = await getJobStatus('job-1');
+    expect(job.updatedAt).toBe(created);
+    expect(job.completedAt).toBeUndefined();
+  });
+
+  it('reads errorMessage from the wire `error` field when present', async () => {
+    mockedApiClient.get.mockResolvedValueOnce({
+      data: {
+        jobId: 'job-1',
+        status: 'TRANSLATION_FAILED',
+        error: 'Gemini API rate limit exceeded',
+      },
+    });
+    const job = await getJobStatus('job-1');
+    expect(job.errorMessage).toBe('Gemini API rate limit exceeded');
+  });
+
+  it('leaves errorMessage undefined when wire omits the error field', async () => {
+    mockedApiClient.get.mockResolvedValueOnce({
+      data: { jobId: 'job-1', status: 'COMPLETED' },
+    });
+    const job = await getJobStatus('job-1');
+    expect(job.errorMessage).toBeUndefined();
+  });
+
+  it('translates chunksTranslated → completedChunks for mid-translation values (C4)', async () => {
+    // Pre-fix C4: the seam was previously only exercised at the
+    // boundary values (0 and totalChunks). A regression that swapped
+    // the field names mid-translation (e.g. `body.completedChunks`)
+    // would silently render "Translating: 0 / 7" until the job hit
+    // 100%. Lock the intermediate-progress contract.
+    mockedApiClient.get.mockResolvedValueOnce({
+      data: {
+        jobId: 'job-1',
+        status: 'IN_PROGRESS',
+        translationStatus: 'IN_PROGRESS',
+        totalChunks: 7,
+        chunksTranslated: 3,
+      },
+    });
+    const job = await getJobStatus('job-1');
+    expect(job.completedChunks).toBe(3);
+    expect(job.totalChunks).toBe(7);
+    // Anti-assertion: the wire field name must NOT leak through onto
+    // the frontend type — that would be the regression we are guarding.
+    expect(job).not.toHaveProperty('chunksTranslated');
+  });
+});
+
+describe('TranslationService - startTranslation — narrow return shape (H1-cq)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getAuthToken as ReturnType<typeof vi.fn>).mockReturnValue('mock-token-123');
+  });
+
+  it('returns ONLY the narrow StartTranslationResult fields (no hollow sentinels)', async () => {
+    // Pre-fix H1-cq: the result was a fabricated TranslationJob with
+    // five hollow sentinel fields (`userId: ''`, `fileName: ''`,
+    // `fileSize: 0`, `contentType: ''`, ...). Narrowing the return type
+    // removes the lie at the type level — assert at runtime that the
+    // sentinels are gone so a future maintainer cannot bring them back
+    // without breaking this test.
+    mockedApiClient.post.mockResolvedValueOnce({
+      data: {
+        message: 'Translation started successfully',
+        jobId: 'job-abc',
+        translationStatus: 'IN_PROGRESS',
+        targetLanguage: 'es',
+        totalChunks: 5,
+        chunksTranslated: 0,
+        executionArn: 'arn:aws:states:us-east-1:000:execution:lfmt:abc',
+      },
+    });
+
+    const result = await startTranslation('job-abc', { targetLanguage: 'es', tone: 'neutral' });
+
+    // Exact-match contract: no hollow sentinels permitted.
+    expect(Object.keys(result).sort()).toEqual(
+      [
+        'jobId',
+        'status',
+        'targetLanguage',
+        'totalChunks',
+        'completedChunks',
+        'message',
+        'executionArn',
+      ].sort()
+    );
+    expect(result).not.toHaveProperty('userId');
+    expect(result).not.toHaveProperty('fileName');
+    expect(result).not.toHaveProperty('fileSize');
+    expect(result).not.toHaveProperty('contentType');
+    expect(result).not.toHaveProperty('createdAt');
+
+    // And the values themselves are the wire values, mapped by name.
+    expect(result.jobId).toBe('job-abc');
+    expect(result.status).toBe('IN_PROGRESS');
+    expect(result.targetLanguage).toBe('es');
+    expect(result.totalChunks).toBe(5);
+    expect(result.completedChunks).toBe(0);
+    expect(result.message).toBe('Translation started successfully');
+    expect(result.executionArn).toBe('arn:aws:states:us-east-1:000:execution:lfmt:abc');
+  });
+
+  it('omits executionArn when the wire response does not include it', async () => {
+    // The Lambda includes executionArn in dev for tracing but the field
+    // is optional in the shared DTO (StartTranslationApiResponse). The
+    // narrow result must not synthesize a placeholder value.
+    mockedApiClient.post.mockResolvedValueOnce({
+      data: {
+        message: 'Translation started successfully',
+        jobId: 'job-xyz',
+        translationStatus: 'IN_PROGRESS',
+        targetLanguage: 'fr',
+        totalChunks: 2,
+        chunksTranslated: 0,
+        // executionArn intentionally absent
+      },
+    });
+
+    const result = await startTranslation('job-xyz', {
+      targetLanguage: 'fr',
+      tone: 'neutral',
+    });
+
+    expect(result.executionArn).toBeUndefined();
+  });
+});

--- a/frontend/src/services/__tests__/translationService.test.ts
+++ b/frontend/src/services/__tests__/translationService.test.ts
@@ -803,20 +803,18 @@ describe('TranslationService - startTranslation', () => {
         tone: 'formal',
       };
 
+      // Wire shape mirrors the real `startTranslation` Lambda
+      // (StartTranslationApiResponse): FLAT body, no `data` wrapper, and
+      // the field name is `chunksTranslated` rather than the
+      // frontend-side `completedChunks`.
       const mockResponse = {
         data: {
-          data: {
-            jobId: 'job-123',
-            userId: 'user-456',
-            status: 'CHUNKING' as const,
-            targetLanguage: 'es' as const,
-            tone: 'formal' as const,
-            fileName: 'test.txt',
-            fileSize: 1024,
-            contentType: 'text/plain',
-            createdAt: '2024-10-31T12:00:00Z',
-            updatedAt: '2024-10-31T12:00:00Z',
-          },
+          message: 'Translation started successfully',
+          jobId: 'job-123',
+          translationStatus: 'IN_PROGRESS',
+          targetLanguage: 'es',
+          totalChunks: 4,
+          chunksTranslated: 0,
         },
       };
 
@@ -831,9 +829,11 @@ describe('TranslationService - startTranslation', () => {
         expect.stringContaining(`/jobs/${jobId}/translate`),
         request
       );
-      expect(result.status).toBe('CHUNKING');
+      expect(result.jobId).toBe('job-123');
+      expect(result.status).toBe('IN_PROGRESS');
       expect(result.targetLanguage).toBe('es');
-      expect(result.tone).toBe('formal');
+      expect(result.totalChunks).toBe(4);
+      expect(result.completedChunks).toBe(0);
     });
   });
 
@@ -901,26 +901,29 @@ describe('TranslationService - getJobStatus', () => {
 
   describe('Success Scenarios', () => {
     it('should fetch job status successfully', async () => {
-      // Arrange
+      // Arrange — wire shape mirrors the real getTranslationStatus Lambda
+      // (TranslationStatusApiResponse from @lfmt/shared-types): FLAT body
+      // (no `data` wrapper) and the field name is `chunksTranslated`,
+      // not `completedChunks`. The frontend service translates at the
+      // boundary back into the local `TranslationJob` shape.
       const jobId = 'job-123';
-      const mockJob: TranslationJob = {
+      const mockWire = {
         jobId: 'job-123',
         userId: 'user-456',
         status: 'IN_PROGRESS',
+        translationStatus: 'IN_PROGRESS',
         fileName: 'test.txt',
         fileSize: 1024,
         contentType: 'text/plain',
         targetLanguage: 'es',
-        tone: 'neutral',
+        tone: 'neutral' as const,
         totalChunks: 10,
-        completedChunks: 5,
+        chunksTranslated: 5,
+        progressPercentage: 50,
         createdAt: '2024-10-31T12:00:00Z',
-        updatedAt: '2024-10-31T12:05:00Z',
       };
 
-      mockedApiClient.get.mockResolvedValueOnce({
-        data: { data: mockJob },
-      });
+      mockedApiClient.get.mockResolvedValueOnce({ data: mockWire });
 
       // Act
       const result = await getJobStatus(jobId);
@@ -930,40 +933,42 @@ describe('TranslationService - getJobStatus', () => {
       expect(mockedApiClient.get).toHaveBeenCalledWith(
         expect.stringContaining(`/jobs/${jobId}/translation-status`)
       );
-      expect(result).toEqual(mockJob);
+      expect(result.jobId).toBe('job-123');
+      expect(result.status).toBe('IN_PROGRESS');
       expect(result.completedChunks).toBe(5);
       expect(result.totalChunks).toBe(10);
+      expect(result.fileSize).toBe(1024);
+      expect(result.tone).toBe('neutral');
     });
 
     it('should handle COMPLETED status', async () => {
       // Arrange
       const jobId = 'job-123';
-      const mockJob: TranslationJob = {
+      const mockWire = {
         jobId: 'job-123',
         userId: 'user-456',
         status: 'COMPLETED',
+        translationStatus: 'COMPLETED',
         fileName: 'test.txt',
         fileSize: 1024,
         contentType: 'text/plain',
         targetLanguage: 'es',
-        tone: 'neutral',
+        tone: 'neutral' as const,
         totalChunks: 10,
-        completedChunks: 10,
+        chunksTranslated: 10,
+        progressPercentage: 100,
         createdAt: '2024-10-31T12:00:00Z',
-        updatedAt: '2024-10-31T12:30:00Z',
-        completedAt: '2024-10-31T12:30:00Z',
+        translationCompletedAt: '2024-10-31T12:30:00Z',
       };
 
-      mockedApiClient.get.mockResolvedValueOnce({
-        data: { data: mockJob },
-      });
+      mockedApiClient.get.mockResolvedValueOnce({ data: mockWire });
 
       // Act
       const result = await getJobStatus(jobId);
 
       // Assert
       expect(result.status).toBe('COMPLETED');
-      expect(result.completedAt).toBeDefined();
+      expect(result.completedAt).toBe('2024-10-31T12:30:00Z');
     });
   });
 
@@ -1027,9 +1032,11 @@ describe('TranslationService - getTranslationJobs', () => {
         },
       ];
 
-      mockedApiClient.get.mockResolvedValueOnce({
-        data: { data: mockJobs },
-      });
+      // Wire shape mirrors the mock contract: a flat array, no
+      // `{data: ...}` wrapper. (As of 2026-05-09 the live backend has
+      // no GET /jobs route — see KNOWN-LIMITATION on
+      // translationService.getTranslationJobs.)
+      mockedApiClient.get.mockResolvedValueOnce({ data: mockJobs });
 
       // Act
       const result = await getTranslationJobs();
@@ -1042,10 +1049,8 @@ describe('TranslationService - getTranslationJobs', () => {
     });
 
     it('should return empty array when no jobs exist', async () => {
-      // Arrange
-      mockedApiClient.get.mockResolvedValueOnce({
-        data: { data: [] },
-      });
+      // Arrange — flat array (no wrapper), per the contract above.
+      mockedApiClient.get.mockResolvedValueOnce({ data: [] });
 
       // Act
       const result = await getTranslationJobs();
@@ -1263,6 +1268,27 @@ describe('TranslationService - uploadAndAwaitChunked', () => {
     updatedAt: '2024-10-31T12:00:00Z',
   };
 
+  // Build the flat TranslationStatusApiResponse wire shape that the real
+  // `getTranslationStatus` Lambda emits. The 2026-05-09 hotfix collapsed
+  // the previous `{data: { data: TranslationJob }}` envelope to a flat
+  // body and mapped `chunksTranslated` (DDB column) ↔ `completedChunks`
+  // (frontend type) at the service seam — all of which is exercised here.
+  const buildWireStatus = (status: string) => ({
+    jobId: baseJob.jobId,
+    userId: baseJob.userId,
+    fileName: baseJob.fileName,
+    fileSize: baseJob.fileSize,
+    contentType: baseJob.contentType,
+    status,
+    translationStatus: status,
+    targetLanguage: baseJob.targetLanguage,
+    tone: baseJob.tone,
+    totalChunks: 0,
+    chunksTranslated: 0,
+    progressPercentage: 0,
+    createdAt: baseJob.createdAt,
+  });
+
   beforeEach(() => {
     vi.useFakeTimers();
     vi.clearAllMocks();
@@ -1297,9 +1323,7 @@ describe('TranslationService - uploadAndAwaitChunked', () => {
     });
     mockedAxios.put.mockResolvedValueOnce({ data: null });
 
-    mockedApiClient.get.mockResolvedValueOnce({
-      data: { data: { ...baseJob, status: 'CHUNKED' } },
-    });
+    mockedApiClient.get.mockResolvedValueOnce({ data: buildWireStatus('CHUNKED') });
 
     const result = await uploadAndAwaitChunked(
       { file: mockFile, legalAttestation: mockLegalAttestation },
@@ -1323,11 +1347,12 @@ describe('TranslationService - uploadAndAwaitChunked', () => {
     });
     mockedAxios.put.mockResolvedValueOnce({ data: null });
 
-    // Three polls: PENDING, CHUNKING, CHUNKED
+    // Three polls: PENDING, CHUNKING, CHUNKED — flat wire shape per
+    // TranslationStatusApiResponse (the 2026-05-09 hotfix contract).
     mockedApiClient.get
-      .mockResolvedValueOnce({ data: { data: { ...baseJob, status: 'PENDING' } } })
-      .mockResolvedValueOnce({ data: { data: { ...baseJob, status: 'CHUNKING' } } })
-      .mockResolvedValueOnce({ data: { data: { ...baseJob, status: 'CHUNKED' } } });
+      .mockResolvedValueOnce({ data: buildWireStatus('PENDING') })
+      .mockResolvedValueOnce({ data: buildWireStatus('CHUNKING') })
+      .mockResolvedValueOnce({ data: buildWireStatus('CHUNKED') });
 
     const resultPromise = uploadAndAwaitChunked(
       { file: mockFile, legalAttestation: mockLegalAttestation },
@@ -1356,7 +1381,7 @@ describe('TranslationService - uploadAndAwaitChunked', () => {
     mockedAxios.put.mockResolvedValueOnce({ data: null });
 
     mockedApiClient.get.mockResolvedValueOnce({
-      data: { data: { ...baseJob, status: 'CHUNKING_FAILED' } },
+      data: buildWireStatus('CHUNKING_FAILED'),
     });
 
     await expect(
@@ -1384,7 +1409,7 @@ describe('TranslationService - uploadAndAwaitChunked', () => {
     mockedAxios.put.mockResolvedValueOnce({ data: null });
 
     mockedApiClient.get.mockResolvedValueOnce({
-      data: { data: { ...baseJob, status: 'FAILED' } },
+      data: buildWireStatus('FAILED'),
     });
 
     await expect(
@@ -1410,7 +1435,7 @@ describe('TranslationService - uploadAndAwaitChunked', () => {
 
     // Always return PENDING so the loop never exits via success.
     mockedApiClient.get.mockResolvedValue({
-      data: { data: { ...baseJob, status: 'PENDING' } },
+      data: buildWireStatus('PENDING'),
     });
 
     const resultPromise = uploadAndAwaitChunked(
@@ -1443,8 +1468,8 @@ describe('TranslationService - uploadAndAwaitChunked', () => {
     mockedAxios.put.mockResolvedValueOnce({ data: null });
 
     mockedApiClient.get
-      .mockResolvedValueOnce({ data: { data: { ...baseJob, status: 'CHUNKING' } } })
-      .mockResolvedValueOnce({ data: { data: { ...baseJob, status: 'CHUNKED' } } });
+      .mockResolvedValueOnce({ data: buildWireStatus('CHUNKING') })
+      .mockResolvedValueOnce({ data: buildWireStatus('CHUNKED') });
 
     const onPollTick = vi.fn();
 

--- a/frontend/src/services/mappers/__tests__/translationJobMapper.test.ts
+++ b/frontend/src/services/mappers/__tests__/translationJobMapper.test.ts
@@ -1,0 +1,107 @@
+/**
+ * translationJobMapper unit tests.
+ *
+ * Pins the wire ↔ frontend field-name translation (architect M3 on PR #218).
+ * The mapper is the single audit point for "how does the SPA decode a
+ * backend job record?" — these tests lock that contract.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { toTranslationJob, type TranslationJobWire } from '../translationJobMapper';
+
+describe('translationJobMapper.toTranslationJob', () => {
+  const FIXED_NOW = '2026-05-09T00:00:00.000Z';
+
+  it('translates `chunksTranslated` (wire) into `completedChunks` (frontend)', () => {
+    const wire: TranslationJobWire = {
+      jobId: 'job-1',
+      status: 'IN_PROGRESS',
+      chunksTranslated: 7,
+      totalChunks: 10,
+    };
+    const job = toTranslationJob(wire, FIXED_NOW);
+
+    // The architectural reason this mapper exists — lock it.
+    expect(job.completedChunks).toBe(7);
+    expect(job.totalChunks).toBe(10);
+    // Frontend type does not surface the legacy backend field name —
+    // a future regression that re-introduces `chunksTranslated` on the
+    // frontend type would break this anti-assertion.
+    expect(job).not.toHaveProperty('chunksTranslated');
+  });
+
+  it('preserves the wire status string verbatim (no enum coercion)', () => {
+    // The mapper trusts the wire status — coercion would mask a real
+    // backend bug. This contract is enforced separately in the
+    // `apiEnvelopeContract` tests.
+    const wire: TranslationJobWire = {
+      jobId: 'job-1',
+      status: 'CHUNKED',
+    };
+    expect(toTranslationJob(wire, FIXED_NOW).status).toBe('CHUNKED');
+  });
+
+  it('falls back to "" / 0 / now when optional fields are omitted', () => {
+    const wire: TranslationJobWire = {
+      jobId: 'job-1',
+      status: 'PENDING',
+    };
+    const job = toTranslationJob(wire, FIXED_NOW);
+
+    expect(job.userId).toBe('');
+    expect(job.fileName).toBe('');
+    expect(job.fileSize).toBe(0);
+    expect(job.contentType).toBe('');
+    expect(job.createdAt).toBe(FIXED_NOW);
+    expect(job.updatedAt).toBe(FIXED_NOW);
+  });
+
+  it('prefers `translationCompletedAt` for `completedAt` / `updatedAt` when present', () => {
+    const completed = '2026-05-09T01:00:00.000Z';
+    const created = '2026-05-09T00:30:00.000Z';
+    const job = toTranslationJob(
+      {
+        jobId: 'job-1',
+        status: 'COMPLETED',
+        createdAt: created,
+        translationCompletedAt: completed,
+      },
+      FIXED_NOW
+    );
+    expect(job.completedAt).toBe(completed);
+    expect(job.updatedAt).toBe(completed);
+    expect(job.createdAt).toBe(created);
+  });
+
+  it('maps `error` (wire) into `errorMessage` (frontend), with `errorMessage` (wire) as a secondary fallback', () => {
+    const fromError = toTranslationJob(
+      { jobId: 'j', status: 'TRANSLATION_FAILED', error: 'rate limited' },
+      FIXED_NOW
+    );
+    expect(fromError.errorMessage).toBe('rate limited');
+
+    const fromMessage = toTranslationJob(
+      { jobId: 'j', status: 'FAILED', errorMessage: 'fallback' },
+      FIXED_NOW
+    );
+    expect(fromMessage.errorMessage).toBe('fallback');
+  });
+
+  it('passes through `targetLanguage`, `tone`, `failedChunks` verbatim', () => {
+    const job = toTranslationJob(
+      {
+        jobId: 'j',
+        status: 'IN_PROGRESS',
+        targetLanguage: 'es',
+        tone: 'formal',
+        failedChunks: 2,
+        chunksTranslated: 0,
+        totalChunks: 5,
+      },
+      FIXED_NOW
+    );
+    expect(job.targetLanguage).toBe('es');
+    expect(job.tone).toBe('formal');
+    expect(job.failedChunks).toBe(2);
+  });
+});

--- a/frontend/src/services/mappers/translationJobMapper.ts
+++ b/frontend/src/services/mappers/translationJobMapper.ts
@@ -1,0 +1,88 @@
+/**
+ * Translation job wire ↔ frontend mapper.
+ *
+ * The backend persists chunk progress under the field name
+ * `chunksTranslated` (mirroring the DDB column) while the frontend's
+ * `TranslationJob` shape uses `completedChunks`. Both seams need the
+ * same translation; pre-PR-#218 the logic was duplicated:
+ *
+ *   - `translationService.getJobStatus` (wire → TranslationJob)
+ *   - `mocks/handlers.ts.toWireJobListItem` and `toWireTranslationStatus`
+ *     (state → wire) — the in-memory mock contract
+ *
+ * Per architect M3 review on PR #218: extract the translation seam into
+ * a single utility so a future renaming of either field updates ONE
+ * implementation. The mock and the real wire contract still differ on
+ * other fields (the mock lacks `userId` rich semantics, etc.) — only
+ * the chunk-progress translation is hoisted here, not the entire
+ * projection. KISS / YAGNI.
+ */
+
+import type { TranslationJobStatus } from '@lfmt/shared-types';
+import type { TranslationJob } from '../translationService';
+
+/**
+ * Minimal subset of the `TranslationStatusApiResponse` (and its mock
+ * parallel) that the mapper actually reads. Defined locally so the
+ * mapper is decoupled from the shared-types module shape — the wire
+ * DTO can grow new fields without forcing a touch here, and the mock
+ * can add internal scaffolding without exposing it through the wire
+ * boundary type.
+ */
+export interface TranslationJobWire {
+  jobId: string;
+  userId?: string;
+  fileName?: string;
+  fileSize?: number;
+  contentType?: string;
+  status: string;
+  /** Backend field name — DDB column. Must NOT be renamed without coordinated frontend update. */
+  chunksTranslated?: number;
+  totalChunks?: number;
+  failedChunks?: number;
+  targetLanguage?: string;
+  tone?: 'formal' | 'informal' | 'neutral';
+  createdAt?: string;
+  updatedAt?: string;
+  translationCompletedAt?: string;
+  completedAt?: string;
+  error?: string;
+  errorMessage?: string;
+}
+
+/**
+ * Project a wire-shape job into the frontend `TranslationJob` type.
+ *
+ * Defensive defaults mirror the per-field nullish-coalescing fallbacks
+ * that previously lived inline in `getJobStatus` — keeping them here
+ * means a single audit point for "what does the SPA do when the
+ * backend omits an optional field?".
+ *
+ * The `now` parameter is injected so callers can pass a deterministic
+ * timestamp in tests; it defaults to `new Date().toISOString()` so the
+ * production code path stays a one-liner.
+ */
+export function toTranslationJob(
+  wire: TranslationJobWire,
+  now: string = new Date().toISOString()
+): TranslationJob {
+  return {
+    jobId: wire.jobId,
+    userId: wire.userId ?? '',
+    fileName: wire.fileName ?? '',
+    fileSize: wire.fileSize ?? 0,
+    contentType: wire.contentType ?? '',
+    status: wire.status as TranslationJobStatus,
+    targetLanguage: wire.targetLanguage,
+    tone: wire.tone,
+    totalChunks: wire.totalChunks,
+    // The renamed seam — `chunksTranslated` (wire) → `completedChunks` (frontend).
+    // This translation is the architectural reason the mapper exists.
+    completedChunks: wire.chunksTranslated,
+    failedChunks: wire.failedChunks,
+    createdAt: wire.createdAt ?? now,
+    updatedAt: wire.translationCompletedAt ?? wire.updatedAt ?? wire.createdAt ?? now,
+    completedAt: wire.translationCompletedAt ?? wire.completedAt,
+    errorMessage: wire.error ?? wire.errorMessage,
+  };
+}

--- a/frontend/src/services/translationService.ts
+++ b/frontend/src/services/translationService.ts
@@ -8,7 +8,12 @@
 import axios from 'axios';
 import { apiClient } from '../utils/api';
 import { stripBrowserForbiddenHeaders } from '../utils/headerFilters';
-import type { TranslationJobStatus } from '@lfmt/shared-types';
+import type {
+  PresignedUrlApiResponse,
+  StartTranslationApiResponse,
+  TranslationJobStatus,
+  TranslationStatusApiResponse,
+} from '@lfmt/shared-types';
 import { CHUNKING_ERROR_STATUSES } from '@lfmt/shared-types';
 
 // N1 (PR #214 OMC R2): the back-compat re-export of
@@ -237,16 +242,15 @@ const handleError = (error: unknown): never => {
  */
 export const uploadDocument = async (request: UploadDocumentRequest): Promise<TranslationJob> => {
   try {
-    // Step 1: Request presigned URL from backend
-    const presignedResponse = await apiClient.post<{
-      data: {
-        uploadUrl: string;
-        fileId: string;
-        jobId: string;
-        expiresIn: number;
-        requiredHeaders: Record<string, string>;
-      };
-    }>('/jobs/upload', {
+    // Step 1: Request presigned URL from backend.
+    //
+    // POST /jobs/upload is the ONLY job-side endpoint that wraps its payload
+    // in `{message, data}` — every other handler returns a flat object. We
+    // type the response with the shared `PresignedUrlApiResponse` DTO from
+    // @lfmt/shared-types so a wire-shape drift between the Lambda
+    // (`backend/functions/jobs/uploadRequest.ts`) and this reader fails at
+    // compile time rather than crashing the demo at runtime.
+    const presignedResponse = await apiClient.post<PresignedUrlApiResponse>('/jobs/upload', {
       fileName: request.file.name,
       fileSize: request.file.size,
       contentType: request.file.type,
@@ -406,47 +410,124 @@ export const uploadAndAwaitChunked = async (
 };
 
 /**
- * Start translation for a job
+ * Start translation for a job.
+ *
+ * The real Lambda (`backend/functions/jobs/startTranslation.ts`) returns a
+ * FLAT object — not `{data: ...}`. Reading `response.data.data` here was
+ * the demo blocker fixed in the 2026-05-09 hotfix; this version reads
+ * `response.data` directly and uses the shared `StartTranslationApiResponse`
+ * DTO so any future drift fails at compile time.
+ *
+ * The Lambda's response is a wider shape than `TranslationJob` (it also
+ * carries `executionArn`, `estimatedCost`, etc.), but the wizard only
+ * needs the `TranslationJob`-compatible fields, so we map at this seam.
  */
 export const startTranslation = async (
   jobId: string,
   config: TranslationConfig
 ): Promise<TranslationJob> => {
   try {
-    const response = await apiClient.post<{ data: TranslationJob }>(`/jobs/${jobId}/translate`, {
+    const response = await apiClient.post<StartTranslationApiResponse>(`/jobs/${jobId}/translate`, {
       targetLanguage: config.targetLanguage,
       tone: config.tone,
     });
 
-    return response.data.data;
+    const body = response.data;
+    return {
+      jobId: body.jobId,
+      // The backend response does not echo userId here; the field is
+      // tracked elsewhere (auth context / job detail endpoint). Default
+      // to '' to satisfy the TranslationJob shape; the value is not
+      // read on the post-startTranslation code paths today.
+      userId: '',
+      fileName: '',
+      fileSize: 0,
+      contentType: '',
+      // The job has just been transitioned to IN_PROGRESS — the wire
+      // shape of `translationStatus` happens to be the same as
+      // TranslationJob.status for this code path.
+      status: body.translationStatus as TranslationJobStatus,
+      targetLanguage: body.targetLanguage,
+      totalChunks: body.totalChunks,
+      completedChunks: body.chunksTranslated,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
   } catch (error) {
     return handleError(error);
   }
 };
 
 /**
- * Get job status
+ * Get job status.
+ *
+ * The real Lambda (`backend/functions/jobs/getTranslationStatus.ts`) returns
+ * a FLAT object, NOT `{data: ...}`. Reading `response.data.data` here was
+ * the root cause of the 2026-05-09 demo blocker:
+ *
+ *   "Cannot read properties of undefined (reading 'status')"
+ *
+ * — `response.data.data` was undefined, the polling loop in
+ * `uploadAndAwaitChunked` then dereferenced `.status` on undefined and
+ * crashed step 4 of the upload wizard.
+ *
+ * The shared `TranslationStatusApiResponse` DTO from @lfmt/shared-types
+ * is the single source of truth; both the Lambda and this reader import
+ * it so a future drift surfaces at compile time, not at the demo.
+ *
+ * Note on field-name mapping: the backend returns `chunksTranslated`
+ * (mirroring its DDB column) while the frontend's `TranslationJob` uses
+ * `completedChunks`. We translate at this seam.
  */
 export const getJobStatus = async (jobId: string): Promise<TranslationJob> => {
   try {
-    const response = await apiClient.get<{ data: TranslationJob }>(
+    const response = await apiClient.get<TranslationStatusApiResponse>(
       `/jobs/${jobId}/translation-status`
     );
 
-    return response.data.data;
+    const body = response.data;
+    return {
+      jobId: body.jobId,
+      userId: body.userId ?? '',
+      fileName: body.fileName ?? '',
+      fileSize: body.fileSize ?? 0,
+      contentType: body.contentType ?? '',
+      status: body.status as TranslationJobStatus,
+      targetLanguage: body.targetLanguage,
+      tone: body.tone,
+      totalChunks: body.totalChunks,
+      completedChunks: body.chunksTranslated,
+      createdAt: body.createdAt ?? new Date().toISOString(),
+      updatedAt: body.translationCompletedAt ?? body.createdAt ?? new Date().toISOString(),
+      completedAt: body.translationCompletedAt,
+      errorMessage: body.error,
+    };
   } catch (error) {
     return handleError(error);
   }
 };
 
 /**
- * Get all translation jobs for the current user
+ * Get all translation jobs for the current user.
+ *
+ * KNOWN-LIMITATION: as of 2026-05-09 there is NO `GET /jobs` route on the
+ * real backend (`backend/infrastructure/lib/lfmt-infrastructure-stack.ts`
+ * only exposes `GET /jobs/{jobId}` and `GET /jobs/{jobId}/translation-status`).
+ * The History page (`pages/TranslationHistory.tsx`) currently calls this
+ * method against the deployed backend and gets a 403/404 — the page
+ * surfaces an empty list, which is the "silently broken" behaviour
+ * flagged in the hotfix audit. This is a pre-existing gap, NOT a
+ * regression from this hotfix; tracked as a follow-up.
+ *
+ * For envelope correctness when the endpoint DOES exist (today only via
+ * the MSW mock): the convention across the rest of the API is a flat
+ * shape, so the reader expects `response.data` to BE the array.
  */
 export const getTranslationJobs = async (): Promise<TranslationJob[]> => {
   try {
-    const response = await apiClient.get<{ data: TranslationJob[] }>('/jobs');
+    const response = await apiClient.get<TranslationJob[]>('/jobs');
 
-    return response.data.data;
+    return response.data;
   } catch (error) {
     return handleError(error);
   }

--- a/frontend/src/services/translationService.ts
+++ b/frontend/src/services/translationService.ts
@@ -15,6 +15,7 @@ import type {
   TranslationStatusApiResponse,
 } from '@lfmt/shared-types';
 import { CHUNKING_ERROR_STATUSES } from '@lfmt/shared-types';
+import { toTranslationJob } from './mappers/translationJobMapper';
 
 // N1 (PR #214 OMC R2): the back-compat re-export of
 // `stripBrowserForbiddenHeaders` from this module has been removed.
@@ -87,6 +88,34 @@ export interface UploadDocumentRequest {
 export interface StartTranslationRequest {
   targetLanguage: string;
   tone: string;
+}
+
+/**
+ * Narrow return type of `startTranslation`.
+ *
+ * Pre-PR-#218 the function fabricated a full `TranslationJob` shape with
+ * five hollow sentinel fields (`userId: ''`, `fileName: ''`,
+ * `fileSize: 0`, ...) because the real `POST /jobs/{jobId}/translate`
+ * Lambda only returns the fields enumerated below. The sentinels were a
+ * code-quality H1 risk (OMC R1 on PR #218): any optimistic UI / polling
+ * seed that read the result would render "0 Bytes" and an empty
+ * filename until the first `getJobStatus` resolved.
+ *
+ * Narrowing the return removes the lie at the type level — the wizard
+ * + `TranslationDetail` page already discard the return value (they
+ * either navigate or call `fetchJobDetails` immediately after), and the
+ * narrower type makes that contract explicit. Future callers MUST use
+ * `getJobStatus` to enrich with file metadata.
+ */
+export interface StartTranslationResult {
+  jobId: string;
+  status: TranslationJobStatus;
+  targetLanguage: string;
+  totalChunks: number;
+  completedChunks: number;
+  message: string;
+  /** Step Functions execution ARN — present in dev for tracing. */
+  executionArn?: string;
 }
 
 /**
@@ -418,14 +447,20 @@ export const uploadAndAwaitChunked = async (
  * `response.data` directly and uses the shared `StartTranslationApiResponse`
  * DTO so any future drift fails at compile time.
  *
- * The Lambda's response is a wider shape than `TranslationJob` (it also
- * carries `executionArn`, `estimatedCost`, etc.), but the wizard only
- * needs the `TranslationJob`-compatible fields, so we map at this seam.
+ * Returns a narrow `StartTranslationResult` containing only the fields the
+ * Lambda actually echoes back (PR #218 OMC R1 H1-cq). Pre-fix this
+ * function fabricated a full `TranslationJob` with five hollow sentinels
+ * (`userId: ''`, `fileName: ''`, `fileSize: 0`, ...) which risked
+ * "0 Bytes / empty filename" UI flicker if any consumer treated the
+ * result as authoritative. Today's consumers (the upload wizard +
+ * `TranslationDetail` retry button) discard the return value and either
+ * navigate or call `fetchJobDetails` immediately after — narrowing makes
+ * that contract type-checkable.
  */
 export const startTranslation = async (
   jobId: string,
   config: TranslationConfig
-): Promise<TranslationJob> => {
+): Promise<StartTranslationResult> => {
   try {
     const response = await apiClient.post<StartTranslationApiResponse>(`/jobs/${jobId}/translate`, {
       targetLanguage: config.targetLanguage,
@@ -435,23 +470,21 @@ export const startTranslation = async (
     const body = response.data;
     return {
       jobId: body.jobId,
-      // The backend response does not echo userId here; the field is
-      // tracked elsewhere (auth context / job detail endpoint). Default
-      // to '' to satisfy the TranslationJob shape; the value is not
-      // read on the post-startTranslation code paths today.
-      userId: '',
-      fileName: '',
-      fileSize: 0,
-      contentType: '',
       // The job has just been transitioned to IN_PROGRESS — the wire
       // shape of `translationStatus` happens to be the same as
       // TranslationJob.status for this code path.
       status: body.translationStatus as TranslationJobStatus,
       targetLanguage: body.targetLanguage,
       totalChunks: body.totalChunks,
+      // Wire field name → frontend field name. Mirrors the
+      // translation done by `toTranslationJob` in the mapper module
+      // (M3-arch). Kept inline here because `StartTranslationResult`
+      // is a narrower shape than `TranslationJob`; using the full
+      // mapper would require silently inventing fields the wire never
+      // returned, which is the exact anti-pattern this refactor closes.
       completedChunks: body.chunksTranslated,
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
+      message: body.message,
+      executionArn: body.executionArn,
     };
   } catch (error) {
     return handleError(error);
@@ -485,23 +518,11 @@ export const getJobStatus = async (jobId: string): Promise<TranslationJob> => {
       `/jobs/${jobId}/translation-status`
     );
 
-    const body = response.data;
-    return {
-      jobId: body.jobId,
-      userId: body.userId ?? '',
-      fileName: body.fileName ?? '',
-      fileSize: body.fileSize ?? 0,
-      contentType: body.contentType ?? '',
-      status: body.status as TranslationJobStatus,
-      targetLanguage: body.targetLanguage,
-      tone: body.tone,
-      totalChunks: body.totalChunks,
-      completedChunks: body.chunksTranslated,
-      createdAt: body.createdAt ?? new Date().toISOString(),
-      updatedAt: body.translationCompletedAt ?? body.createdAt ?? new Date().toISOString(),
-      completedAt: body.translationCompletedAt,
-      errorMessage: body.error,
-    };
+    // Project the wire shape into the frontend `TranslationJob` via the
+    // shared `toTranslationJob` mapper (architect M3 on PR #218). The
+    // mapper is the single audit point for "how does the SPA decode a
+    // backend job record?" — see frontend/src/services/mappers/.
+    return toTranslationJob(response.data);
   } catch (error) {
     return handleError(error);
   }

--- a/frontend/src/services/uploadService.ts
+++ b/frontend/src/services/uploadService.ts
@@ -10,7 +10,7 @@
  */
 
 import { apiClient } from '../utils/api';
-import type { PresignedUrlRequest, PresignedUrlResponse } from '@lfmt/shared-types';
+import type { PresignedUrlApiResponse, PresignedUrlRequest } from '@lfmt/shared-types';
 import { stripBrowserForbiddenHeaders } from '../utils/headerFilters';
 
 /**
@@ -68,7 +68,11 @@ export async function requestUploadUrl(file: File): Promise<UploadRequestResult>
     contentType: file.type,
   };
 
-  const response = await apiClient.post<{ data: PresignedUrlResponse }>('/jobs/upload', request);
+  // POST /jobs/upload returns the `{message, data: PresignedUrlResponse}`
+  // wrapper — see PresignedUrlApiResponse in @lfmt/shared-types for why
+  // this is the only job-side endpoint with an envelope. Using the shared
+  // DTO keeps backend and frontend wire shapes coupled at compile time.
+  const response = await apiClient.post<PresignedUrlApiResponse>('/jobs/upload', request);
 
   return response.data.data;
 }

--- a/frontend/src/utils/__tests__/api.refresh.test.ts
+++ b/frontend/src/utils/__tests__/api.refresh.test.ts
@@ -109,46 +109,21 @@ describe('API Token Refresh Interceptor', () => {
       expect(response.data).toEqual({ message: 'Success with new token' });
     });
 
-    it('should extract idToken from the real backend wrapped response shape', async () => {
-      // This test uses the ACTUAL backend response shape produced by
-      // `createSuccessResponse()`:
-      //   { message, data: { accessToken, idToken, expiresIn }, requestId }
-      //
-      // The flat mock shape used by other tests exercises the compat path.
-      // This test ensures the interceptor extracts tokens from the nested
-      // `data` field — the absence of this test was the root cause that
-      // allowed the original wrong-token bug to ship undetected.
-      const newAccessToken = 'wrapped-access-token';
-      const newIdToken = 'wrapped-id-token'; // distinct value — must end up as Bearer
-
-      setStoredSession({
-        idToken: 'expired-id-token',
-        accessToken: 'expired-access',
-        refreshToken: 'some-refresh-token',
-      });
-
-      instanceMock.onGet('/protected').replyOnce(401, {});
-
-      // Wrapped shape — matches what the backend actually sends:
-      moduleMock.onPost(/\/auth\/refresh$/).replyOnce(200, {
-        message: 'Tokens refreshed successfully',
-        data: {
-          accessToken: newAccessToken,
-          idToken: newIdToken,
-          expiresIn: 3600,
-        },
-        requestId: 'req-abc-123',
-      });
-
-      moduleMock.onGet(/\/protected$/).replyOnce(200, { ok: true });
-
-      await apiClient.get('/protected');
-
-      // ID token extracted from response.data.data.idToken — the nested field.
-      const session = getStoredSession();
-      expect(session?.idToken).toBe(newIdToken);
-      expect(session?.accessToken).toBe(newAccessToken);
-    });
+    // The previous test "should extract idToken from the real backend
+    // wrapped response shape" was REMOVED in PR #218 OMC R1 C2.
+    //
+    // Background: the test exercised the legacy `payload.data?.accessToken
+    // ?? payload.accessToken` dual-path extractor inside `responseErrorInterceptor`.
+    // PR #218 flattened `auth/refreshToken.ts` so the real backend now ALWAYS
+    // emits `{message, accessToken, idToken, expiresIn, requestId}` — the
+    // nested `{data: {...}}` shape the test mocked is no longer possible to
+    // produce. The dead branch in the extractor was simplified at the same
+    // time (the dual-path reader → flat-only reader). YAGNI: delete the test
+    // AND the dead code path it covered, rather than rename the test to
+    // assert "rejects unexpected nested shape" — the runtime guard that
+    // matters (empty bearer → fail-closed) is exercised by
+    // `should treat an empty bearer from the refresh response as a failure
+    // and clear tokens` further down.
 
     it('should send the new idToken (not accessToken) as Authorization Bearer on the retried request', async () => {
       // Critical 2: assert the Authorization header on the RETRIED request
@@ -506,10 +481,14 @@ describe('API Token Refresh Interceptor', () => {
       // Step 2: API call → 401.
       instanceMock.onPost('/jobs/translate').replyOnce(401, { message: 'Token expired' });
 
-      // Step 3: refresh → new tokens (wrapped backend shape to also cover Critical 1).
+      // Step 3: refresh → new tokens. PR #218 OMC R1 C2 flattened the
+      // real backend's response shape; the mock now mirrors the live
+      // contract directly (no nested `data` wrapper).
       moduleMock.onPost(/\/auth\/refresh$/).replyOnce(200, {
         message: 'Tokens refreshed successfully',
-        data: { accessToken: newAccessToken, idToken: newIdToken, expiresIn: 3600 },
+        accessToken: newAccessToken,
+        idToken: newIdToken,
+        expiresIn: 3600,
         requestId: 'req-chain-test',
       });
 

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -577,23 +577,24 @@ async function responseErrorInterceptor(error: unknown): Promise<unknown> {
     try {
       // Call refresh endpoint.
       //
-      // The backend `/auth/refresh` response is shaped by `createSuccessResponse`:
-      //   { message, data: { accessToken, idToken, expiresIn }, requestId }
+      // The backend `/auth/refresh` response is FLAT (PR #218 hotfix
+      // flattened the previously-wrapped envelope so it matches every
+      // other auth handler):
+      //   { message, accessToken, idToken, expiresIn, requestId }
       //
-      // We also tolerate a flat shape `{ accessToken, idToken, refreshToken }`
-      // so that unit tests can mock a simpler payload without breaking.
+      // The dual-path extractor that previously also tolerated a nested
+      // `{ data: { ... } }` shape was deleted alongside the dead code
+      // branch in PR #218 OMC R1 C2 (YAGNI — the nested shape is no
+      // longer producible by any caller).
       const response = await axios.post<{
-        // Flat shape (unit-test mocks / forward-compat)
         accessToken?: string;
         idToken?: string;
         refreshToken?: string;
-        // Nested shape (actual backend via createSuccessResponse)
-        data?: { accessToken?: string; idToken?: string; expiresIn?: number };
       }>(`${API_CONFIG.BASE_URL}/auth/refresh`, { refreshToken });
 
       const payload = response.data;
-      const newAccessToken = payload.data?.accessToken ?? payload.accessToken ?? '';
-      const newIdToken = payload.data?.idToken ?? payload.idToken ?? '';
+      const newAccessToken = payload.accessToken ?? '';
+      const newIdToken = payload.idToken ?? '';
       // Cognito REFRESH_TOKEN_AUTH does not rotate the refresh token, so
       // `refreshToken` may be absent in the backend response. Fall back to
       // the existing value so we don't accidentally store an empty string.

--- a/shared-types/src/api.ts
+++ b/shared-types/src/api.ts
@@ -1,8 +1,18 @@
 // API Types - From Document 3 (API Gateway & Lambda Functions) and Document 5 (Claude API Integration)
 import { z } from 'zod';
 
-// Generic API Response
-export interface ApiResponse<T = any> {
+// Generic API Response.
+//
+// `T` defaults to `unknown` (not `any`) so that bare `ApiResponse` consumers
+// must narrow the payload before reading it — `unknown` won't sail blindly
+// into a runtime crash the way `any` does, which is precisely the failure
+// mode this PR is meant to prevent (see #221 / PR #218 review item 6).
+//
+// Note: this generic is currently superseded by the per-endpoint
+// `*ApiResponse` interfaces (TranslationStatusApiResponse, etc.). It is
+// kept as a fallback for endpoints without a dedicated DTO; new endpoints
+// should prefer a concrete `*ApiResponse` interface.
+export interface ApiResponse<T = unknown> {
   success: boolean;
   data?: T;
   error?: ApiError;

--- a/shared-types/src/documents.ts
+++ b/shared-types/src/documents.ts
@@ -88,6 +88,31 @@ export interface PresignedUrlResponse {
   requiredHeaders: Record<string, string>;
 }
 
+/**
+ * Wire envelope for POST /jobs/upload.
+ *
+ * This endpoint is the ONLY job-side endpoint that returns a `{message, data}`
+ * wrapper — every other handler returns a flat object. The wrapper is preserved
+ * because the message is shown verbatim in some operator tooling. Frontend
+ * callers MUST read `.data` (one wrapper level) to access `PresignedUrlResponse`.
+ *
+ * Documented as a SSoT type so the wire shape cannot drift between the Lambda
+ * (`backend/functions/jobs/uploadRequest.ts`) and the frontend services
+ * (`translationService.uploadDocument`, `uploadService.requestUploadUrl`).
+ */
+export interface PresignedUrlApiResponse {
+  message: string;
+  data: PresignedUrlResponse;
+  requestId?: string;
+  /**
+   * Index signature satisfies the `ApiSuccessResponse` constraint used by
+   * `createSuccessResponse` in the backend Lambda — required because the
+   * helper accepts `ApiSuccessResponse<T>` (which carries an index sig)
+   * and refuses to widen-and-spread otherwise.
+   */
+  [key: string]: unknown;
+}
+
 export interface FileValidationRequest {
   fileId: string;
   expectedHash?: string;

--- a/shared-types/src/jobs.ts
+++ b/shared-types/src/jobs.ts
@@ -345,6 +345,75 @@ export interface DeleteJobApiResponse {
 }
 
 /**
+ * Response body returned by GET /jobs/{jobId}/translation-status.
+ *
+ * Shape is intentionally flat (no `data` wrapper) so frontend callers can
+ * access `response.data.jobId` directly. This DTO is the SINGLE SOURCE OF
+ * TRUTH for the wire shape — both the Lambda handler
+ * (`backend/functions/jobs/getTranslationStatus.ts`) and the frontend
+ * service (`frontend/src/services/translationService.ts:getJobStatus`) MUST
+ * import this type so a wire-shape drift surfaces as a TypeScript error
+ * rather than a `Cannot read properties of undefined` runtime crash
+ * (the 2026-05-09 demo blocker).
+ *
+ * Field naming notes (preserved from the live Lambda response):
+ *   - `chunksTranslated` (NOT `completedChunks`) — the backend persists this
+ *     name in DDB and surfaces it as-is on the wire.
+ *   - `fileName` is camelCase here even though DDB stores `filename`
+ *     (lowercase n) — the Lambda translates at the response boundary.
+ *
+ * The index signature satisfies the `ApiSuccessResponse` constraint used by
+ * `createSuccessResponse` in the Lambda handler.
+ */
+export interface TranslationStatusApiResponse {
+  jobId: string;
+  /** Owning user (Cognito sub). */
+  userId?: string;
+  fileName?: string;
+  fileSize?: number;
+  contentType?: string;
+  /** Overall job status (PENDING_UPLOAD, UPLOADED, CHUNKED, etc.). */
+  status: string;
+  translationStatus: string;
+  targetLanguage?: string;
+  tone?: TranslationTone;
+  totalChunks: number;
+  /** Number of chunks translated so far (NOT named `completedChunks`). */
+  chunksTranslated: number;
+  progressPercentage: number;
+  tokensUsed?: number;
+  estimatedCost?: number;
+  createdAt?: string;
+  translationStartedAt?: string;
+  translationCompletedAt?: string;
+  estimatedCompletion?: string;
+  error?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Response body returned by POST /jobs/{jobId}/translate.
+ *
+ * Shape is intentionally flat (no `data` wrapper). Both the Lambda
+ * (`backend/functions/jobs/startTranslation.ts`) and the frontend
+ * (`translationService.ts:startTranslation`) MUST import this DTO so any
+ * future drift surfaces at compile time.
+ */
+export interface StartTranslationApiResponse {
+  message: string;
+  jobId: string;
+  translationStatus: string;
+  targetLanguage: string;
+  totalChunks: number;
+  chunksTranslated: number;
+  estimatedCompletion?: string;
+  estimatedCost?: number;
+  /** Step Functions execution ARN (for tracking / debugging). */
+  executionArn?: string;
+  [key: string]: unknown;
+}
+
+/**
  * Response body returned by GET /jobs/{jobId}/download.
  *
  * Note: The actual HTTP response from the Lambda is raw text/plain (not JSON).


### PR DESCRIPTION
## Summary

Hotfix for the demo blocker discovered during the browser walkthrough on dev after PR #214 merged. The CSP fix worked correctly — this is a NEW bug surfaced once the upload path actually completed.

### Symptom

Browser walkthrough at https://d39xcun7144jgl.cloudfront.net was blocked at `/translation/upload` Step 4 with UI error:

> Cannot read properties of undefined (reading 'status')

POST `/jobs/upload` (200) → S3 PUT (200) → GET `/jobs/{id}/translation-status` (200) all succeeded. The error originated in the polling loop (`uploadAndAwaitChunked` → `tick` → `getJobStatus`).

### Root cause

API response envelope mismatch between MSW mock and real Lambda:

- **Real Lambda** (`backend/functions/jobs/getTranslationStatus.ts` via `createSuccessResponse`) returns a FLAT body: `{ jobId, status, totalChunks, ... }`.
- **Frontend service** `getJobStatus` was reading `response.data.data` — expecting an extra `.data` wrapper that the real backend never produced.
- **MSW mock** wrapped responses as `{ data: { ... } }`, matching the (wrong) frontend expectation, hiding the divergence on every Vitest / Playwright run.

The polling loop dereferences `.status` on the undefined `response.data.data`, throwing the runtime error.

## Audit results

Walked every frontend service method and matched it against the real Lambda wire shape. Findings:

| Method | Real Lambda shape | Old reader | Status |
|---|---|---|---|
| `translationService.uploadDocument` (presigned URL) | `{message, data: {...}}` | `response.data.data` | OK as-is |
| `uploadService.requestUploadUrl` (presigned URL) | `{message, data: {...}}` | `response.data.data` | OK as-is |
| `translationService.startTranslation` | flat `{jobId, translationStatus, ...}` | `response.data.data` | **BROKEN — fixed** |
| `translationService.getJobStatus` | flat `{jobId, status, chunksTranslated, ...}` | `response.data.data` | **BROKEN — fixed** (the demo blocker) |
| `translationService.getTranslationJobs` | endpoint not deployed | `response.data.data` | **Pre-existing brokenness** — fixed envelope, flagged for follow-up |
| `translationService.downloadTranslation` | raw text/plain blob | `response.data` | OK |
| `authService.login/register` | flat `{user, accessToken, ...}` | `response.data` | OK |
| `authService.refreshToken` | `{message, data: {...}}` (Lambda) | `response.data.accessToken` | **BROKEN — flattened Lambda response to match the rest of auth + frontend reader** |
| `authService.getCurrentUser` | flat `{user}` | `response.data.user` | OK |

Field-name corrections caught in the same audit:

- The real status Lambda returns `chunksTranslated` (mirroring the DDB column), not `completedChunks` — service now translates at the seam.
- `translationCompletedAt` mapped to `completedAt` on the local `TranslationJob` shape.

## Fixes per method

### Wire-shape SSoT (shared-types)

- `shared-types/src/jobs.ts`: added `TranslationStatusApiResponse` and `StartTranslationApiResponse` interfaces — both intentionally flat. Documented as the single source of truth for backend ↔ frontend wire shapes.
- `shared-types/src/documents.ts`: added `PresignedUrlApiResponse` to capture the unique `{message, data}` envelope used only by `POST /jobs/upload`.

### Backend handlers (now import the shared DTOs)

- `getTranslationStatus.ts` — replaced local `TranslationStatusResponse` interface with `TranslationStatusApiResponse` import.
- `startTranslation.ts` — typed the response body with `StartTranslationApiResponse`.
- `uploadRequest.ts` — typed envelope with `PresignedUrlApiResponse`.
- `refreshToken.ts` — flattened the response (no more `{message, data: {...}}` wrapper) so it matches the rest of the auth handlers and the frontend reader. Test updated.

### Frontend services (now import shared DTOs and read the correct shape)

- `translationService.ts`:
  - `uploadDocument` types presigned response as `PresignedUrlApiResponse`.
  - `startTranslation` reads flat body and maps to `TranslationJob`.
  - `getJobStatus` reads flat body, maps `chunksTranslated → completedChunks`, etc.
  - `getTranslationJobs` reads flat array — flagged the missing `GET /jobs` route on the real backend with a `KNOWN-LIMITATION` comment for follow-up.
- `uploadService.ts` — typed presigned response as `PresignedUrlApiResponse`.

### Mock fidelity (MSW handlers — single source of truth)

- `frontend/src/mocks/handlers.ts`:
  - Replaced `toWireJob` with `toWireTranslationStatus` (flat shape, mirrors real Lambda) and `toWireJobListItem` (flat array shape for `/jobs` list).
  - `POST /jobs/upload` now emits `{message, data: {...}}` (matches real Lambda).
  - `POST /jobs/{jobId}/translate` now emits flat `StartTranslationApiResponse`.
  - `GET /jobs/{jobId}/translation-status` now emits flat `TranslationStatusApiResponse` (with `chunksTranslated`, `progressPercentage`, etc.).
  - `GET /jobs` returns a flat array.
  - `POST /auth/refresh` returns a flat object (matches the flattened backend).
- Updated `handlers.test.ts` and `translationService.test.ts` to assert against the new flat shapes (with `buildWireStatus` helper to keep tests DRY).

## Contract guard

Picked **option A (type-level)** + a small **option B (runtime)** assist:

- The shared DTOs (`TranslationStatusApiResponse`, `StartTranslationApiResponse`, `PresignedUrlApiResponse`) are imported by BOTH the backend Lambda and the frontend reader. Future drift on either side fails at compile time (`tsc --noEmit`).
- New `frontend/src/__tests__/apiEnvelopeContract.test.ts` — drives the actual MSW handlers end-to-end through `apiClient` and the frontend service, asserting that:
  1. `POST /jobs/upload` returns the `{message, data}` envelope.
  2. `POST /jobs/{jobId}/translate` returns the flat shape.
  3. `GET /jobs/{jobId}/translation-status` returns the flat shape.
  4. `translationService.getJobStatus` does NOT crash on the real wire shape (regression guard for the exact demo failure).

## Test plan

- [x] `cd shared-types && npm run build` — passes
- [x] `cd backend/functions && npm run build && npm run lint && npm run format:check && npm test` — 534 passed (3 skipped, 537 total) across 25 test suites; previously 463 passed (3 skipped) across 22 suites — all suites that previously failed-to-load (TS errors) now pass
- [x] `cd backend/infrastructure && npm run build && npm test && npx cdk synth --context environment=dev` — 77 tests pass, synth exits 0
- [x] `cd frontend && npm run type-check && npm run lint && npm run format:check && npx vitest --run` — **708 passed | 14 skipped (722) across 34 test files** (baseline was 704 passed | 14 skipped (718) across 33 test files; +4 tests = the 4 new contract tests in apiEnvelopeContract.test.ts)
- [ ] Browser walkthrough on deployed dev once this lands (gated on user/owner)

### Known limitation surfaced (NOT fixed in this hotfix)

`GET /jobs` does not exist as an API Gateway route on the real backend (only `GET /jobs/{jobId}` and `GET /jobs/{jobId}/translation-status`). The History page consumes it via `getTranslationJobs` and silently surfaces an empty list. Documented in a `KNOWN-LIMITATION` comment on the service method; will need a follow-up PR to add the route + Lambda.