### PR TITLE
fix(auth): auto-login after registration; production fallback for email-verified flow (#222)

### DIFF
--- a/frontend/src/__tests__/apiEnvelopeContract.test.ts
+++ b/frontend/src/__tests__/apiEnvelopeContract.test.ts
@@ -210,7 +210,14 @@ describe('API Envelope Contract — auth pipeline', () => {
   // The auth handlers all return the FLAT envelope. The mock matches
   // the real backend (post-PR-#218: refreshToken was flattened too).
 
-  it('authService.register returns flat AuthResponse with user + tokens', async () => {
+  it('authService.register returns a flat MessageResponse (no tokens — Cognito issues tokens at /auth/login)', async () => {
+    // Real backend (`backend/functions/auth/register.ts:165`) returns
+    // ONLY `{ message }` on 201. Cognito does not issue session tokens
+    // until /auth/login. Issue #222 R1 F-01 / F-06: the mock previously
+    // returned `{ user, ...tokens }` and the service layer's
+    // `storeAuthTokens` was writing `idToken: undefined` on every
+    // production registration — this contract test now locks the
+    // correct shape for both mock and live wire.
     const result = await authService.register({
       email: 'contract@example.com',
       password: 'TestPass123!',
@@ -220,12 +227,8 @@ describe('API Envelope Contract — auth pipeline', () => {
       acceptedTerms: true,
       acceptedPrivacy: true,
     });
-    // Flat: `user` is a top-level field, NOT `result.data.user`.
-    expect(result.user).toBeDefined();
-    expect(typeof result.user.email).toBe('string');
-    expect(typeof result.accessToken).toBe('string');
-    expect(typeof result.idToken).toBe('string');
-    expect(typeof result.refreshToken).toBe('string');
+    expect(typeof result.message).toBe('string');
+    expect(result.message.length).toBeGreaterThan(0);
   });
 
   it('authService.login returns flat AuthResponse with user + tokens', async () => {
@@ -252,7 +255,11 @@ describe('API Envelope Contract — auth pipeline', () => {
   });
 
   it('authService.getCurrentUser returns the user inside a flat `user` field', async () => {
-    const registered = await authService.register({
+    // Seed: register creates the account (no tokens), then login establishes
+    // the session and `storeAuthTokens` writes idToken/accessToken to
+    // localStorage so subsequent /auth/me requests are authenticated. This
+    // mirrors the real production flow exactly (Issue #222 R1).
+    await authService.register({
       email: 'me@example.com',
       password: 'TestPass123!',
       confirmPassword: 'TestPass123!',
@@ -261,8 +268,11 @@ describe('API Envelope Contract — auth pipeline', () => {
       acceptedTerms: true,
       acceptedPrivacy: true,
     });
-    // Tokens are auto-stored by `storeAuthTokens` inside the service.
-    expect(registered.user.email).toBe('me@example.com');
+    const session = await authService.login({
+      email: 'me@example.com',
+      password: 'TestPass123!',
+    });
+    expect(session.user.email).toBe('me@example.com');
 
     const me = await authService.getCurrentUser();
     // `getCurrentUser` reads `response.data.user` — the flat envelope.
@@ -289,8 +299,12 @@ describe('API Envelope Contract — auth pipeline', () => {
   });
 
   it('authService.refreshToken reads tokens from the FLAT refresh response', async () => {
-    // Ensure a session exists so getStoredRefreshToken() returns a value.
-    const registered = await authService.register({
+    // Seed: register creates the account, then login populates the session
+    // with a refreshToken that `storeAuthTokens` persists to localStorage.
+    // `getStoredRefreshToken()` (called inside `authService.refreshToken`)
+    // reads from that storage. Mirrors the real production seeding flow
+    // exactly — register no longer issues tokens (Issue #222 R1).
+    await authService.register({
       email: 'refresh@example.com',
       password: 'TestPass123!',
       confirmPassword: 'TestPass123!',
@@ -299,7 +313,11 @@ describe('API Envelope Contract — auth pipeline', () => {
       acceptedTerms: true,
       acceptedPrivacy: true,
     });
-    expect(registered.refreshToken).toBeDefined();
+    const session = await authService.login({
+      email: 'refresh@example.com',
+      password: 'TestPass123!',
+    });
+    expect(session.refreshToken).toBeDefined();
 
     // Override the mock to return the EXACT real-backend wire shape:
     //   { message, accessToken, idToken, expiresIn, requestId }

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -147,13 +147,19 @@ export function AuthProvider({ children }: AuthProviderProps) {
   }, []);
 
   /**
-   * Register new user
+   * Register new user.
+   *
+   * Only creates the account (POST /auth/register). The real backend
+   * returns 201 + { message } — no tokens. Setting the authenticated
+   * user is the caller's responsibility via a subsequent login() call
+   * (see RegisterPage and issue #222). This separation avoids silently
+   * swallowing a missing-user shape that would leave isAuthenticated
+   * stuck as false despite a successful API round-trip.
    */
   const register = useCallback(async (data: RegisterRequest) => {
     try {
       setError(null);
-      const response = await authService.register(data);
-      setUser(response.user);
+      await authService.register(data);
     } catch (err) {
       setError(err as ApiError);
       throw err;

--- a/frontend/src/contexts/__tests__/AuthContext.test.tsx
+++ b/frontend/src/contexts/__tests__/AuthContext.test.tsx
@@ -233,19 +233,17 @@ describe('AuthContext - Register', () => {
     localStorage.clear();
   });
 
-  it('should register new user successfully', async () => {
-    const mockAuthResponse = {
-      user: {
-        id: 'new-user-123',
-        email: 'newuser@example.com',
-        firstName: 'New',
-        lastName: 'User',
-      },
-      accessToken: 'new-access-token',
-      refreshToken: 'new-refresh-token',
+  it('should register new user successfully without setting auth state (issue #222)', async () => {
+    // The real backend returns 201 + { message } — no tokens, no user.
+    // AuthContext.register() only creates the account; the caller (RegisterPage)
+    // is responsible for calling login() separately to set the authenticated user.
+    const mockRegisterResponse = {
+      user: { id: '', email: '', firstName: '', lastName: '' },
+      accessToken: '',
+      refreshToken: '',
     };
 
-    vi.mocked(authService.register).mockResolvedValueOnce(mockAuthResponse);
+    vi.mocked(authService.register).mockResolvedValueOnce(mockRegisterResponse);
 
     const { result } = renderHook(() => useAuth(), {
       wrapper: createWrapper(),
@@ -264,10 +262,11 @@ describe('AuthContext - Register', () => {
       });
     });
 
-    // Verify user is registered and logged in
-    expect(result.current.user).toEqual(mockAuthResponse.user);
-    expect(result.current.isAuthenticated).toBe(true);
+    // register() does NOT set the authenticated user — that is login()'s job.
+    expect(result.current.user).toBeNull();
+    expect(result.current.isAuthenticated).toBe(false);
     expect(result.current.error).toBeNull();
+    expect(authService.register).toHaveBeenCalledOnce();
   });
 
   it('should handle registration errors', async () => {

--- a/frontend/src/contexts/__tests__/AuthContext.test.tsx
+++ b/frontend/src/contexts/__tests__/AuthContext.test.tsx
@@ -238,9 +238,7 @@ describe('AuthContext - Register', () => {
     // AuthContext.register() only creates the account; the caller (RegisterPage)
     // is responsible for calling login() separately to set the authenticated user.
     const mockRegisterResponse = {
-      user: { id: '', email: '', firstName: '', lastName: '' },
-      accessToken: '',
-      refreshToken: '',
+      message: 'User registered successfully. You can now log in.',
     };
 
     vi.mocked(authService.register).mockResolvedValueOnce(mockRegisterResponse);

--- a/frontend/src/mocks/__tests__/handlers.test.ts
+++ b/frontend/src/mocks/__tests__/handlers.test.ts
@@ -116,8 +116,11 @@ describe('computeProgress (simulation policy)', () => {
 
 describe('resetState()', () => {
   it('clears all jobs and sessions between tests', async () => {
-    // Seed: register a user (populates sessions) and upload a file
-    // (populates jobs).
+    // Seed: register a user (populates `registeredUsers`) and upload a
+    // file (populates jobs). Note: register no longer populates
+    // `sessions` — sessions are issued at login. This test asserts on
+    // jobs clearing; sessions clearing is exercised by the auth-handler
+    // login + /auth/me round-trip elsewhere in this suite.
     await fetch(`${API_URL}/auth/register`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -152,7 +155,10 @@ describe('resetState()', () => {
 });
 
 describe('Auth handlers (msw/node)', () => {
-  it('register returns user + tokens including idToken; /auth/me round-trip resolves the same email', async () => {
+  it('register returns flat MessageResponse (mirrors real backend); login + /auth/me round-trip resolves the same email', async () => {
+    // Real backend returns ONLY `{ message }` on /auth/register (Cognito
+    // does not issue tokens at registration). The mock now matches that
+    // shape — see Issue #222 R1 F-01 for the production-impact context.
     const reg = await fetch(`${API_URL}/auth/register`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -162,16 +168,32 @@ describe('Auth handlers (msw/node)', () => {
         lastName: 'Trip',
       }),
     }).then((r) => r.json());
-    expect(reg.user.email).toBe('roundtrip@test.dev');
-    expect(typeof reg.accessToken).toBe('string');
+    expect(typeof reg.message).toBe('string');
+    expect(reg.message.length).toBeGreaterThan(0);
+    // No tokens at registration — that's now /auth/login's job.
+    expect(reg.user).toBeUndefined();
+    expect(reg.accessToken).toBeUndefined();
+    expect(reg.idToken).toBeUndefined();
+
+    // Login establishes the session and issues tokens. The mock recovers
+    // firstName/lastName from `registeredUsers` keyed by email (Issue #142).
+    const login = await fetch(`${API_URL}/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'roundtrip@test.dev', password: 'TestPass123!' }),
+    }).then((r) => r.json());
+    expect(login.user.email).toBe('roundtrip@test.dev');
+    expect(login.user.firstName).toBe('Round');
+    expect(login.user.lastName).toBe('Trip');
+    expect(typeof login.accessToken).toBe('string');
     // idToken must be distinct from accessToken so the frontend's
     // `idToken ?? accessToken` preference is exercised on the production path.
-    expect(typeof reg.idToken).toBe('string');
-    expect(reg.idToken).not.toBe(reg.accessToken);
+    expect(typeof login.idToken).toBe('string');
+    expect(login.idToken).not.toBe(login.accessToken);
 
     // /auth/me using the idToken as Bearer (production code path).
     const me = await fetch(`${API_URL}/auth/me`, {
-      headers: { Authorization: `Bearer ${reg.idToken}` },
+      headers: { Authorization: `Bearer ${login.idToken}` },
     }).then((r) => r.json());
     // /auth/me MUST wrap the user in { user } per
     // services/authService.ts:185 — NOT a bare User object.
@@ -210,8 +232,10 @@ describe('Auth handlers (msw/node)', () => {
   // ----------------------------------------------------------------
 
   it('Issue #141: /auth/me falls back to lastIssuedUser when token is unknown but Bearer is present', async () => {
-    // Step 1: register so `lastIssuedUser` is populated.
-    const reg = await fetch(`${API_URL}/auth/register`, {
+    // Step 1: register the user (no tokens — Cognito doesn't issue at
+    // registration; mirrors the real backend per Issue #222 R1 F-01),
+    // then login to populate `lastIssuedUser` via `issueTokens`.
+    await fetch(`${API_URL}/auth/register`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -219,14 +243,19 @@ describe('Auth handlers (msw/node)', () => {
         firstName: 'SW',
         lastName: 'Restart',
       }),
+    });
+    const login = await fetch(`${API_URL}/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'sw-restart@test.dev', password: 'irrelevant-in-mock' }),
     }).then((r) => r.json());
-    expect(reg.user.email).toBe('sw-restart@test.dev');
+    expect(login.user.email).toBe('sw-restart@test.dev');
 
     // Step 2: simulate a Service-Worker restart by passing a Bearer
     // token the closure-scoped `sessions` Map has never seen. Pre-#141
     // this returned a hardcoded 'Mock User'; post-#141 the recovery
     // path should resolve to whoever was last issued tokens (i.e. the
-    // user we just registered).
+    // user we just logged in).
     const me = await fetch(`${API_URL}/auth/me`, {
       headers: { Authorization: 'Bearer mock-access-fake-token-the-sw-forgot' },
     });
@@ -252,7 +281,10 @@ describe('Auth handlers (msw/node)', () => {
   });
 
   it('Issue #142: /auth/login looks up registeredUsers and returns the registered firstName/lastName', async () => {
-    // Step 1: register with concrete identity fields.
+    // Step 1: register with concrete identity fields (no tokens
+    // returned — the real backend's flat MessageResponse contract).
+    // The handler still populates `registeredUsers` keyed by email so
+    // the subsequent login can recover identity.
     const reg = await fetch(`${API_URL}/auth/register`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -262,11 +294,12 @@ describe('Auth handlers (msw/node)', () => {
         lastName: 'Bar',
       }),
     }).then((r) => r.json());
-    expect(reg.user.firstName).toBe('Foo');
+    expect(typeof reg.message).toBe('string');
 
     // Step 2: log in with the same email but supply NO firstName/lastName.
     // Pre-#142 the handler fabricated a generic 'Mock User' here; post-#142
-    // it resolves the previously-registered identity by email.
+    // it resolves the previously-registered identity by email — this is
+    // the assertion that locks Issue #142.
     const login = await fetch(`${API_URL}/auth/login`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -216,8 +216,18 @@ const authHandlers: HttpHandler[] = [
     // round-trip can recover firstName/lastName instead of fabricating a
     // generic "Mock User" (Issue #142).
     registeredUsers.set(user.email.toLowerCase(), user);
-    const tokens = issueTokens(user);
-    return HttpResponse.json({ user, ...tokens }, { status: 200 });
+    // Real backend (`backend/functions/auth/register.ts:165`) returns
+    // ONLY a flat `{ message }` envelope on 201 — Cognito does not
+    // issue tokens at registration. The mock must mirror that shape so
+    // the frontend's typed `MessageResponse` reader is exercised
+    // end-to-end. Issuing tokens here was the source of Issue #222 R1
+    // F-01: the service layer's `storeAuthTokens` was writing
+    // `idToken: undefined` into localStorage on every registration in
+    // production while tests continued to pass against the buggy mock.
+    return HttpResponse.json(
+      { message: 'User registered successfully. You can now log in.' },
+      { status: 201 }
+    );
   }),
 
   // POST /auth/login

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -3,18 +3,31 @@
  *
  * Provides the login interface using the LoginForm component.
  * Handles authentication flow and redirects to dashboard on success.
+ *
+ * Reads optional router state `{ message: string }` so that other pages
+ * (e.g., RegisterPage auto-login fallback) can surface a friendly hint
+ * without introducing a separate toast library.
  */
 
-import { useNavigate } from 'react-router-dom';
-import { Container, Box, Paper } from '@mui/material';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { Container, Box, Paper, Alert } from '@mui/material';
 import { LoginForm } from '../components/Auth/LoginForm';
 import { useAuth } from '../contexts/AuthContext';
 import { ROUTES } from '../config/constants';
 import type { LoginRequest } from '../services/authService';
 
+/** Shape of state that other pages may pass when redirecting here. */
+interface LoginLocationState {
+  message?: string;
+}
+
 export default function LoginPage() {
   const navigate = useNavigate();
+  const location = useLocation();
   const { login } = useAuth();
+
+  // Friendly message from a referring page (e.g., post-register fallback).
+  const inboundMessage = (location.state as LoginLocationState | null)?.message;
 
   const handleLogin = async (data: LoginRequest) => {
     await login(data);
@@ -31,6 +44,11 @@ export default function LoginPage() {
           alignItems: 'center',
         }}
       >
+        {inboundMessage && (
+          <Alert severity="info" sx={{ mb: 2, width: '100%' }}>
+            {inboundMessage}
+          </Alert>
+        )}
         <Paper
           elevation={3}
           sx={{

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -2,7 +2,15 @@
  * Register Page
  *
  * Provides the registration interface using the RegisterForm component.
- * Handles user registration flow and redirects to dashboard on success.
+ * Handles user registration flow with auto-login on success (issue #222).
+ *
+ * Post-registration flow (dev environment — Cognito auto-confirm enabled):
+ *   1. POST /auth/register succeeds (201, no tokens returned by real backend).
+ *   2. Silently attempt login with the same credentials via the shared login().
+ *   3a. Login succeeds  → navigate to /dashboard (user is already authenticated).
+ *   3b. Login fails     → navigate to /login with a friendly message in router
+ *       state so the user can sign in manually without losing their credentials.
+ *       The RegisterForm surfaces the error; this page does NOT crash.
  */
 
 import { useNavigate } from 'react-router-dom';
@@ -14,7 +22,7 @@ import type { RegisterRequest } from '../services/authService';
 
 export default function RegisterPage() {
   const navigate = useNavigate();
-  const { register } = useAuth();
+  const { register, login } = useAuth();
 
   const handleRegister = async (formData: {
     email: string;
@@ -29,8 +37,29 @@ export default function RegisterPage() {
       acceptedTerms: true,
       acceptedPrivacy: true,
     };
+
+    // Step 1: create the account (201; real backend does not return tokens).
     await register(registrationData);
-    navigate(ROUTES.DASHBOARD);
+
+    // Step 2: silently auto-login using the same credentials so the user
+    // lands on /dashboard without having to retype their password (issue #222).
+    // In dev, Cognito auto-confirms the account immediately after registration,
+    // so login succeeds synchronously. In prod (email verification required)
+    // this call will fail — we catch it and fall back to /login gracefully.
+    try {
+      await login({ email: formData.email, password: formData.password });
+      navigate(ROUTES.DASHBOARD);
+    } catch {
+      // Auto-login failed (e.g., prod env where email verification is still
+      // required, or a transient network error). Redirect to /login and pass
+      // a friendly hint so the user knows their account was created.
+      navigate(ROUTES.LOGIN, {
+        state: {
+          message:
+            'Account created! Please sign in — check your email if verification is required.',
+        },
+      });
+    }
   };
 
   return (

--- a/frontend/src/pages/__tests__/LoginPage.test.tsx
+++ b/frontend/src/pages/__tests__/LoginPage.test.tsx
@@ -57,6 +57,37 @@ describe('LoginPage - Integration Tests', () => {
       expect(screen.getByRole('button', { name: /log in/i })).toBeInTheDocument();
     });
 
+    it('should render inbound message from router state (post-register fallback)', () => {
+      // LoginPage reads location.state.message and renders it in an Alert.
+      // This path is exercised when RegisterPage catches a failed auto-login
+      // and redirects here with a friendly hint (issue #222).
+      render(
+        <MemoryRouter
+          initialEntries={[
+            {
+              pathname: '/login',
+              state: { message: 'Account created! Please sign in.' },
+            },
+          ]}
+        >
+          <AuthProvider>
+            <Routes>
+              <Route path="/login" element={<LoginPage />} />
+              <Route path="/dashboard" element={<MockDashboard />} />
+            </Routes>
+          </AuthProvider>
+        </MemoryRouter>
+      );
+
+      expect(screen.getByText(/account created/i)).toBeInTheDocument();
+    });
+
+    it('should not render an alert when there is no inbound router state', () => {
+      renderWithAppContext();
+
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+
     it('should render navigation links', () => {
       renderWithAppContext();
 

--- a/frontend/src/pages/__tests__/RegisterPage.test.tsx
+++ b/frontend/src/pages/__tests__/RegisterPage.test.tsx
@@ -258,9 +258,7 @@ describe('RegisterPage - Integration Tests', () => {
       );
 
       // Friendly message should be visible on the login page
-      expect(
-        screen.getByText(/account created/i)
-      ).toBeInTheDocument();
+      expect(screen.getByText(/account created/i)).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/pages/__tests__/RegisterPage.test.tsx
+++ b/frontend/src/pages/__tests__/RegisterPage.test.tsx
@@ -5,6 +5,7 @@
  * - Page rendering with AuthProvider and Router
  * - Form submission with mock API
  * - Navigation after successful registration
+ * - Auto-login after registration (issue #222)
  * - Error handling
  *
  * These tests catch integration issues that unit tests miss,
@@ -17,6 +18,7 @@ import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import { http, HttpResponse, delay } from 'msw';
 import RegisterPage from '../RegisterPage';
+import LoginPage from '../LoginPage';
 import { AuthProvider } from '../../contexts/AuthContext';
 import { server } from '../../mocks/server';
 
@@ -39,6 +41,8 @@ function renderWithAppContext(initialRoute = '/register') {
         <Routes>
           <Route path="/register" element={<RegisterPage />} />
           <Route path="/dashboard" element={<MockDashboard />} />
+          {/* LoginPage included to test the auto-login fallback redirect */}
+          <Route path="/login" element={<LoginPage />} />
         </Routes>
       </AuthProvider>
     </MemoryRouter>
@@ -187,6 +191,76 @@ describe('RegisterPage - Integration Tests', () => {
 
       // Note: localStorage storage is tested in authService.test.ts
       // This integration test focuses on the navigation flow
+    });
+  });
+
+  /**
+   * Auto-Login After Registration (issue #222)
+   *
+   * Covers the two outcomes of the silent login attempt that follows a
+   * successful POST /auth/register in dev (Cognito auto-confirm enabled):
+   *
+   *   (a) register success + login success → /dashboard
+   *   (b) register success + login failure → /login with friendly message
+   */
+  describe('Auto-Login After Registration (issue #222)', () => {
+    /** Fill and submit the registration form with valid test data. */
+    async function fillAndSubmitForm(user: ReturnType<typeof userEvent.setup>) {
+      await user.type(screen.getByLabelText(/first name/i), 'Jane');
+      await user.type(screen.getByLabelText(/last name/i), 'Demo');
+      await user.type(screen.getByLabelText(/email/i), 'jane@example.com');
+      await user.type(screen.getByLabelText(/^password/i), 'Secure123!');
+      await user.type(screen.getByLabelText(/confirm password/i), 'Secure123!');
+      await user.click(screen.getByLabelText(/terms of service/i));
+      await user.click(screen.getByLabelText(/privacy policy/i));
+      await user.click(screen.getByRole('button', { name: /sign up/i }));
+    }
+
+    it('(a) register success → auto-login succeeds → navigates to /dashboard', async () => {
+      // Both /auth/register and /auth/login use the default MSW handlers
+      // which return a valid user + tokens — mirrors the dev auto-confirm flow.
+      const user = userEvent.setup();
+      renderWithAppContext();
+
+      await fillAndSubmitForm(user);
+
+      await waitFor(
+        () => {
+          expect(screen.getByRole('heading', { name: /dashboard/i })).toBeInTheDocument();
+        },
+        { timeout: 3000 }
+      );
+    });
+
+    it('(b) register success but auto-login fails → navigates to /login with friendly message', async () => {
+      // Override only the login handler to simulate a failure (e.g., prod env
+      // where email verification is still required, returning 403).
+      server.use(
+        http.post(/\/auth\/login$/, () => {
+          return HttpResponse.json(
+            { message: 'Please verify your email address before logging in.' },
+            { status: 403 }
+          );
+        })
+      );
+
+      const user = userEvent.setup();
+      renderWithAppContext();
+
+      await fillAndSubmitForm(user);
+
+      // Should redirect to /login (not crash, not stay on /register)
+      await waitFor(
+        () => {
+          expect(screen.getByRole('button', { name: /log in/i })).toBeInTheDocument();
+        },
+        { timeout: 3000 }
+      );
+
+      // Friendly message should be visible on the login page
+      expect(
+        screen.getByText(/account created/i)
+      ).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/services/__tests__/authService.test.ts
+++ b/frontend/src/services/__tests__/authService.test.ts
@@ -50,17 +50,14 @@ describe('AuthService - Registration', () => {
     localStorage.clear();
   });
 
-  it('should register new user successfully', async () => {
+  it('should register new user successfully and NOT store tokens (issue #222)', async () => {
+    // The real backend (register.ts) returns HTTP 201 + { message } only —
+    // no user object, no tokens. authService.register() must NOT call
+    // storeAuthTokens; doing so would write empty/undefined fields into the
+    // session blob and corrupt any existing session.
     const mockResponse: Partial<AxiosResponse> = {
       data: {
-        user: {
-          id: 'user-123',
-          email: 'test@example.com',
-          firstName: 'John',
-          lastName: 'Doe',
-        },
-        accessToken: 'mock-access-token',
-        refreshToken: 'mock-refresh-token',
+        message: 'User registered successfully. You can now log in.',
       },
       status: 201,
     };
@@ -88,41 +85,21 @@ describe('AuthService - Registration', () => {
       acceptedPrivacy: true,
     });
 
-    // Without an idToken in the mock response, storeAuthTokens falls back
-    // to the accessToken at the ingest seam so existing behaviour is
-    // preserved. The blob persists both fields atomically.
+    // Confirm the server message is returned to the caller.
+    expect(result.message).toBe('User registered successfully. You can now log in.');
+
+    // The session blob must be untouched — registration does not log the user in.
+    // The caller (RegisterPage → AuthContext.login) is responsible for that step.
     const session = getStoredSession();
-    expect(session).toEqual({
-      idToken: 'mock-access-token',
-      accessToken: 'mock-access-token',
-      refreshToken: 'mock-refresh-token',
-      user: {
-        id: 'user-123',
-        email: 'test@example.com',
-        firstName: 'John',
-        lastName: 'Doe',
-      },
-    });
-
-    // Verify user data is returned
-    expect(result.user).toEqual({
-      id: 'user-123',
-      email: 'test@example.com',
-      firstName: 'John',
-      lastName: 'Doe',
-    });
-
-    expect(result.accessToken).toBe('mock-access-token');
+    expect(session).toBeNull();
   });
 
-  it('should use idToken as Bearer credential when present in register response', async () => {
+  it('should not write tokens to localStorage on registration (regression guard)', async () => {
+    // Explicit guard: even if the mock accidentally returns token-shaped data,
+    // authService.register() must never call storeAuthTokens. This test will
+    // fail if someone re-introduces the storeAuthTokens call in register().
     const mockResponse: Partial<AxiosResponse> = {
-      data: {
-        user: { id: 'user-123', email: 'test@example.com', firstName: 'John', lastName: 'Doe' },
-        accessToken: 'mock-access-token',
-        idToken: 'mock-id-token',
-        refreshToken: 'mock-refresh-token',
-      },
+      data: { message: 'User registered successfully. You can now log in.' },
       status: 201,
     };
 
@@ -138,12 +115,7 @@ describe('AuthService - Registration', () => {
       acceptedPrivacy: true,
     });
 
-    // API Gateway CognitoUserPoolsAuthorizer requires the ID token.
-    // The session blob preserves both tokens distinctly.
-    const session = getStoredSession();
-    expect(session?.idToken).toBe('mock-id-token');
-    expect(session?.accessToken).toBe('mock-access-token');
-    expect(session?.refreshToken).toBe('mock-refresh-token');
+    expect(localStorage.getItem('lfmt_session')).toBeNull();
   });
 
   it('should handle registration errors', async () => {

--- a/frontend/src/services/authService.ts
+++ b/frontend/src/services/authService.ts
@@ -153,13 +153,19 @@ function storeAuthTokens(tokens: {
 /**
  * Register a new user
  *
+ * The real backend (register.ts) returns HTTP 201 + `{ message: string }` —
+ * no tokens, no user object. This function intentionally does NOT call
+ * storeAuthTokens; doing so would write empty/undefined values into
+ * localStorage and corrupt the session blob. The caller (RegisterPage via
+ * AuthContext.register) must call login() separately to obtain tokens
+ * (issue #222).
+ *
  * @param data - Registration details (email, password, name)
- * @returns User data and authentication tokens
+ * @returns Server message confirming account creation
  * @throws ApiError if registration fails
  */
-async function register(data: RegisterRequest): Promise<AuthResponse> {
-  const response = await apiClient.post<AuthResponse>('/auth/register', data);
-  storeAuthTokens(response.data);
+async function register(data: RegisterRequest): Promise<MessageResponse> {
+  const response = await apiClient.post<MessageResponse>('/auth/register', data);
   return response.data;
 }
 


### PR DESCRIPTION
## Summary

Resolves #222. After a successful registration the SPA was redirecting users to `/login`, forcing them to retype the credentials they had just provided. The dev environment auto-confirms the Cognito user (per `docs/AUTH-AUTO-CONFIRM.md`), so this was pure friction with no security upside. Investor demo would feel like \"register, then log in again — is it broken?\".

This change:

- Chains an immediate `login()` call after `register()` resolves successfully and navigates to `/dashboard`.
- On any login failure (401, network, or — most importantly — production's email-not-confirmed path), routes the user to `/login` with a friendly inline message via `location.state`.
- Makes the `register → login` chain SRP-clean: `AuthContext.register()` stays a thin account-creation API; the page-layer `RegisterPage` orchestrates the two-step UX. Future callers (admin onboarding, CLI, etc.) can call `register()` without an implicit login side effect.
- Fixes a session-corruption bug discovered in OMC R1 self-review: `authService.register()` was calling `storeAuthTokens()` on a `{ message }` response, silently writing `idToken: undefined` / `accessToken: undefined` to localStorage on every registration. Tests had been masking it because the MSW mock returned the wrong shape; tests now assert `session === null` post-register.

## Production-path safety

In production where Cognito requires email verification, the auto-login `login()` will throw with NotAuthorizedException / UserNotConfirmedException. The `catch` block redirects to `/login` with `location.state.message = 'Account created. Please log in.'` (or equivalent). No silent failure, no broken UX.

## Files

- `frontend/src/pages/RegisterPage.tsx` — chain `login()` after `register()`; navigate to `/dashboard`; fallback to `/login` with state message
- `frontend/src/contexts/AuthContext.tsx` — `register()` no longer calls `setUser` (real backend returns no tokens); JSDoc updated
- `frontend/src/pages/LoginPage.tsx` — read optional `location.state.message` and render via MUI `Alert`; typed `LoginLocationState` interface
- `frontend/src/services/authService.ts` — return type corrected to `MessageResponse`; removed wrong `storeAuthTokens()` call
- `frontend/src/services/__tests__/authService.test.ts` — tests rewritten to assert real backend contract (no tokens on register)
- `frontend/src/contexts/__tests__/AuthContext.test.tsx` — mock updated to `MessageResponse` shape
- `frontend/src/pages/__tests__/RegisterPage.test.tsx` — 2 new tests (success path → /dashboard; login-failure fallback → /login with message)
- `frontend/src/pages/__tests__/LoginPage.test.tsx` — 2 new tests (renders Alert when state.message set; no spurious Alert when absent)

## OMC R1 self-review

A structured pre-team-review pass was conducted on this branch — see the dedicated review comment for findings, severity matrix, and remediation actions.

## Test plan

- [x] `npm run type-check` — pass on all touched files
- [x] `npm run lint` — clean (0 warnings)
- [x] `npm test` — auth suite 454 passed, 10 skipped (11 pre-existing failures in unrelated translation tests, present on main)
- [ ] Verify against deployed dev once merged: register a fresh account → expect `/dashboard` immediately

## Closes

- Closes #222