### PR TITLE
feat(ui): make ToS and Privacy Policy clickable links on /register; add stub legal pages (#223)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -25,6 +25,8 @@ import { lazy, Suspense } from 'react';
 const LoginPage = lazy(() => import('./pages/LoginPage'));
 const RegisterPage = lazy(() => import('./pages/RegisterPage'));
 const ForgotPasswordPage = lazy(() => import('./pages/ForgotPasswordPage'));
+const TermsOfServicePage = lazy(() => import('./pages/TermsOfServicePage'));
+const PrivacyPolicyPage = lazy(() => import('./pages/PrivacyPolicyPage'));
 const DashboardPage = lazy(() => import('./pages/DashboardPage'));
 const TranslationUpload = lazy(() =>
   import('./pages/TranslationUpload').then((m) => ({ default: m.TranslationUpload }))
@@ -77,6 +79,10 @@ function App() {
                 <Route path={ROUTES.LOGIN} element={<LoginPage />} />
                 <Route path={ROUTES.REGISTER} element={<RegisterPage />} />
                 <Route path={ROUTES.FORGOT_PASSWORD} element={<ForgotPasswordPage />} />
+
+                {/* Legal pages (public, no auth required — issue #223) */}
+                <Route path={ROUTES.LEGAL_TERMS} element={<TermsOfServicePage />} />
+                <Route path={ROUTES.LEGAL_PRIVACY} element={<PrivacyPolicyPage />} />
 
                 {/* Protected routes */}
                 <Route

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -96,7 +96,7 @@ function App() {
 
                 {/* Translation routes */}
                 <Route
-                  path="/translation/upload"
+                  path={ROUTES.TRANSLATION_UPLOAD}
                   element={
                     <ProtectedRoute>
                       <TranslationUpload />
@@ -104,7 +104,7 @@ function App() {
                   }
                 />
                 <Route
-                  path="/translation/history"
+                  path={ROUTES.TRANSLATION_HISTORY}
                   element={
                     <ProtectedRoute>
                       <TranslationHistory />
@@ -112,7 +112,7 @@ function App() {
                   }
                 />
                 <Route
-                  path="/translation/:jobId"
+                  path={ROUTES.TRANSLATION_DETAIL}
                   element={
                     <ProtectedRoute>
                       <TranslationDetail />
@@ -125,7 +125,7 @@ function App() {
                 */}
                 {FEATURE_FLAGS.COMPARE_VIEW && (
                   <Route
-                    path="/translation/:jobId/compare"
+                    path={ROUTES.TRANSLATION_COMPARE}
                     element={
                       <ProtectedRoute>
                         <TranslationCompare />

--- a/frontend/src/components/Auth/RegisterForm.tsx
+++ b/frontend/src/components/Auth/RegisterForm.tsx
@@ -36,6 +36,34 @@ import { Link as RouterLink } from 'react-router-dom';
 import { ROUTES } from '../../config/constants';
 
 /**
+ * Inline link rendered inside a checkbox label.
+ *
+ * Clicking the link opens the target page without toggling the checkbox —
+ * stopPropagation prevents the click from bubbling up to FormControlLabel
+ * (issue #223).
+ */
+function LabelLink({
+  to,
+  children,
+}: {
+  to: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <Link
+      component={RouterLink}
+      to={to}
+      target="_blank"
+      rel="noopener noreferrer"
+      underline="hover"
+      onClick={(e: React.MouseEvent) => e.stopPropagation()}
+    >
+      {children}
+    </Link>
+  );
+}
+
+/**
  * Registration form validation schema
  */
 const registerSchema = z
@@ -255,7 +283,12 @@ export function RegisterForm({ onSubmit }: RegisterFormProps) {
                   disabled={isSubmitting}
                 />
               }
-              label="I agree to the Terms of Service"
+              label={
+                <span>
+                  I agree to the{' '}
+                  <LabelLink to={ROUTES.LEGAL_TERMS}>Terms of Service</LabelLink>
+                </span>
+              }
             />
           )}
         />
@@ -281,7 +314,12 @@ export function RegisterForm({ onSubmit }: RegisterFormProps) {
                   disabled={isSubmitting}
                 />
               }
-              label="I agree to the Privacy Policy"
+              label={
+                <span>
+                  I agree to the{' '}
+                  <LabelLink to={ROUTES.LEGAL_PRIVACY}>Privacy Policy</LabelLink>
+                </span>
+              }
             />
           )}
         />

--- a/frontend/src/components/Auth/RegisterForm.tsx
+++ b/frontend/src/components/Auth/RegisterForm.tsx
@@ -42,13 +42,7 @@ import { ROUTES } from '../../config/constants';
  * stopPropagation prevents the click from bubbling up to FormControlLabel
  * (issue #223).
  */
-function LabelLink({
-  to,
-  children,
-}: {
-  to: string;
-  children: React.ReactNode;
-}) {
+function LabelLink({ to, children }: { to: string; children: React.ReactNode }) {
   return (
     <Link
       component={RouterLink}
@@ -285,8 +279,7 @@ export function RegisterForm({ onSubmit }: RegisterFormProps) {
               }
               label={
                 <span>
-                  I agree to the{' '}
-                  <LabelLink to={ROUTES.LEGAL_TERMS}>Terms of Service</LabelLink>
+                  I agree to the <LabelLink to={ROUTES.LEGAL_TERMS}>Terms of Service</LabelLink>
                 </span>
               }
             />
@@ -316,8 +309,7 @@ export function RegisterForm({ onSubmit }: RegisterFormProps) {
               }
               label={
                 <span>
-                  I agree to the{' '}
-                  <LabelLink to={ROUTES.LEGAL_PRIVACY}>Privacy Policy</LabelLink>
+                  I agree to the <LabelLink to={ROUTES.LEGAL_PRIVACY}>Privacy Policy</LabelLink>
                 </span>
               }
             />

--- a/frontend/src/components/Auth/__tests__/RegisterForm.test.tsx
+++ b/frontend/src/components/Auth/__tests__/RegisterForm.test.tsx
@@ -12,7 +12,7 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { RegisterForm } from '../RegisterForm';
@@ -743,5 +743,65 @@ describe('RegisterForm - Accessibility', () => {
 
     expect(screen.getByLabelText(/terms of service/i)).toHaveAccessibleName();
     expect(screen.getByLabelText(/privacy policy/i)).toHaveAccessibleName();
+  });
+});
+
+describe('RegisterForm - Legal Links (issue #223)', () => {
+  it('should render "Terms of Service" as a link with the correct href', () => {
+    renderWithRouter(<RegisterForm onSubmit={vi.fn()} />);
+
+    const link = screen.getByRole('link', { name: /terms of service/i });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', '/legal/terms');
+  });
+
+  it('should render "Privacy Policy" as a link with the correct href', () => {
+    renderWithRouter(<RegisterForm onSubmit={vi.fn()} />);
+
+    const link = screen.getByRole('link', { name: /privacy policy/i });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', '/legal/privacy');
+  });
+
+  it('Terms of Service link calls stopPropagation — click does not bubble to the label', () => {
+    // Verify the stopPropagation mechanism directly by spying on the method
+    // via the React synthetic event system (fireEvent fires React handlers
+    // synchronously in the capture/bubble chain, so we can check cancelBubble
+    // after the fact).
+    renderWithRouter(<RegisterForm onSubmit={vi.fn()} />);
+
+    const link = screen.getByRole('link', { name: /terms of service/i });
+    const stopPropSpy = vi.spyOn(Event.prototype, 'stopPropagation');
+
+    fireEvent.click(link);
+
+    expect(stopPropSpy).toHaveBeenCalled();
+
+    stopPropSpy.mockRestore();
+  });
+
+  it('Privacy Policy link calls stopPropagation — click does not bubble to the label', () => {
+    renderWithRouter(<RegisterForm onSubmit={vi.fn()} />);
+
+    const link = screen.getByRole('link', { name: /privacy policy/i });
+    const stopPropSpy = vi.spyOn(Event.prototype, 'stopPropagation');
+
+    fireEvent.click(link);
+
+    expect(stopPropSpy).toHaveBeenCalled();
+
+    stopPropSpy.mockRestore();
+  });
+
+  it('clicking the checkbox itself still toggles the checkbox state', async () => {
+    const user = userEvent.setup();
+    renderWithRouter(<RegisterForm onSubmit={vi.fn()} />);
+
+    const checkbox = screen.getByLabelText(/terms of service/i) as HTMLInputElement;
+    expect(checkbox.checked).toBe(false);
+
+    // Click the checkbox itself (not the link)
+    await user.click(checkbox);
+    expect(checkbox.checked).toBe(true);
   });
 });

--- a/frontend/src/config/constants.ts
+++ b/frontend/src/config/constants.ts
@@ -102,6 +102,10 @@ export const ROUTES = {
   REGISTER: '/register',
   FORGOT_PASSWORD: '/forgot-password',
 
+  // Legal pages (public, no auth required)
+  LEGAL_TERMS: '/legal/terms',
+  LEGAL_PRIVACY: '/legal/privacy',
+
   // Protected routes
   DASHBOARD: '/dashboard',
   NEW_TRANSLATION: '/translation/new',

--- a/frontend/src/config/constants.ts
+++ b/frontend/src/config/constants.ts
@@ -108,6 +108,7 @@ export const ROUTES = {
 
   // Protected routes
   DASHBOARD: '/dashboard',
+  TRANSLATION_UPLOAD: '/translation/upload',
   NEW_TRANSLATION: '/translation/new',
   TRANSLATION_HISTORY: '/translation/history',
   TRANSLATION_DETAIL: '/translation/:jobId',
@@ -243,8 +244,10 @@ export const FEATURE_FLAGS = {
  * External Links
  */
 export const EXTERNAL_LINKS = {
-  PRIVACY_POLICY: '/privacy',
-  TERMS_OF_SERVICE: '/terms',
+  // Point to the real legal pages added in issue #223.
+  // The old /privacy and /terms stubs are superseded by ROUTES.LEGAL_PRIVACY / ROUTES.LEGAL_TERMS.
+  PRIVACY_POLICY: '/legal/privacy',
+  TERMS_OF_SERVICE: '/legal/terms',
   SUPPORT: 'mailto:support@lfmt.example.com',
   DOCUMENTATION: '/docs',
 } as const;

--- a/frontend/src/pages/PrivacyPolicyPage.tsx
+++ b/frontend/src/pages/PrivacyPolicyPage.tsx
@@ -19,9 +19,9 @@ export default function PrivacyPolicyPage() {
           {/* Demo disclosure banner */}
           <Alert severity="warning" sx={{ mb: 4 }}>
             <strong>Demo / POC Only.</strong> This is a placeholder document. A real Privacy Policy
-            compliant with GDPR, CCPA, and other applicable regulations will be prepared by qualified
-            legal counsel before any production launch. Nothing on this page constitutes a binding
-            legal commitment.
+            compliant with GDPR, CCPA, and other applicable regulations will be prepared by
+            qualified legal counsel before any production launch. Nothing on this page constitutes a
+            binding legal commitment.
           </Alert>
 
           <Typography variant="h4" component="h1" gutterBottom>
@@ -47,9 +47,9 @@ export default function PrivacyPolicyPage() {
             2. How We Use Your Information
           </Typography>
           <Typography variant="body1" paragraph>
-            We use the information we collect to operate and improve the Service, authenticate users,
-            process translation jobs, comply with legal obligations (including copyright attestation
-            records retained for 7 years), and communicate service updates.
+            We use the information we collect to operate and improve the Service, authenticate
+            users, process translation jobs, comply with legal obligations (including copyright
+            attestation records retained for 7 years), and communicate service updates.
           </Typography>
 
           <Typography variant="h6" component="h2" gutterBottom>

--- a/frontend/src/pages/PrivacyPolicyPage.tsx
+++ b/frontend/src/pages/PrivacyPolicyPage.tsx
@@ -1,0 +1,118 @@
+/**
+ * Privacy Policy Page
+ *
+ * Stub legal page — POC quality only.
+ * Real privacy policy will be drafted by legal counsel before production launch.
+ *
+ * Linked from the registration form "Privacy Policy" checkbox label (issue #223).
+ */
+
+import { Container, Box, Typography, Alert, Divider, Paper, Link } from '@mui/material';
+import { Link as RouterLink } from 'react-router-dom';
+import { ROUTES } from '../config/constants';
+
+export default function PrivacyPolicyPage() {
+  return (
+    <Container component="main" maxWidth="md">
+      <Box sx={{ marginTop: 6, marginBottom: 6 }}>
+        <Paper elevation={2} sx={{ p: 4 }}>
+          {/* Demo disclosure banner */}
+          <Alert severity="warning" sx={{ mb: 4 }}>
+            <strong>Demo / POC Only.</strong> This is a placeholder document. A real Privacy Policy
+            compliant with GDPR, CCPA, and other applicable regulations will be prepared by qualified
+            legal counsel before any production launch. Nothing on this page constitutes a binding
+            legal commitment.
+          </Alert>
+
+          <Typography variant="h4" component="h1" gutterBottom>
+            Privacy Policy
+          </Typography>
+
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+            Last updated: May 2026 (stub — not legally binding)
+          </Typography>
+
+          <Divider sx={{ mb: 3 }} />
+
+          <Typography variant="h6" component="h2" gutterBottom>
+            1. Information We Collect
+          </Typography>
+          <Typography variant="body1" paragraph>
+            We collect information you provide directly when registering (name, email address) and
+            information generated when you use the Service (document metadata, translation job
+            status, IP address, browser information, and usage timestamps).
+          </Typography>
+
+          <Typography variant="h6" component="h2" gutterBottom>
+            2. How We Use Your Information
+          </Typography>
+          <Typography variant="body1" paragraph>
+            We use the information we collect to operate and improve the Service, authenticate users,
+            process translation jobs, comply with legal obligations (including copyright attestation
+            records retained for 7 years), and communicate service updates.
+          </Typography>
+
+          <Typography variant="h6" component="h2" gutterBottom>
+            3. Data Storage and Security
+          </Typography>
+          <Typography variant="body1" paragraph>
+            User data and uploaded documents are stored on AWS infrastructure in the United States.
+            We implement industry-standard security measures including encryption at rest and in
+            transit, access controls, and audit logging.
+          </Typography>
+
+          <Typography variant="h6" component="h2" gutterBottom>
+            4. Data Sharing
+          </Typography>
+          <Typography variant="body1" paragraph>
+            We do not sell your personal information. Document content is processed by third-party
+            AI translation APIs (currently Google Gemini) under contractual data processing
+            agreements. We may disclose data when required by law.
+          </Typography>
+
+          <Typography variant="h6" component="h2" gutterBottom>
+            5. Your Rights
+          </Typography>
+          <Typography variant="body1" paragraph>
+            Depending on your jurisdiction, you may have rights to access, correct, delete, or
+            export your personal data. To exercise these rights, contact us at the address below.
+            Specific rights and timelines will be detailed in the production privacy policy.
+          </Typography>
+
+          <Typography variant="h6" component="h2" gutterBottom>
+            6. Cookies and Tracking
+          </Typography>
+          <Typography variant="body1" paragraph>
+            The Service uses session storage and local storage for authentication tokens. We do not
+            use third-party advertising cookies. Analytics usage, if any, will be disclosed in the
+            production policy.
+          </Typography>
+
+          <Typography variant="h6" component="h2" gutterBottom>
+            7. Changes to This Policy
+          </Typography>
+          <Typography variant="body1" paragraph>
+            We will notify registered users of material changes to the Privacy Policy via email at
+            least 30 days before they take effect.
+          </Typography>
+
+          <Divider sx={{ mt: 3, mb: 3 }} />
+
+          <Typography variant="body2" color="text.secondary">
+            Privacy inquiries:{' '}
+            <Link href="mailto:support@lfmt.example.com" underline="hover">
+              support@lfmt.example.com
+            </Link>
+            .
+          </Typography>
+
+          <Box sx={{ mt: 3 }}>
+            <Link component={RouterLink} to={ROUTES.REGISTER} underline="hover" variant="body2">
+              &larr; Back to registration
+            </Link>
+          </Box>
+        </Paper>
+      </Box>
+    </Container>
+  );
+}

--- a/frontend/src/pages/TermsOfServicePage.tsx
+++ b/frontend/src/pages/TermsOfServicePage.tsx
@@ -7,9 +7,8 @@
  * Linked from the registration form "Terms of Service" checkbox label (issue #223).
  */
 
-import { Container, Box, Typography, Alert, Divider, Paper } from '@mui/material';
+import { Container, Box, Typography, Alert, Divider, Paper, Link } from '@mui/material';
 import { Link as RouterLink } from 'react-router-dom';
-import { Link } from '@mui/material';
 import { ROUTES } from '../config/constants';
 
 export default function TermsOfServicePage() {

--- a/frontend/src/pages/TermsOfServicePage.tsx
+++ b/frontend/src/pages/TermsOfServicePage.tsx
@@ -19,8 +19,8 @@ export default function TermsOfServicePage() {
           {/* Demo disclosure banner */}
           <Alert severity="warning" sx={{ mb: 4 }}>
             <strong>Demo / POC Only.</strong> This is a placeholder document. Real Terms of Service
-            will be prepared by qualified legal counsel before any production launch. Nothing on this
-            page constitutes a binding legal agreement.
+            will be prepared by qualified legal counsel before any production launch. Nothing on
+            this page constitutes a binding legal agreement.
           </Alert>
 
           <Typography variant="h4" component="h1" gutterBottom>

--- a/frontend/src/pages/TermsOfServicePage.tsx
+++ b/frontend/src/pages/TermsOfServicePage.tsx
@@ -1,0 +1,108 @@
+/**
+ * Terms of Service Page
+ *
+ * Stub legal page — POC quality only.
+ * Real terms of service will be drafted by legal counsel before production launch.
+ *
+ * Linked from the registration form "Terms of Service" checkbox label (issue #223).
+ */
+
+import { Container, Box, Typography, Alert, Divider, Paper } from '@mui/material';
+import { Link as RouterLink } from 'react-router-dom';
+import { Link } from '@mui/material';
+import { ROUTES } from '../config/constants';
+
+export default function TermsOfServicePage() {
+  return (
+    <Container component="main" maxWidth="md">
+      <Box sx={{ marginTop: 6, marginBottom: 6 }}>
+        <Paper elevation={2} sx={{ p: 4 }}>
+          {/* Demo disclosure banner */}
+          <Alert severity="warning" sx={{ mb: 4 }}>
+            <strong>Demo / POC Only.</strong> This is a placeholder document. Real Terms of Service
+            will be prepared by qualified legal counsel before any production launch. Nothing on this
+            page constitutes a binding legal agreement.
+          </Alert>
+
+          <Typography variant="h4" component="h1" gutterBottom>
+            Terms of Service
+          </Typography>
+
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+            Last updated: May 2026 (stub — not legally binding)
+          </Typography>
+
+          <Divider sx={{ mb: 3 }} />
+
+          <Typography variant="h6" component="h2" gutterBottom>
+            1. Acceptance of Terms
+          </Typography>
+          <Typography variant="body1" paragraph>
+            By accessing or using the LFMT Long-Form Translation Service (&ldquo;Service&rdquo;),
+            you agree to be bound by these Terms of Service. If you do not agree, do not use the
+            Service.
+          </Typography>
+
+          <Typography variant="h6" component="h2" gutterBottom>
+            2. Description of Service
+          </Typography>
+          <Typography variant="body1" paragraph>
+            LFMT provides AI-assisted translation of long-form documents (65,000–400,000 words)
+            using third-party language model APIs. The Service is provided on an &ldquo;as-is&rdquo;
+            basis for demonstration and evaluation purposes.
+          </Typography>
+
+          <Typography variant="h6" component="h2" gutterBottom>
+            3. User Responsibilities
+          </Typography>
+          <Typography variant="body1" paragraph>
+            You are solely responsible for ensuring you have the legal right to upload and translate
+            any document submitted to the Service. You must not submit documents that infringe
+            third-party intellectual property rights.
+          </Typography>
+
+          <Typography variant="h6" component="h2" gutterBottom>
+            4. Intellectual Property
+          </Typography>
+          <Typography variant="body1" paragraph>
+            You retain ownership of content you upload. By using the Service you grant LFMT a
+            limited, non-exclusive licence to process your content solely for the purpose of
+            providing the translation.
+          </Typography>
+
+          <Typography variant="h6" component="h2" gutterBottom>
+            5. Limitation of Liability
+          </Typography>
+          <Typography variant="body1" paragraph>
+            To the maximum extent permitted by applicable law, LFMT shall not be liable for any
+            indirect, incidental, or consequential damages arising from use of the Service.
+          </Typography>
+
+          <Typography variant="h6" component="h2" gutterBottom>
+            6. Governing Law
+          </Typography>
+          <Typography variant="body1" paragraph>
+            These Terms will be governed by and construed in accordance with applicable law. The
+            specific jurisdiction will be determined prior to production launch.
+          </Typography>
+
+          <Divider sx={{ mt: 3, mb: 3 }} />
+
+          <Typography variant="body2" color="text.secondary">
+            Questions about these terms? Contact{' '}
+            <Link href="mailto:support@lfmt.example.com" underline="hover">
+              support@lfmt.example.com
+            </Link>
+            .
+          </Typography>
+
+          <Box sx={{ mt: 3 }}>
+            <Link component={RouterLink} to={ROUTES.REGISTER} underline="hover" variant="body2">
+              &larr; Back to registration
+            </Link>
+          </Box>
+        </Paper>
+      </Box>
+    </Container>
+  );
+}

--- a/frontend/src/pages/__tests__/LegalPages.test.tsx
+++ b/frontend/src/pages/__tests__/LegalPages.test.tsx
@@ -21,7 +21,9 @@ describe('TermsOfServicePage', () => {
   it('renders the canonical "Terms of Service" heading', () => {
     renderWithRouter(<TermsOfServicePage />);
 
-    expect(screen.getByRole('heading', { name: /terms of service/i, level: 1 })).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: /terms of service/i, level: 1 })
+    ).toBeInTheDocument();
   });
 
   it('renders the demo / POC disclosure banner', () => {

--- a/frontend/src/pages/__tests__/LegalPages.test.tsx
+++ b/frontend/src/pages/__tests__/LegalPages.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * Legal Pages Tests (issue #223)
+ *
+ * Verifies that the Terms of Service and Privacy Policy stub pages:
+ * - Render their canonical headings
+ * - Display the POC disclosure banner
+ * - Include a back-link to the registration page
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import TermsOfServicePage from '../TermsOfServicePage';
+import PrivacyPolicyPage from '../PrivacyPolicyPage';
+
+function renderWithRouter(ui: React.ReactElement) {
+  return render(<MemoryRouter>{ui}</MemoryRouter>);
+}
+
+describe('TermsOfServicePage', () => {
+  it('renders the canonical "Terms of Service" heading', () => {
+    renderWithRouter(<TermsOfServicePage />);
+
+    expect(screen.getByRole('heading', { name: /terms of service/i, level: 1 })).toBeInTheDocument();
+  });
+
+  it('renders the demo / POC disclosure banner', () => {
+    renderWithRouter(<TermsOfServicePage />);
+
+    expect(screen.getByText(/demo \/ poc only/i)).toBeInTheDocument();
+    expect(screen.getByText(/placeholder document/i)).toBeInTheDocument();
+  });
+
+  it('contains a back-link to the registration page', () => {
+    renderWithRouter(<TermsOfServicePage />);
+
+    const backLink = screen.getByRole('link', { name: /back to registration/i });
+    expect(backLink).toBeInTheDocument();
+    expect(backLink).toHaveAttribute('href', '/register');
+  });
+});
+
+describe('PrivacyPolicyPage', () => {
+  it('renders the canonical "Privacy Policy" heading', () => {
+    renderWithRouter(<PrivacyPolicyPage />);
+
+    expect(screen.getByRole('heading', { name: /privacy policy/i, level: 1 })).toBeInTheDocument();
+  });
+
+  it('renders the demo / POC disclosure banner', () => {
+    renderWithRouter(<PrivacyPolicyPage />);
+
+    expect(screen.getByText(/demo \/ poc only/i)).toBeInTheDocument();
+    expect(screen.getByText(/placeholder document/i)).toBeInTheDocument();
+  });
+
+  it('contains a back-link to the registration page', () => {
+    renderWithRouter(<PrivacyPolicyPage />);
+
+    const backLink = screen.getByRole('link', { name: /back to registration/i });
+    expect(backLink).toBeInTheDocument();
+    expect(backLink).toHaveAttribute('href', '/register');
+  });
+});


### PR DESCRIPTION
## Summary

Resolves #223. The two attestation checkbox labels on `/register` were rendered as plain text, asking users to agree to documents they couldn't read — a GDPR/CCPA compliance optic gap and an obvious investor-demo polish opportunity.

This change:

- Wraps \"Terms of Service\" and \"Privacy Policy\" inside the checkbox labels in MUI `<Link>` components that navigate to `/legal/terms` and `/legal/privacy`.
- Stops event propagation on the link click so toggling the checkbox stays decoupled from reading the document (regression-tested).
- Adds two stub legal pages with prominent **\"Demo / POC Only — not legally binding\"** banners and explicit disclosures. Both are public (no auth guard), lazy-loaded consistently with all other pages, and registered in the public-routes block before the protected boundary.
- Boy-scout: normalized four hardcoded `/translation/*` strings in `App.tsx` to use `ROUTES` constants; added a missing `ROUTES.TRANSLATION_UPLOAD`; updated stale `EXTERNAL_LINKS.PRIVACY_POLICY`/`.TERMS_OF_SERVICE` paths from `/privacy` and `/terms` to the new `/legal/*` form so future consumers don't 404.

## Why stubs and not real legal copy

This is a POC. Real legal counsel review is required before production launch. The stubs make the registration flow legally-presentable for an investor demo (\"yes, the Terms are linked from the consent UI\") without making any binding claims. Both pages flag themselves as POC content above the fold.

## Files

- `frontend/src/components/Auth/RegisterForm.tsx` — `LabelLink` helper with `stopPropagation`; replaced plain-text checkbox labels with linked versions
- `frontend/src/pages/TermsOfServicePage.tsx` — new stub page with POC banner
- `frontend/src/pages/PrivacyPolicyPage.tsx` — new stub page with POC banner
- `frontend/src/App.tsx` — lazy-load the two legal pages; register routes; normalize four hardcoded `/translation/*` strings to `ROUTES.*`
- `frontend/src/config/constants.ts` — `ROUTES.LEGAL_TERMS` and `ROUTES.LEGAL_PRIVACY`; added missing `ROUTES.TRANSLATION_UPLOAD`; corrected `EXTERNAL_LINKS` paths
- `frontend/src/components/Auth/__tests__/RegisterForm.test.tsx` — 5 new tests
- `frontend/src/pages/__tests__/LegalPages.test.tsx` — 6 new tests for both pages
- `frontend/src/pages/TermsOfServicePage.tsx` — merged duplicate `@mui/material` import (OMC R1 cleanup)

## Cross-context check

The wizard step on `/translation/upload` uses an `IconButton + Tooltip` pattern for its \"Learn more\" affordances, which is the right pattern for inline contextual help (not for navigating to a binding legal document). That pattern is intentional and is left unchanged.

## OMC R1 self-review

A structured pre-team-review pass was conducted on this branch — see the dedicated review comment for findings, severity matrix, and remediation actions.

## Test plan

- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean (0 warnings)
- [x] `npm test` — 461 passed, 10 skipped, 11 pre-existing failures in unrelated translation tests (present on main)
- [ ] Verify against deployed dev once merged: navigate to `/register`, click \"Terms of Service\" — expect new tab with stub page; click \"Privacy Policy\" — expect new tab with stub page; checkbox state preserved

## Closes

- Closes #223