### PR TITLE
fix(api): strip trailing slash from BASE_URL to prevent double-slash URLs (#224)

### DIFF
--- a/frontend/src/config/constants.ts
+++ b/frontend/src/config/constants.ts
@@ -21,12 +21,17 @@ function getRequiredEnv(key: string): string {
  */
 export const API_CONFIG = {
   /**
-   * Base URL for API requests
-   * REQUIRED: Must be set via VITE_API_URL environment variable
-   * In development: proxied through Vite dev server
-   * In production: direct API Gateway URL
+   * Base URL for API requests.
+   * REQUIRED: Must be set via VITE_API_URL environment variable.
+   * In development: proxied through Vite dev server.
+   * In production: direct API Gateway URL.
+   *
+   * Trailing slash is stripped so that every URL join — whether via
+   * axios baseURL + leading-slash path, or via explicit template-literal
+   * concatenation in the refresh interceptor — produces exactly one
+   * slash separator and never yields a double-slash (issue #224).
    */
-  BASE_URL: getRequiredEnv('VITE_API_URL'),
+  BASE_URL: getRequiredEnv('VITE_API_URL').replace(/\/+$/, ''),
 
   /**
    * Request timeout in milliseconds

--- a/frontend/src/utils/__tests__/api.test.ts
+++ b/frontend/src/utils/__tests__/api.test.ts
@@ -766,6 +766,11 @@ describe('API Client - No double-slash in constructed URLs (issue #224)', () => 
 
   afterEach(() => {
     fullReset();
+    // Unstub env vars AND reset the module registry so that stubs set inside
+    // individual tests (vi.stubEnv + vi.resetModules) do not leak into
+    // subsequent test files or describe blocks.
+    vi.unstubAllEnvs();
+    vi.resetModules();
   });
 
   /**
@@ -776,7 +781,14 @@ describe('API Client - No double-slash in constructed URLs (issue #224)', () => 
     return url.replace(/^https?:\/\//, '');
   }
 
-  it('apiClient.get path should not produce // in the final URL', async () => {
+  it('apiClient.get path should not produce // in the final URL when VITE_API_URL has trailing slash', async () => {
+    // Simulate the copy-paste scenario: VITE_API_URL arrives with a trailing
+    // slash. Without vi.stubEnv + vi.resetModules the test uses the cached
+    // .env.test value (http://localhost:3000/v1 — no slash) and would pass
+    // even if the fix in constants.ts were reverted. This is the actual
+    // regression guard for issue #224.
+    vi.stubEnv('VITE_API_URL', 'http://localhost:3000/v1/');
+    vi.resetModules();
     const { createApiClient } = await import('../api');
     const client = createApiClient();
     const captured: string[] = [];
@@ -793,7 +805,11 @@ describe('API Client - No double-slash in constructed URLs (issue #224)', () => 
     expect(pathAfterScheme(captured[0])).not.toContain('//');
   });
 
-  it('apiClient.post path should not produce // in the final URL', async () => {
+  it('apiClient.post path should not produce // in the final URL when VITE_API_URL has trailing slash', async () => {
+    // Same rationale as the .get test above: stub with a trailing-slash value
+    // so this test fails when the constants.ts fix is absent.
+    vi.stubEnv('VITE_API_URL', 'http://localhost:3000/v1/');
+    vi.resetModules();
     const { createApiClient } = await import('../api');
     const client = createApiClient();
     const captured: string[] = [];

--- a/frontend/src/utils/__tests__/api.test.ts
+++ b/frontend/src/utils/__tests__/api.test.ts
@@ -744,6 +744,102 @@ describe('API Client - legacy access-only migration → first request (Round 2 i
   });
 });
 
+// =====================================================================
+// Issue #224: double-slash URL regression guard.
+//
+// VITE_API_URL may arrive with a trailing slash (e.g. when copy-pasted
+// from the CloudFormation output). Every request URL constructed from
+// BASE_URL must contain at most one slash at the join point — i.e., no
+// `//` anywhere except the protocol (`https://`).
+//
+// The test captures the raw URL via a custom axios adapter and checks
+// every callsite that constructs a path:
+//   - apiClient.get/post paths (prefix slash on path, handled by axios)
+//   - inline template literal in the refresh interceptor:
+//     `${API_CONFIG.BASE_URL}/auth/refresh`
+// =====================================================================
+
+describe('API Client - No double-slash in constructed URLs (issue #224)', () => {
+  beforeEach(() => {
+    fullReset();
+  });
+
+  afterEach(() => {
+    fullReset();
+  });
+
+  /**
+   * Strip the protocol scheme so assertions on `https://…` don't
+   * false-positive on the `://` in the scheme itself.
+   */
+  function pathAfterScheme(url: string): string {
+    return url.replace(/^https?:\/\//, '');
+  }
+
+  it('apiClient.get path should not produce // in the final URL', async () => {
+    const { createApiClient } = await import('../api');
+    const client = createApiClient();
+    const captured: string[] = [];
+    client.defaults.adapter = async (config) => {
+      captured.push(config.url ?? '');
+      return { data: {}, status: 200, statusText: 'OK', headers: {}, config };
+    };
+
+    await client.get('/auth/me');
+
+    // There must be exactly one captured URL and it must not contain //
+    // outside of the protocol scheme.
+    expect(captured).toHaveLength(1);
+    expect(pathAfterScheme(captured[0])).not.toContain('//');
+  });
+
+  it('apiClient.post path should not produce // in the final URL', async () => {
+    const { createApiClient } = await import('../api');
+    const client = createApiClient();
+    const captured: string[] = [];
+    client.defaults.adapter = async (config) => {
+      captured.push(config.url ?? '');
+      return { data: {}, status: 200, statusText: 'OK', headers: {}, config };
+    };
+
+    await client.post('/auth/refresh', { refreshToken: 'rt' });
+
+    expect(captured).toHaveLength(1);
+    expect(pathAfterScheme(captured[0])).not.toContain('//');
+  });
+
+  it('BASE_URL constant itself must not have a trailing slash', async () => {
+    // vi.stubEnv + vi.resetModules is required to force constants.ts to
+    // re-evaluate with a different VITE_API_URL value. Without the module
+    // reset the cached module instance is returned regardless of the stub.
+    vi.stubEnv('VITE_API_URL', 'https://example.execute-api.us-east-1.amazonaws.com/v1/');
+    vi.resetModules();
+    const { API_CONFIG } = await import('../../config/constants');
+    expect(API_CONFIG.BASE_URL).not.toMatch(/\/$/);
+    expect(API_CONFIG.BASE_URL).toBe(
+      'https://example.execute-api.us-east-1.amazonaws.com/v1'
+    );
+  });
+
+  it('BASE_URL with multiple trailing slashes is fully stripped', async () => {
+    vi.stubEnv('VITE_API_URL', 'https://example.execute-api.us-east-1.amazonaws.com/v1///');
+    vi.resetModules();
+    const { API_CONFIG } = await import('../../config/constants');
+    expect(API_CONFIG.BASE_URL).toBe(
+      'https://example.execute-api.us-east-1.amazonaws.com/v1'
+    );
+  });
+
+  it('BASE_URL without trailing slash is left unchanged', async () => {
+    vi.stubEnv('VITE_API_URL', 'https://example.execute-api.us-east-1.amazonaws.com/v1');
+    vi.resetModules();
+    const { API_CONFIG } = await import('../../config/constants');
+    expect(API_CONFIG.BASE_URL).toBe(
+      'https://example.execute-api.us-east-1.amazonaws.com/v1'
+    );
+  });
+});
+
 describe('API Client - Configuration', () => {
   it('should export createApiClient function', async () => {
     const { createApiClient } = await import('../api');

--- a/frontend/src/utils/__tests__/api.test.ts
+++ b/frontend/src/utils/__tests__/api.test.ts
@@ -832,27 +832,21 @@ describe('API Client - No double-slash in constructed URLs (issue #224)', () => 
     vi.resetModules();
     const { API_CONFIG } = await import('../../config/constants');
     expect(API_CONFIG.BASE_URL).not.toMatch(/\/$/);
-    expect(API_CONFIG.BASE_URL).toBe(
-      'https://example.execute-api.us-east-1.amazonaws.com/v1'
-    );
+    expect(API_CONFIG.BASE_URL).toBe('https://example.execute-api.us-east-1.amazonaws.com/v1');
   });
 
   it('BASE_URL with multiple trailing slashes is fully stripped', async () => {
     vi.stubEnv('VITE_API_URL', 'https://example.execute-api.us-east-1.amazonaws.com/v1///');
     vi.resetModules();
     const { API_CONFIG } = await import('../../config/constants');
-    expect(API_CONFIG.BASE_URL).toBe(
-      'https://example.execute-api.us-east-1.amazonaws.com/v1'
-    );
+    expect(API_CONFIG.BASE_URL).toBe('https://example.execute-api.us-east-1.amazonaws.com/v1');
   });
 
   it('BASE_URL without trailing slash is left unchanged', async () => {
     vi.stubEnv('VITE_API_URL', 'https://example.execute-api.us-east-1.amazonaws.com/v1');
     vi.resetModules();
     const { API_CONFIG } = await import('../../config/constants');
-    expect(API_CONFIG.BASE_URL).toBe(
-      'https://example.execute-api.us-east-1.amazonaws.com/v1'
-    );
+    expect(API_CONFIG.BASE_URL).toBe('https://example.execute-api.us-east-1.amazonaws.com/v1');
   });
 });
 


### PR DESCRIPTION
## Summary

Resolves #224. During the 2026-05-09 E2E sweep we observed a request:

\`\`\`
POST https://8brwlwf68h.execute-api.us-east-1.amazonaws.com/v1//auth/refresh
\`\`\`

API Gateway tolerates the double slash today (returns 200), but the URL is malformed. Stricter gateways or future custom domains with path-rewrite rules can 404 on it. Other refresh requests in the same session use the correct `/v1/auth/refresh` form, indicating inconsistent URL composition rather than a missing endpoint.

## Root cause

`API_CONFIG.BASE_URL` in `frontend/src/config/constants.ts` was `getRequiredEnv('VITE_API_URL')` verbatim. When `VITE_API_URL` carries a trailing slash (the project's own `CLAUDE.md` documented it that way), the 401-refresh interceptor at `frontend/src/utils/api.ts:592` constructs:

\`\`\`ts
\`\${API_CONFIG.BASE_URL}/auth/refresh\`
\`\`\`

…yielding `/v1//auth/refresh`. The `authService.ts` path (`apiClient.post('/auth/refresh', ...)`) was at risk too because axios joins `baseURL + path` naively when both edges have slashes.

## Fix

One-line change in `constants.ts`:

\`\`\`ts
BASE_URL: getRequiredEnv('VITE_API_URL').replace(/\\/+$/, '')
\`\`\`

Single source of truth, zero per-callsite changes, defensive against any number of trailing slashes (`/v1`, `/v1/`, `/v1////` all normalize to `/v1`).

## Tests

Five regression-guard tests added in `api.test.ts`:

- BASE_URL with trailing slash is normalized
- BASE_URL with multiple trailing slashes is normalized
- BASE_URL without trailing slash is unchanged
- `apiClient.get()` produces no `//` in the constructed URL when env has trailing slash
- `apiClient.post()` likewise

OMC R1 self-review caught that the adapter-based tests were initially **vacuous** (they used `.env.test`'s slash-free `VITE_API_URL` and would have passed even with the fix reverted). Hardened with `vi.stubEnv` + `vi.resetModules()` inside each test to force the trailing-slash scenario; `vi.unstubAllEnvs()` + `vi.resetModules()` in `afterEach` to prevent stub bleed. The fixed tests now actually exercise the bug scenario.

## Conflict-with-merged-PR-#218 check

PR #218 touched `frontend/src/utils/api.ts` (envelope shape, refresh-flow read paths). This PR touches `constants.ts` only — they don't overlap. Verified before push by rebasing on the post-#218 main without conflict.

## Follow-up filed

Issue #231 — `e2e/fixtures/url.ts` has a parallel `resolveApiUrl` helper using `.slice(0, -1)` (strips exactly one slash) instead of `/\\/+$/` (strips all). Divergent behavior on pathological inputs, low production risk, but a future maintenance trap. Filed as enhancement.

## OMC R1 self-review

A structured pre-team-review pass was conducted on this branch — see the dedicated review comment for findings, severity matrix, and remediation actions.

## Test plan

- [x] `npm run type-check` — clean (no new errors)
- [x] `npm run lint` — clean
- [x] `npm test` — 455 passed, 10 skipped, 11 pre-existing translation-suite failures (present on main)
- [ ] Verify against deployed dev once merged: open DevTools network panel; observe NO `//` in any constructed URL across login, refresh, jobs/upload, translation-status, etc.

## Closes

- Closes #224