### PR TITLE
refactor(types): Wave 1 Track C — frontend type-safety + sentinel hygiene (#215 #200 #217 #199)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2350,7 +2350,6 @@
       "version": "18.3.26",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.26.tgz",
       "integrity": "sha512-RFA/bURkcKzx/X9oumPG9Vp3D3JUgus/d0b67KB0t5S/raciymilkOa66olh78MUI92QLbEJevO7rvqU/kjwKA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",

--- a/frontend/src/__tests__/auth-integration.test.tsx
+++ b/frontend/src/__tests__/auth-integration.test.tsx
@@ -16,6 +16,7 @@ import { ProtectedRoute } from '../components/Auth/ProtectedRoute';
 import * as api from '../utils/api';
 import { setStoredSession } from '../utils/api';
 import { AUTH_CONFIG } from '../config/constants';
+import type { UserProfile } from '@lfmt/shared-types';
 
 // Mock API client
 vi.mock('../utils/api', async () => {
@@ -113,7 +114,8 @@ describe('Authentication Integration Tests', () => {
   });
 
   describe('Protected Route with Valid Authentication', () => {
-    const mockUser = {
+    const mockUser: UserProfile = {
+      userId: 'user-123',
       id: 'user-123',
       email: 'test@example.com',
       firstName: 'Test',

--- a/frontend/src/components/Auth/__tests__/ProtectedRoute.test.tsx
+++ b/frontend/src/components/Auth/__tests__/ProtectedRoute.test.tsx
@@ -65,6 +65,7 @@ function renderProtectedRoute(authContext: Partial<AuthContextType>) {
 
 describe('ProtectedRoute - Security Tests', () => {
   const mockUser: User = {
+    userId: 'test-user-id',
     id: 'test-user-id',
     email: 'test@example.com',
     firstName: 'Test',
@@ -215,6 +216,7 @@ describe('ProtectedRoute - Security Tests', () => {
 
     it('should handle user without all fields', () => {
       const incompleteUser: User = {
+        userId: 'test-id',
         id: 'test-id',
         email: 'test@example.com',
         firstName: '',

--- a/frontend/src/config/constants.ts
+++ b/frontend/src/config/constants.ts
@@ -54,9 +54,11 @@ export const AUTH_CONFIG = {
    * Local storage key for the one-blob session document (Issue #196).
    *
    * The entire authenticated session — `idToken`, `accessToken`,
-   * optional `refreshToken`, optional `expiresAt`, optional `user` —
-   * is serialized to JSON and stored under THIS single key. See the
-   * `StoredSession` type in `@lfmt/shared-types`.
+   * optional `refreshToken`, optional `user` — is serialized to JSON
+   * and stored under THIS single key. See the `StoredSession` type in
+   * `@lfmt/shared-types`. (`expiresAt` was removed in issue #200 — the
+   * refresh interceptor is reactive-on-401 only; `REFRESH_THRESHOLD_MS`
+   * is retained for future proactive-refresh work.)
    *
    * Atomicity: every session write replaces the blob in full, so the
    * fields cannot drift out of sync (the failure mode that motivated

--- a/frontend/src/config/constants.ts
+++ b/frontend/src/config/constants.ts
@@ -81,10 +81,16 @@ export const AUTH_CONFIG = {
    * source of truth — addition or rename here automatically
    * propagates to the migration code (Round 2 item 13).
    *
-   * Removal plan: tracked in issue #199. Once telemetry confirms no
-   * in-the-wild sessions pre-date the blob (one release cycle is
-   * sufficient — worst case is one 401 → refresh → re-login), this
-   * object can be deleted along with the migration code.
+   * Removal plan: tracked in issue #199.
+   *
+   * Safe removal window: 30 days after the 2026-05-04 deploy of PR #198
+   * — i.e., no earlier than 2026-06-04. The Cognito refresh token
+   * lifetime is 30 days; any user who has not logged in since before
+   * that deploy will have had their session silently migrated (or will
+   * receive a 401 → forced re-login that writes a fresh blob). After
+   * 2026-06-04 this object, `AUTH_CONFIG.LEGACY.*`, the migration
+   * helpers in `utils/api.ts`, and the migration tests in
+   * `utils/__tests__/api.test.ts` can all be deleted in one sweep.
    */
   LEGACY: {
     ID_TOKEN_KEY: 'lfmt_id_token',

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -32,12 +32,8 @@ import {
 } from 'react';
 import { authService } from '../services/authService';
 import { getAuthToken } from '../utils/api';
-import type {
-  User,
-  LoginRequest,
-  RegisterRequest,
-  RefreshTokenResponse,
-} from '../services/authService';
+import type { UserProfile } from '@lfmt/shared-types';
+import type { LoginRequest, RegisterRequest, RefreshTokenResponse } from '../services/authService';
 import type { ApiError } from '../utils/api';
 
 /**
@@ -45,7 +41,7 @@ import type { ApiError } from '../utils/api';
  */
 interface AuthContextState {
   /** Current authenticated user (null if not authenticated) */
-  user: User | null;
+  user: UserProfile | null;
 
   /** Whether user is currently authenticated */
   isAuthenticated: boolean;
@@ -95,7 +91,7 @@ interface AuthProviderProps {
  * Automatically loads user session on mount if token exists.
  */
 export function AuthProvider({ children }: AuthProviderProps) {
-  const [user, setUser] = useState<User | null>(null);
+  const [user, setUser] = useState<UserProfile | null>(null);
   // Issue #228: initialise isLoading to `true` when a session token already
   // exists in localStorage, so ProtectedRoute sees a loading state on the
   // very first render (before the async /auth/me probe completes) rather

--- a/frontend/src/contexts/__tests__/AuthContext.test.tsx
+++ b/frontend/src/contexts/__tests__/AuthContext.test.tsx
@@ -73,6 +73,7 @@ describe('AuthContext - Initialization', () => {
 
   it('should initialize with loading state when user is in localStorage', async () => {
     const mockUser = {
+      userId: 'user-123',
       id: 'user-123',
       email: 'test@example.com',
       firstName: 'John',
@@ -117,6 +118,7 @@ describe('AuthContext - Login', () => {
   it('should login user successfully', async () => {
     const mockAuthResponse = {
       user: {
+        userId: 'user-456',
         id: 'user-456',
         email: 'login@example.com',
         firstName: 'Jane',
@@ -184,6 +186,7 @@ describe('AuthContext - Login', () => {
 
     const mockAuthResponse = {
       user: {
+        userId: 'user-789',
         id: 'user-789',
         email: 'success@example.com',
         firstName: 'Success',
@@ -313,6 +316,7 @@ describe('AuthContext - Logout', () => {
   it('should logout user and clear state', async () => {
     const mockAuthResponse = {
       user: {
+        userId: 'user-123',
         id: 'user-123',
         email: 'test@example.com',
         firstName: 'Test',
@@ -398,6 +402,7 @@ describe('AuthContext - Token Refresh', () => {
 
   it('should handle refresh token failure and logout user', async () => {
     const mockUser = {
+      userId: 'user-123',
       id: 'user-123',
       email: 'test@example.com',
       firstName: 'Test',
@@ -498,6 +503,7 @@ describe('AuthContext - Initial User Load', () => {
 
   it('should load user from localStorage on mount', async () => {
     const mockUser = {
+      userId: 'stored-user',
       id: 'stored-user',
       email: 'stored@example.com',
       firstName: 'Stored',
@@ -607,12 +613,14 @@ describe('AuthContext - Initial User Load', () => {
     // that overwrite. Removing the guard from `AuthContext.tsx` makes this
     // test fail with `result.current.user === staleUser`.
     const staleUser = {
+      userId: 'user-stale',
       id: 'user-stale',
       email: 'stale@example.com',
       firstName: 'Stale',
       lastName: 'Mount',
     };
     const freshUser = {
+      userId: 'user-fresh',
       id: 'user-fresh',
       email: 'fresh@example.com',
       firstName: 'Fresh',

--- a/frontend/src/pages/__tests__/DashboardPage.test.tsx
+++ b/frontend/src/pages/__tests__/DashboardPage.test.tsx
@@ -52,6 +52,7 @@ function renderDashboard(authContext: Partial<AuthContextType>) {
 
 describe('DashboardPage', () => {
   const mockUser: User = {
+    userId: 'test-user-123',
     id: 'test-user-123',
     email: 'john.doe@example.com',
     firstName: 'John',
@@ -102,6 +103,7 @@ describe('DashboardPage', () => {
   describe('User Data Display', () => {
     it('should display full name correctly', () => {
       const user: User = {
+        userId: 'test-id',
         id: 'test-id',
         email: 'test@example.com',
         firstName: 'Jane',
@@ -115,6 +117,7 @@ describe('DashboardPage', () => {
 
     it('should display email correctly', () => {
       const user: User = {
+        userId: 'test-id',
         id: 'test-id',
         email: 'custom@email.com',
         firstName: 'Test',
@@ -129,6 +132,7 @@ describe('DashboardPage', () => {
 
     it('should handle user with empty first name', () => {
       const user: User = {
+        userId: 'test-id',
         id: 'test-id',
         email: 'test@example.com',
         firstName: '',
@@ -143,6 +147,7 @@ describe('DashboardPage', () => {
 
     it('should handle user with empty last name', () => {
       const user: User = {
+        userId: 'test-id',
         id: 'test-id',
         email: 'test@example.com',
         firstName: 'John',
@@ -157,6 +162,7 @@ describe('DashboardPage', () => {
 
     it('should handle special characters in user name', () => {
       const user: User = {
+        userId: 'test-id',
         id: 'test-id',
         email: 'test@example.com',
         firstName: "O'Brien",
@@ -245,6 +251,7 @@ describe('DashboardPage', () => {
   describe('Integration with AuthContext', () => {
     it('should use user from AuthContext', () => {
       const contextUser: User = {
+        userId: 'context-user',
         id: 'context-user',
         email: 'context@example.com',
         firstName: 'Context',
@@ -282,6 +289,7 @@ describe('DashboardPage', () => {
 
     it('should handle undefined user fields', () => {
       const user = {
+        userId: 'test-id',
         id: 'test-id',
         email: 'test@example.com',
         firstName: undefined as any,

--- a/frontend/src/pages/__tests__/NewTranslationPage.test.tsx
+++ b/frontend/src/pages/__tests__/NewTranslationPage.test.tsx
@@ -41,6 +41,7 @@ vi.mock('react-router-dom', async () => {
 describe('NewTranslationPage', () => {
   const mockLogout = vi.fn();
   const mockUser = {
+    userId: 'user-123',
     id: 'user-123',
     email: 'test@example.com',
     firstName: 'Test',
@@ -252,6 +253,7 @@ describe('NewTranslationPage', () => {
   describe('Edge Cases', () => {
     it('should handle user with missing firstName/lastName', () => {
       const minimalUser = {
+        userId: 'user-456',
         id: 'user-456',
         email: 'minimal@example.com',
         firstName: '',

--- a/frontend/src/pages/__tests__/TranslationCompare.test.tsx
+++ b/frontend/src/pages/__tests__/TranslationCompare.test.tsx
@@ -102,7 +102,7 @@ describe('TranslationCompare page', () => {
 
   it('shows 404 message when getJobStatus returns 404', async () => {
     vi.mocked(translationService.getJobStatus).mockRejectedValue(
-      new TranslationServiceError('not found', 404)
+      new TranslationServiceError('not found', 'API_GENERIC', 404)
     );
 
     renderAt();
@@ -115,7 +115,7 @@ describe('TranslationCompare page', () => {
   it('shows 403 message and navigates to dashboard after timeout', async () => {
     vi.useFakeTimers();
     vi.mocked(translationService.getJobStatus).mockRejectedValue(
-      new TranslationServiceError('forbidden', 403)
+      new TranslationServiceError('forbidden', 'API_GENERIC', 403)
     );
 
     renderAt();
@@ -138,7 +138,7 @@ describe('TranslationCompare page', () => {
   it('cleans up the 403 navigation timer on unmount (no stale navigate)', async () => {
     vi.useFakeTimers();
     vi.mocked(translationService.getJobStatus).mockRejectedValue(
-      new TranslationServiceError('forbidden', 403)
+      new TranslationServiceError('forbidden', 'API_GENERIC', 403)
     );
 
     const { unmount } = renderAt();
@@ -159,7 +159,7 @@ describe('TranslationCompare page', () => {
 
   it('shows generic message for other API errors', async () => {
     vi.mocked(translationService.getJobStatus).mockRejectedValue(
-      new TranslationServiceError('server bork', 500)
+      new TranslationServiceError('server bork', 'API_GENERIC', 500)
     );
 
     renderAt();

--- a/frontend/src/pages/__tests__/TranslationDetail.test.tsx
+++ b/frontend/src/pages/__tests__/TranslationDetail.test.tsx
@@ -49,11 +49,13 @@ vi.mock('../../services/translationService', () => ({
     downloadTranslation: vi.fn(),
     startTranslation: vi.fn(),
   },
+  // Issue #215: updated to match new 4-arg constructor (message, errorCode, statusCode?, originalError?).
   TranslationServiceError: class TranslationServiceError extends Error {
     constructor(
       message: string,
+      public errorCode: string,
       public statusCode?: number,
-      public code?: string
+      public originalError?: Error
     ) {
       super(message);
       this.name = 'TranslationServiceError';
@@ -483,7 +485,7 @@ describe('TranslationDetail', () => {
       const user = userEvent.setup();
       vi.mocked(translationService.getJobStatus).mockResolvedValue(mockCompletedJob);
       vi.mocked(translationService.downloadTranslation).mockRejectedValue(
-        new TranslationServiceError('Download failed', 500)
+        new TranslationServiceError('Download failed', 'API_GENERIC', 500)
       );
 
       renderComponent();
@@ -599,7 +601,7 @@ describe('TranslationDetail', () => {
       const user = userEvent.setup();
       vi.mocked(translationService.getJobStatus).mockResolvedValue(mockChunkedJob);
       vi.mocked(translationService.startTranslation).mockRejectedValue(
-        new TranslationServiceError('Failed to start', 500)
+        new TranslationServiceError('Failed to start', 'API_GENERIC', 500)
       );
 
       renderComponent();
@@ -689,7 +691,7 @@ describe('TranslationDetail', () => {
       vi.useFakeTimers({ shouldAdvanceTime: true });
 
       vi.mocked(translationService.getJobStatus).mockRejectedValue(
-        new TranslationServiceError('Forbidden', 403)
+        new TranslationServiceError('Forbidden', 'API_GENERIC', 403)
       );
 
       renderComponent();
@@ -714,7 +716,7 @@ describe('TranslationDetail', () => {
       vi.useFakeTimers({ shouldAdvanceTime: true });
 
       vi.mocked(translationService.getJobStatus).mockRejectedValue(
-        new TranslationServiceError('Forbidden', 403)
+        new TranslationServiceError('Forbidden', 'API_GENERIC', 403)
       );
 
       const { unmount } = renderComponent();

--- a/frontend/src/pages/__tests__/TranslationHistory.test.tsx
+++ b/frontend/src/pages/__tests__/TranslationHistory.test.tsx
@@ -40,11 +40,13 @@ vi.mock('../../services/translationService', () => ({
     getTranslationJobs: vi.fn(),
     downloadTranslation: vi.fn(),
   },
+  // Issue #215: updated to match new 4-arg constructor (message, errorCode, statusCode?, originalError?).
   TranslationServiceError: class TranslationServiceError extends Error {
     constructor(
       message: string,
+      public errorCode: string,
       public statusCode?: number,
-      public code?: string
+      public originalError?: Error
     ) {
       super(message);
       this.name = 'TranslationServiceError';
@@ -501,7 +503,7 @@ describe('TranslationHistory', () => {
       const user = userEvent.setup();
       vi.mocked(translationService.getTranslationJobs).mockResolvedValue(mockJobs);
       vi.mocked(translationService.downloadTranslation).mockRejectedValue(
-        new TranslationServiceError('Download failed', 500)
+        new TranslationServiceError('Download failed', 'API_GENERIC', 500)
       );
 
       renderComponent();
@@ -550,7 +552,7 @@ describe('TranslationHistory', () => {
   describe('Error Handling', () => {
     it('should show error message when loading jobs fails', async () => {
       vi.mocked(translationService.getTranslationJobs).mockRejectedValue(
-        new TranslationServiceError('Failed to fetch jobs', 500)
+        new TranslationServiceError('Failed to fetch jobs', 'API_GENERIC', 500)
       );
 
       renderComponent();
@@ -575,7 +577,7 @@ describe('TranslationHistory', () => {
     it('should clear error when clicking close button', async () => {
       const user = userEvent.setup();
       vi.mocked(translationService.getTranslationJobs).mockRejectedValue(
-        new TranslationServiceError('Failed to fetch jobs', 500)
+        new TranslationServiceError('Failed to fetch jobs', 'API_GENERIC', 500)
       );
 
       renderComponent();

--- a/frontend/src/pages/__tests__/TranslationUpload.test.tsx
+++ b/frontend/src/pages/__tests__/TranslationUpload.test.tsx
@@ -487,7 +487,7 @@ describe('TranslationUpload', () => {
       const TranslationServiceError = (await import('../../services/translationService'))
         .TranslationServiceError;
       vi.mocked(translationService.createLegalAttestation).mockRejectedValue(
-        new TranslationServiceError('Upload failed: invalid file', 400)
+        new TranslationServiceError('Upload failed: invalid file', 'API_GENERIC', 400)
       );
 
       const submitButton = screen.getByRole('button', { name: /Submit & Start Translation/i });
@@ -541,9 +541,10 @@ describe('TranslationUpload', () => {
 
       const { S3_UPLOAD_BLOCKED_MESSAGE, TranslationServiceError } =
         await import('../../services/translationService');
-      // statusCode left undefined to match the production wrap path.
+      // errorCode='S3_UPLOAD_BLOCKED' + statusCode=undefined matches the
+      // production wrapS3UploadError path for CSP/network blocks (issue #215).
       vi.mocked(translationService.uploadAndAwaitChunked).mockRejectedValue(
-        new TranslationServiceError(S3_UPLOAD_BLOCKED_MESSAGE)
+        new TranslationServiceError(S3_UPLOAD_BLOCKED_MESSAGE, 'S3_UPLOAD_BLOCKED')
       );
 
       const submitButton = screen.getByRole('button', { name: /Submit & Start Translation/i });
@@ -567,7 +568,7 @@ describe('TranslationUpload', () => {
       const TranslationServiceError = (await import('../../services/translationService'))
         .TranslationServiceError;
       vi.mocked(translationService.createLegalAttestation).mockRejectedValue(
-        new TranslationServiceError('Upload failed')
+        new TranslationServiceError('Upload failed', 'API_GENERIC')
       );
 
       await user.click(screen.getByRole('button', { name: /Submit & Start Translation/i }));

--- a/frontend/src/services/__tests__/authService.test.ts
+++ b/frontend/src/services/__tests__/authService.test.ts
@@ -25,6 +25,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { authService } from '../authService';
 import { apiClient, getStoredSession, setStoredSession, clearAuthToken } from '../../utils/api';
+import type { UserProfile } from '@lfmt/shared-types';
 import type { AxiosResponse } from 'axios';
 
 // Mock ONLY the apiClient — storage helpers run against real jsdom
@@ -370,7 +371,8 @@ describe('AuthService - Logout', () => {
       idToken: 'id',
       accessToken: 'test-access-token',
       refreshToken: 'test-refresh-token',
-      user: { id: 'user-123' },
+      // Minimal object — only tests that clearAuthToken removes the blob.
+      user: { userId: 'user-123', id: 'user-123' } as UserProfile,
     });
 
     await authService.logout();

--- a/frontend/src/services/__tests__/translationService.test.ts
+++ b/frontend/src/services/__tests__/translationService.test.ts
@@ -240,6 +240,9 @@ describe('TranslationService - uploadDocument', () => {
         expect.fail('Should have thrown TranslationServiceError');
       } catch (err) {
         expect(err).toBeInstanceOf(TranslationServiceError);
+        // Issue #215: assert on the stable errorCode discriminator, not
+        // on the user-visible copy that can be reworded independently.
+        expect((err as TranslationServiceError).errorCode).toBe('S3_UPLOAD_BLOCKED');
         expect((err as TranslationServiceError).message).toBe(S3_UPLOAD_BLOCKED_MESSAGE);
         expect((err as TranslationServiceError).statusCode).toBeUndefined();
       }
@@ -258,6 +261,7 @@ describe('TranslationService - uploadDocument', () => {
         expect.fail('Should have thrown TranslationServiceError');
       } catch (err) {
         expect(err).toBeInstanceOf(TranslationServiceError);
+        expect((err as TranslationServiceError).errorCode).toBe('S3_UPLOAD_BLOCKED');
         expect((err as TranslationServiceError).message).toBe(S3_UPLOAD_BLOCKED_MESSAGE);
         expect((err as TranslationServiceError).statusCode).toBeUndefined();
       }
@@ -276,6 +280,7 @@ describe('TranslationService - uploadDocument', () => {
         expect.fail('Should have thrown TranslationServiceError');
       } catch (err) {
         expect(err).toBeInstanceOf(TranslationServiceError);
+        expect((err as TranslationServiceError).errorCode).toBe('S3_HTTP_ERROR');
         expect((err as TranslationServiceError).statusCode).toBe(403);
         expect((err as TranslationServiceError).originalError).toBe(xhrError);
       }
@@ -301,6 +306,8 @@ describe('TranslationService - uploadDocument', () => {
         expect.fail('Should have thrown TranslationServiceError');
       } catch (err) {
         expect(err).toBeInstanceOf(TranslationServiceError);
+        // Issue #215: stable errorCode discriminator asserted alongside message.
+        expect((err as TranslationServiceError).errorCode).toBe('S3_UPLOAD_BLOCKED');
         expect((err as TranslationServiceError).message).toBe(S3_UPLOAD_BLOCKED_MESSAGE);
         expect((err as TranslationServiceError).statusCode).toBeUndefined();
       }
@@ -328,6 +335,7 @@ describe('TranslationService - uploadDocument', () => {
         expect.fail('Should have thrown TranslationServiceError');
       } catch (err) {
         expect(err).toBeInstanceOf(TranslationServiceError);
+        expect((err as TranslationServiceError).errorCode).toBe('S3_HTTP_ERROR');
         expect((err as TranslationServiceError).statusCode).toBe(403);
         expect((err as TranslationServiceError).originalError).toBe(rejectedAxiosError);
       }
@@ -340,7 +348,7 @@ describe('TranslationService - uploadDocument', () => {
     // rejects with something that's neither an Error nor an AxiosError.
     // -------------------------------------------------------------------------
     describe('wrapS3UploadError — non-Error rejected values', () => {
-      it('handles a thrown string gracefully (does not crash)', async () => {
+      it('handles a thrown string gracefully — errorCode S3_HTTP_ERROR (does not crash)', async () => {
         mockPresignedUrl();
         mockedUploadToS3.mockRejectedValueOnce('boom');
 
@@ -352,6 +360,7 @@ describe('TranslationService - uploadDocument', () => {
           expect.fail('Should have thrown TranslationServiceError');
         } catch (err) {
           expect(err).toBeInstanceOf(TranslationServiceError);
+          expect((err as TranslationServiceError).errorCode).toBe('S3_HTTP_ERROR');
           expect((err as TranslationServiceError).message).toBe('S3 upload failed');
           const original = (err as TranslationServiceError).originalError as Error | undefined;
           expect(original).toBeInstanceOf(Error);
@@ -359,7 +368,7 @@ describe('TranslationService - uploadDocument', () => {
         }
       });
 
-      it('handles a thrown undefined gracefully (does not crash)', async () => {
+      it('handles a thrown undefined gracefully — errorCode S3_HTTP_ERROR (does not crash)', async () => {
         mockPresignedUrl();
         mockedUploadToS3.mockRejectedValueOnce(undefined);
 
@@ -371,6 +380,7 @@ describe('TranslationService - uploadDocument', () => {
           expect.fail('Should have thrown TranslationServiceError');
         } catch (err) {
           expect(err).toBeInstanceOf(TranslationServiceError);
+          expect((err as TranslationServiceError).errorCode).toBe('S3_HTTP_ERROR');
           expect((err as TranslationServiceError).message).toBe('S3 upload failed');
           const original = (err as TranslationServiceError).originalError as Error | undefined;
           expect(original).toBeInstanceOf(Error);

--- a/frontend/src/services/authService.ts
+++ b/frontend/src/services/authService.ts
@@ -19,19 +19,21 @@ import {
   setStoredSession,
   updateStoredSession,
 } from '../utils/api';
-import type { StoredSession } from '@lfmt/shared-types';
+import type { StoredSession, UserProfile } from '@lfmt/shared-types';
 
 /**
- * User data returned from authentication endpoints
+ * @deprecated Use `UserProfile` from `@lfmt/shared-types` instead.
+ *
+ * This local alias is kept ONLY for consumers that already import `User`
+ * by name (e.g. test files, AuthContext). All new code should import
+ * `UserProfile` directly. See issue #200 for the unification plan.
+ *
+ * Wire-compatibility note: the backend login/register handlers return a
+ * shape that uses `userId` (matching UserProfile). Legacy sessions may
+ * carry `id` instead — `narrowStoredUser()` in `utils/api.ts` handles
+ * both spellings and normalises to `id` for SPA consumers.
  */
-export interface User {
-  id: string;
-  email: string;
-  firstName: string;
-  lastName: string;
-  emailVerified?: boolean;
-  createdAt?: string;
-}
+export type User = UserProfile;
 
 /**
  * Authentication response structure
@@ -45,7 +47,7 @@ export interface User {
  * back to `accessToken` in that case.
  */
 export interface AuthResponse {
-  user: User;
+  user: UserProfile;
   accessToken: string;
   idToken?: string;
   refreshToken: string;
@@ -118,17 +120,18 @@ export interface MessageResponse {
  *     read `accessToken` directly via `getStoredSession()` without
  *     coordinating a second migration.
  *
- * The user-shape coercion is safe: the backend's `User` and
- * `UserProfile` are wire-compatible for the fields the SPA renders
- * (id/email/firstName/lastName); the additional `UserProfile` fields
- * (`mfaEnabled`, `preferences`, ...) are optional from the SPA's
- * perspective and surface lazily when the user updates their profile.
+ * The user shape is now the canonical `UserProfile` from shared-types
+ * (issue #200). The fields the SPA renders (userId/email/firstName/lastName)
+ * are required; additional fields (`mfaEnabled`, `preferences`, etc.) are
+ * optional and surface lazily when the user updates their profile. Legacy
+ * sessions that stored `{ id, ... }` remain valid — `narrowStoredUser()`
+ * in `utils/api.ts` accepts both `id` and `userId`.
  */
 function storeAuthTokens(tokens: {
   accessToken: string;
   idToken?: string;
   refreshToken?: string;
-  user?: User;
+  user?: UserProfile;
 }): void {
   // ID token is what API Gateway CognitoUserPoolsAuthorizer validates.
   // The legacy `idToken ?? accessToken` fallback survives ONLY at this
@@ -142,9 +145,10 @@ function storeAuthTokens(tokens: {
     idToken,
     accessToken: tokens.accessToken,
     refreshToken: tokens.refreshToken,
-    // `user` on StoredSession is `unknown` — the SPA persists its
-    // narrower `User` shape and reads it back through `getStoredUser`,
-    // which returns `unknown` and forces callers to narrow.
+    // `user` on StoredSession is now `UserProfile | undefined` (issue #200).
+    // The login/register response carries a UserProfile-compatible shape;
+    // `narrowStoredUser()` in `utils/api.ts` handles sessions from before
+    // this migration that stored the older `{ id, ... }` shape.
     user: tokens.user,
   };
   setStoredSession(session);
@@ -247,8 +251,8 @@ async function logout(): Promise<void> {
  * @returns Current user data
  * @throws ApiError if not authenticated or request fails
  */
-async function getCurrentUser(): Promise<User> {
-  const response = await apiClient.get<{ user: User }>('/auth/me');
+async function getCurrentUser(): Promise<UserProfile> {
+  const response = await apiClient.get<{ user: UserProfile }>('/auth/me');
   return response.data.user;
 }
 

--- a/frontend/src/services/translationService.ts
+++ b/frontend/src/services/translationService.ts
@@ -141,22 +141,40 @@ export interface UploadAndAwaitChunkedOptions {
 }
 
 /**
+ * Typed discriminator for TranslationServiceError instances (issue #215).
+ *
+ * Replaces the previous `S3_UPLOAD_BLOCKED_MESSAGE` sentinel-string
+ * pattern. Having a stable enum as the dispatch key means:
+ *   - User-visible copy lives in ONE place (translationErrorMessages.ts).
+ *   - Tests assert on the enum value, not on copy that can be reworded.
+ *   - New error categories slot in without precedence-rule gymnastics.
+ *   - The compiler enforces exhaustive COPY_BY_CODE coverage.
+ *
+ * 'API_GENERIC' is the catch-all for errors that fall through to the
+ * existing status-code / message-pass-through logic in
+ * `getTranslationErrorMessage`. A TranslationServiceError without an
+ * explicit errorCode should never be constructed in practice; the
+ * `handleError` helper always sets one of the other variants.
+ */
+export type TranslationErrorCode =
+  | 'S3_UPLOAD_BLOCKED' // Transport-level block (CSP, network, DNS, XHR abort)
+  | 'S3_HTTP_ERROR' // S3 returned an HTTP error (e.g. SignatureDoesNotMatch, 403)
+  | 'API_GENERIC'; // API / service error — fall through to status-code map
+
+/**
  * Translation Service Error.
  *
- * `originalError` is typed `Error | undefined` (NOT `AxiosError`) so
- * the non-axios branch in `wrapS3UploadError` can preserve plain Error
- * causes (disk-full, generic XHR failure, etc.) without a type cast.
- * AxiosError extends Error, so axios-error code paths remain
- * compatible — callers that need axios-specific fields (`.response`,
- * `.request`) MUST narrow with `axios.isAxiosError(originalError)`
- * before reading them. This matches the wider runtime contract
- * ("preserve any underlying cause") and removes the `as unknown as
- * AxiosError` lie that previously allowed the field to silently lose
- * the cause shape (PR #214 OMC R2 M-1).
+ * `errorCode` (required) is a stable discriminator for the error category
+ * (issue #215). `statusCode` is preserved for HTTP errors so the
+ * `getTranslationErrorMessage` status-code table still works for API-side
+ * failures. `originalError` is typed `Error | undefined` (NOT `AxiosError`)
+ * so the non-axios branch in `wrapS3UploadError` can preserve plain Error
+ * causes without a type cast (PR #214 OMC R2 M-1).
  */
 export class TranslationServiceError extends Error {
   constructor(
     message: string,
+    public errorCode: TranslationErrorCode,
     public statusCode?: number,
     public originalError?: Error
   ) {
@@ -166,17 +184,16 @@ export class TranslationServiceError extends Error {
 }
 
 /**
- * Sentinel message used by `wrapS3UploadError` when the browser blocks
- * the S3 PUT before any HTTP response is received. Exported so the
- * page-level error mapper (`translationErrorMessages`) can match on it
- * deterministically rather than parsing a free-form string.
+ * Backwards-compatibility re-export for tests and call sites that still
+ * reference `S3_UPLOAD_BLOCKED_MESSAGE` by name (issue #215 cleanup).
  *
- * The wording is deliberately neutral: from the browser's perspective
- * we cannot prove which of {CSP block, network outage, DNS failure,
- * S3 outage} caused `error.response === undefined`, so we describe the
- * symptom and point the user at the action with the highest expected
- * value (contact support if persistent — these are config issues, not
- * transient network blips, in 95%+ of observed cases).
+ * @deprecated Use `error.errorCode === 'S3_UPLOAD_BLOCKED'` instead of
+ * matching on this string. This constant will be removed in a follow-up
+ * once all consumers have migrated to the `errorCode` discriminator.
+ *
+ * The message text is intentionally preserved verbatim so any UI that
+ * accidentally surfaces `error.message` instead of routing through
+ * `getTranslationErrorMessage` still shows the same copy as before.
  */
 export const S3_UPLOAD_BLOCKED_MESSAGE =
   'Upload was blocked. This is likely a configuration issue — please refresh and try again, or contact support if it persists.';
@@ -202,13 +219,19 @@ function wrapS3UploadError(error: unknown): TranslationServiceError {
   if (axios.isAxiosError(error)) {
     if (!error.response) {
       // No HTTP response — CSP block, DNS failure, or network outage.
-      return new TranslationServiceError(S3_UPLOAD_BLOCKED_MESSAGE, undefined, error);
+      return new TranslationServiceError(
+        S3_UPLOAD_BLOCKED_MESSAGE,
+        'S3_UPLOAD_BLOCKED',
+        undefined,
+        error
+      );
     }
     // S3 returned an HTTP error (e.g. SignatureDoesNotMatch, 403). Surface
     // its status to the page so it can branch on the curated table in
     // translationErrorMessages.
     return new TranslationServiceError(
       error.response.statusText || `S3 upload failed with status ${error.response.status}`,
+      'S3_HTTP_ERROR',
       error.response.status,
       error
     );
@@ -222,21 +245,25 @@ function wrapS3UploadError(error: unknown): TranslationServiceError {
   //   "Upload was cancelled"              — XHR `abort` event.
   //   "Upload failed with status N: …"   — XHR `load` event with status ≥ 300.
   //
-  // We map network / abort failures to S3_UPLOAD_BLOCKED_MESSAGE (same
-  // sentinel the axios path surfaced for `error.response === undefined`) so
-  // the page's error mapper still shows the targeted phrase instead of a raw
-  // XHR string. HTTP errors surface the message as-is; the status code is
-  // extracted from the message string so `translationErrorMessages` can use
-  // it in future (currently the code only tests `statusCode === 403`).
+  // Network / abort failures → errorCode 'S3_UPLOAD_BLOCKED' (same
+  // category as the axios `error.response === undefined` path) so the
+  // page's error mapper shows the targeted phrase instead of a raw XHR
+  // string. HTTP errors → 'S3_HTTP_ERROR'; the status code is extracted
+  // from the message string for the curated-table lookup.
   if (error instanceof Error) {
     const msg = error.message;
     if (msg === 'Network error during file upload' || msg === 'Upload was cancelled') {
-      return new TranslationServiceError(S3_UPLOAD_BLOCKED_MESSAGE, undefined, error);
+      return new TranslationServiceError(
+        S3_UPLOAD_BLOCKED_MESSAGE,
+        'S3_UPLOAD_BLOCKED',
+        undefined,
+        error
+      );
     }
     // "Upload failed with status N: text" — extract the numeric status.
     const statusMatch = /Upload failed with status (\d+)/.exec(msg);
     const statusCode = statusMatch ? parseInt(statusMatch[1], 10) : undefined;
-    return new TranslationServiceError(msg, statusCode, error);
+    return new TranslationServiceError(msg, 'S3_HTTP_ERROR', statusCode, error);
   }
 
   // Non-Error rejection — preserve as much context as possible.
@@ -244,7 +271,7 @@ function wrapS3UploadError(error: unknown): TranslationServiceError {
   // M-1 (PR #214 OMC R2): widen `originalError` to `Error | undefined`
   // at the field level so the non-axios branch no longer needs a cast.
   const originalError: Error = new Error(String(error));
-  return new TranslationServiceError('S3 upload failed', undefined, originalError);
+  return new TranslationServiceError('S3 upload failed', 'S3_HTTP_ERROR', undefined, originalError);
 }
 
 // ---------------------------------------------------------------------------
@@ -283,9 +310,9 @@ const handleError = (error: unknown): never => {
   if (axios.isAxiosError(error)) {
     const message = error.response?.data?.message || error.message;
     const statusCode = error.response?.status;
-    throw new TranslationServiceError(message, statusCode, error);
+    throw new TranslationServiceError(message, 'API_GENERIC', statusCode, error);
   }
-  throw new TranslationServiceError('An unexpected error occurred');
+  throw new TranslationServiceError('An unexpected error occurred', 'API_GENERIC');
 };
 
 /**

--- a/frontend/src/utils/__tests__/api.refresh.test.ts
+++ b/frontend/src/utils/__tests__/api.refresh.test.ts
@@ -38,6 +38,7 @@ import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import { createApiClient, getStoredSession, setStoredSession } from '../api';
 import { AUTH_CONFIG } from '../../config/constants';
+import type { UserProfile } from '@lfmt/shared-types';
 
 describe('API Token Refresh Interceptor', () => {
   let apiClient: ReturnType<typeof createApiClient>;
@@ -246,7 +247,7 @@ describe('API Token Refresh Interceptor', () => {
         idToken: 'expired-id',
         accessToken: 'expired-access',
         refreshToken: 'valid-refresh-token',
-        user: { id: 'u1' },
+        user: { id: 'u1' } as unknown as UserProfile,
       });
 
       instanceMock.onGet('/auth/me').replyOnce(401, {});

--- a/frontend/src/utils/__tests__/api.test.ts
+++ b/frontend/src/utils/__tests__/api.test.ts
@@ -27,7 +27,7 @@ import {
   __testResetLegacyShortCircuit,
 } from '../api';
 import { AUTH_CONFIG } from '../../config/constants';
-import type { StoredSession } from '@lfmt/shared-types';
+import type { StoredSession, UserProfile } from '@lfmt/shared-types';
 
 function readBlob(): StoredSession | null {
   const raw = localStorage.getItem(AUTH_CONFIG.SESSION_KEY);
@@ -146,7 +146,8 @@ describe('API Client - Token Management (one-blob model)', () => {
         idToken: 'id',
         accessToken: 'access',
         refreshToken: 'rt',
-        user: { id: 'u1' },
+        // Minimal fixture — tests clearAuthToken removes blob, not user shape.
+        user: { id: 'u1' } as unknown as UserProfile,
       });
 
       clearAuthToken();
@@ -180,7 +181,8 @@ describe('API Client - Token Management (one-blob model)', () => {
         idToken: 'id-1',
         accessToken: 'access-1',
         refreshToken: 'refresh-1',
-        user: { id: 'u1' },
+        // Minimal fixture — tests merge semantics, not user shape.
+        user: { id: 'u1' } as unknown as UserProfile,
       });
 
       updateStoredSession({ idToken: 'id-2', accessToken: 'access-2' });
@@ -224,8 +226,9 @@ describe('API Client - Token Management (one-blob model)', () => {
       // previous version of this test stored only id+email and
       // happened to pass because the helper was a bare passthrough;
       // the hardened narrower correctly returns null for that input.
+      // Legacy shape (id, not userId) — narrowStoredUser accepts both.
       const user = { id: 'u1', email: 'test@example.com', firstName: 'T', lastName: 'U' };
-      setStoredSession({ idToken: 'id', accessToken: 'a', user });
+      setStoredSession({ idToken: 'id', accessToken: 'a', user: user as unknown as UserProfile });
       expect(getStoredUser()).toEqual(user);
     });
 
@@ -236,7 +239,13 @@ describe('API Client - Token Management (one-blob model)', () => {
       // `unknown`, and a downstream consumer doing
       // `(user as User).email.toLowerCase()` would crash. Now they
       // get null and can branch defensively.
-      setStoredSession({ idToken: 'id', accessToken: 'a', user: { id: 'u1' } });
+      // Intentionally minimal (missing email/firstName/lastName) to verify
+      // narrowStoredUser returns null for malformed shapes.
+      setStoredSession({
+        idToken: 'id',
+        accessToken: 'a',
+        user: { id: 'u1' } as unknown as UserProfile,
+      });
       expect(getStoredUser()).toBeNull();
     });
   });
@@ -511,12 +520,53 @@ describe('API Client - narrowStoredUser (Round 2 item 8)', () => {
     expect(narrowStoredUser({})).toBeNull();
   });
 
+  // -----------------------------------------------------------------------
+  // Issue #200: accepts canonical UserProfile shape (`userId`) and normalises
+  // to `id` in the returned NarrowedStoredUser for SPA consumers.
+  // -----------------------------------------------------------------------
+
+  it('should accept userId (UserProfile shape) and normalise to id (issue #200)', () => {
+    const result = narrowStoredUser({
+      userId: 'up-1',
+      email: 'a@b.com',
+      firstName: 'A',
+      lastName: 'B',
+    });
+    // SPA consumers always receive `id` regardless of whether the stored
+    // object used `userId` (new sessions) or `id` (legacy sessions).
+    expect(result).toEqual({ id: 'up-1', email: 'a@b.com', firstName: 'A', lastName: 'B' });
+  });
+
+  it('should prefer userId over id when both are present', () => {
+    const result = narrowStoredUser({
+      userId: 'canonical',
+      id: 'legacy',
+      email: 'a@b.com',
+      firstName: 'A',
+      lastName: 'B',
+    });
+    expect(result?.id).toBe('canonical');
+  });
+
+  it('normalises isEmailVerified (UserProfile) → emailVerified (NarrowedStoredUser)', () => {
+    const result = narrowStoredUser({
+      userId: 'up-2',
+      email: 'a@b.com',
+      firstName: 'A',
+      lastName: 'B',
+      isEmailVerified: true,
+    });
+    expect(result?.emailVerified).toBe(true);
+  });
+
   it('getStoredUser routes through narrowStoredUser', () => {
     fullReset();
+    // Legacy shape (id, not userId) — narrowStoredUser accepts both and
+    // normalises to `id` in the returned NarrowedStoredUser.
     setStoredSession({
       idToken: 'id',
       accessToken: 'a',
-      user: { id: 'u1', email: 'a@b.com', firstName: 'A', lastName: 'B' },
+      user: { id: 'u1', email: 'a@b.com', firstName: 'A', lastName: 'B' } as unknown as UserProfile,
     });
     const user = getStoredUser();
     expect(user).toEqual({ id: 'u1', email: 'a@b.com', firstName: 'A', lastName: 'B' });
@@ -525,7 +575,7 @@ describe('API Client - narrowStoredUser (Round 2 item 8)', () => {
     setStoredSession({
       idToken: 'id',
       accessToken: 'a',
-      user: { id: 'u1' /* missing email, firstName, lastName */ },
+      user: { id: 'u1' /* missing email, firstName, lastName */ } as unknown as UserProfile,
     });
     expect(getStoredUser()).toBeNull();
 
@@ -990,7 +1040,7 @@ describe('API Client - Response Error Interceptor', () => {
       idToken: 'id',
       accessToken: 'test-token',
       refreshToken: 'refresh-token',
-      user: { id: '123' },
+      user: { id: '123' } as unknown as UserProfile,
     });
 
     const { createApiClient } = await import('../api');

--- a/frontend/src/utils/__tests__/translationErrorMessages.test.ts
+++ b/frontend/src/utils/__tests__/translationErrorMessages.test.ts
@@ -137,3 +137,58 @@ describe('getTranslationErrorMessage — null / non-object inputs', () => {
     }
   );
 });
+
+// ---------------------------------------------------------------------------
+// Issue #215: typed errorCode discriminator tests
+// ---------------------------------------------------------------------------
+
+describe('getTranslationErrorMessage — errorCode discriminator (issue #215)', () => {
+  it('returns the S3_UPLOAD_BLOCKED copy when errorCode is S3_UPLOAD_BLOCKED (no statusCode)', () => {
+    const error = {
+      errorCode: 'S3_UPLOAD_BLOCKED' as const,
+      message: 'some raw message that should be ignored',
+      statusCode: undefined,
+    };
+    expect(getTranslationErrorMessage(error)).toBe(
+      'Upload was blocked. This is likely a configuration issue — please refresh and try again, or contact support if it persists.'
+    );
+  });
+
+  it('S3_UPLOAD_BLOCKED errorCode takes precedence over a known statusCode', () => {
+    // Even when a statusCode is present, the errorCode should win.
+    const error = {
+      errorCode: 'S3_UPLOAD_BLOCKED' as const,
+      statusCode: 403,
+      message: 'ignored',
+    };
+    const result = getTranslationErrorMessage(error);
+    expect(result).toBe(
+      'Upload was blocked. This is likely a configuration issue — please refresh and try again, or contact support if it persists.'
+    );
+    // Must NOT return the 403 curated phrase.
+    expect(result).not.toMatch(/permission/i);
+  });
+
+  it('API_GENERIC errorCode falls through to the status-code table', () => {
+    // API_GENERIC has no COPY_BY_CODE entry; the 429 curated phrase should apply.
+    const error = {
+      errorCode: 'API_GENERIC' as const,
+      statusCode: 429,
+      message: 'raw rate limit message',
+    };
+    expect(getTranslationErrorMessage(error)).toBe(
+      'Translation rate limit reached — please try again in a moment.'
+    );
+  });
+
+  it('S3_HTTP_ERROR errorCode falls through to the status-code table for mapped statuses', () => {
+    const error = {
+      errorCode: 'S3_HTTP_ERROR' as const,
+      statusCode: 403,
+      message: 'Forbidden',
+    };
+    expect(getTranslationErrorMessage(error)).toBe(
+      "You don't have permission to start this translation."
+    );
+  });
+});

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -11,7 +11,7 @@
  */
 
 import axios, { AxiosInstance, AxiosError, InternalAxiosRequestConfig, AxiosResponse } from 'axios';
-import type { StoredSession } from '@lfmt/shared-types';
+import type { StoredSession, UserProfile } from '@lfmt/shared-types';
 import { API_CONFIG, AUTH_CONFIG, ERROR_MESSAGES } from '../config/constants';
 
 /**
@@ -106,10 +106,18 @@ function readLegacySession(): StoredSession | null {
     return null;
   }
 
-  let user: unknown;
+  // The stored user JSON may be the legacy `{ id, ... }` shape (pre-#200)
+  // or the canonical `UserProfile` shape (post-#200). Both are valid
+  // inputs for `narrowStoredUser()` at read time. Casting the raw parse
+  // result to `UserProfile` is safe here because: (a) all new UserProfile
+  // fields beyond the core four are optional, so a legacy `{ id, email,
+  // firstName, lastName }` object satisfies the type structurally; (b)
+  // `narrowStoredUser()` validates and normalises the actual value at every
+  // read, so a malformed blob can never propagate to a consumer.
+  let user: UserProfile | undefined;
   if (rawUser) {
     try {
-      user = JSON.parse(rawUser);
+      user = JSON.parse(rawUser) as UserProfile;
     } catch {
       // Corrupted user JSON — discard rather than fail the whole
       // migration. The user will be re-fetched via `/auth/me`.
@@ -359,14 +367,16 @@ export function getStoredRefreshToken(): string | null {
 }
 
 /**
- * Minimal user shape the SPA renders. Mirrors `User` in
- * `services/authService.ts` (which we cannot import here without
- * creating a circular dependency: authService → api → authService).
+ * Minimal user shape the SPA renders. Unified with the canonical
+ * `UserProfile` in `@lfmt/shared-types` via issue #200.
+ *
+ * `id` is the normalised identity key used by all SPA consumers (e.g.
+ * DashboardPage). New sessions store `userId` (UserProfile canonical
+ * field); legacy sessions stored `id` (pre-#200 `User` shape). The
+ * `narrowStoredUser()` helper accepts both spellings and always returns
+ * `id` so consumers are insulated from the migration.
  *
  * Field-set MUST stay aligned with `narrowStoredUser()` below.
- *
- * The unification of this shape with the canonical `UserProfile`
- * (in `@lfmt/shared-types`) is tracked in issue #200.
  */
 export interface NarrowedStoredUser {
   id: string;
@@ -379,12 +389,13 @@ export interface NarrowedStoredUser {
 
 /**
  * Runtime narrowing helper for the persisted user object (OMC Round 2
- * item 8). The `StoredSession.user` field is typed as `unknown` because
- * the SPA persists a narrower shape than canonical `UserProfile`
- * (see #200). This helper performs the narrowing safely:
+ * item 8, issue #200). Accepts both the legacy `{ id, ... }` shape
+ * (pre-#200 `User`) and the canonical `UserProfile` shape (`userId`),
+ * normalising to `NarrowedStoredUser` with `id` so SPA consumers are
+ * insulated from the migration.
  *
- *   - Returns the value cast to `NarrowedStoredUser` if it has the
- *     required string fields (`id`, `email`, `firstName`, `lastName`).
+ *   - Returns `NarrowedStoredUser` when all required string fields are
+ *     present (`id` OR `userId`, `email`, `firstName`, `lastName`).
  *   - Returns `null` otherwise (no session, malformed user, etc.).
  *
  * Consumers MUST NOT bare-cast the return of `getStoredUser()` — call
@@ -396,8 +407,17 @@ export function narrowStoredUser(value: unknown): NarrowedStoredUser | null {
     return null;
   }
   const candidate = value as Record<string, unknown>;
+  // Accept `userId` (UserProfile canonical field, issue #200) OR `id`
+  // (legacy User shape, pre-#200 sessions). Normalise to `id` in the
+  // returned value so all SPA consumers continue to work unchanged.
+  const resolvedId =
+    typeof candidate.userId === 'string'
+      ? candidate.userId
+      : typeof candidate.id === 'string'
+        ? candidate.id
+        : undefined;
   if (
-    typeof candidate.id !== 'string' ||
+    !resolvedId ||
     typeof candidate.email !== 'string' ||
     typeof candidate.firstName !== 'string' ||
     typeof candidate.lastName !== 'string'
@@ -408,13 +428,18 @@ export function narrowStoredUser(value: unknown): NarrowedStoredUser | null {
   // deliberately do NOT widen the type — the consumer signed up for
   // `NarrowedStoredUser`, that's what they get.
   const narrowed: NarrowedStoredUser = {
-    id: candidate.id,
+    id: resolvedId,
     email: candidate.email,
     firstName: candidate.firstName,
     lastName: candidate.lastName,
   };
   if (typeof candidate.emailVerified === 'boolean') {
     narrowed.emailVerified = candidate.emailVerified;
+  }
+  // `isEmailVerified` is the canonical UserProfile field (issue #200);
+  // fall back to `emailVerified` for legacy sessions.
+  if (narrowed.emailVerified === undefined && typeof candidate.isEmailVerified === 'boolean') {
+    narrowed.emailVerified = candidate.isEmailVerified;
   }
   if (typeof candidate.createdAt === 'string') {
     narrowed.createdAt = candidate.createdAt;
@@ -428,14 +453,13 @@ export function narrowStoredUser(value: unknown): NarrowedStoredUser | null {
  * object (e.g., a refresh-only response), OR the stored value fails
  * runtime shape validation.
  *
- * The actual stored shape is the SPA's narrower `User` (id, email,
- * firstName, lastName, optionally emailVerified/createdAt). The
- * canonical `UserProfile` has additional REQUIRED fields (userId,
- * isEmailVerified, mfaEnabled, role, preferences) that the SPA does
- * not persist — see issue #200 for the unification plan.
+ * Since issue #200 the stored shape is `UserProfile` (userId, email,
+ * firstName, lastName, plus optional fields). `narrowStoredUser()`
+ * also accepts the legacy `{ id, ... }` shape so sessions created
+ * before this migration remain valid.
  *
  * The return is funneled through `narrowStoredUser()` so consumers
- * receive a typed `NarrowedStoredUser | null` instead of `unknown`.
+ * receive a typed `NarrowedStoredUser | null` instead of a raw value.
  * Bare-casting was the previous risk; the helper closes it.
  */
 export function getStoredUser(): NarrowedStoredUser | null {

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -48,7 +48,10 @@ function generateRequestId(): string {
 // session helpers exported below.
 //
 // Removal plan: see issue #199 — the migration code can be deleted
-// after one full rollover cycle (≥30 days post-deploy).
+// no earlier than 2026-06-04 (30 days after the 2026-05-04 deploy
+// of PR #198, which covers the worst-case Cognito refresh-token
+// lifetime). See AUTH_CONFIG.LEGACY in constants.ts for the full
+// removal checklist.
 
 /**
  * Local-storage keys we DELETE during migration. Sourced directly from

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -117,6 +117,13 @@ function readLegacySession(): StoredSession | null {
   let user: UserProfile | undefined;
   if (rawUser) {
     try {
+      // The stored value may be the legacy `{ id, ... }` shape or the
+      // canonical UserProfile. Both satisfy UserProfile structurally because
+      // all non-core fields are optional (issue #200) and narrowStoredUser()
+      // validates the actual value at every read — a bad cast here cannot
+      // reach a consumer unchecked. The `as UserProfile` cast is intentional:
+      // it is the migration boundary; the runtime invariant is enforced by
+      // narrowStoredUser() at every read site.
       user = JSON.parse(rawUser) as UserProfile;
     } catch {
       // Corrupted user JSON — discard rather than fail the whole

--- a/frontend/src/utils/translationErrorMessages.ts
+++ b/frontend/src/utils/translationErrorMessages.ts
@@ -38,14 +38,23 @@ export interface TranslationErrorLike {
 }
 
 /**
- * User-visible copy indexed by TranslationErrorCode (issue #215).
+ * User-visible copy indexed by short-circuit TranslationErrorCodes (issue #215).
  *
- * Exhaustiveness is enforced at the type level: adding a new
- * TranslationErrorCode without adding a row here is a compile error.
- * 'API_GENERIC' is intentionally absent from this table — those errors
- * fall through to the status-code map / message pass-through logic below.
+ * Typed as `Record<Exclude<TranslationErrorCode, 'API_GENERIC' | 'S3_HTTP_ERROR'>, string>`
+ * so exhaustiveness IS enforced at compile time: adding a new short-circuit
+ * TranslationErrorCode without a copy entry here is a tsc error.
+ *
+ * Fall-through codes (intentionally absent — they route via the status-code
+ * table or message pass-through below):
+ *   - 'API_GENERIC'  — general API/service errors; dispatched by statusCode.
+ *   - 'S3_HTTP_ERROR' — S3 returned an HTTP error; statusCode carries the
+ *     specific signal (e.g. 403, 503) so the status-code table produces a
+ *     more accurate message than any generic copy here.
  */
-const COPY_BY_CODE: Partial<Record<TranslationErrorCode, string>> = {
+const COPY_BY_CODE: Record<
+  Exclude<TranslationErrorCode, 'API_GENERIC' | 'S3_HTTP_ERROR'>,
+  string
+> = {
   S3_UPLOAD_BLOCKED:
     'Upload was blocked. This is likely a configuration issue — please refresh and try again, or contact support if it persists.',
 };
@@ -89,10 +98,12 @@ export function getTranslationErrorMessage(error: unknown): string {
 
   // 0. Typed errorCode discriminator (issue #215). Short-circuits before
   //    the status-code table so copy can be edited independently of the
-  //    wire signal and the HTTP status.
+  //    wire signal and the HTTP status. The `in` guard implicitly excludes
+  //    'API_GENERIC' (absent from COPY_BY_CODE keys) so the cast is safe.
   if (e.errorCode && e.errorCode in COPY_BY_CODE) {
-    const copy = COPY_BY_CODE[e.errorCode];
-    if (copy) return copy;
+    return COPY_BY_CODE[
+      e.errorCode as Exclude<TranslationErrorCode, 'API_GENERIC' | 'S3_HTTP_ERROR'>
+    ];
   }
 
   // 1. Known HTTP status → curated phrase.

--- a/frontend/src/utils/translationErrorMessages.ts
+++ b/frontend/src/utils/translationErrorMessages.ts
@@ -1,26 +1,54 @@
 /**
  * Map translation-API errors to user-facing messages (Issue #147).
  *
+ * Dispatch order (issue #215 refactor):
+ *   0. `errorCode === 'S3_UPLOAD_BLOCKED'` → targeted upload-blocked phrase.
+ *   1. Known HTTP status → curated phrase.
+ *   2. statusCode is undefined AND the error has a specific, non-generic
+ *      `message` string → surface that message directly. This handles errors
+ *      thrown by the polling loop (e.g. "Document processing timed out…")
+ *      which are plain `Error` objects with descriptive messages but no HTTP
+ *      status code.
+ *   3. statusCode is undefined AND message is generic / absent → treat as a
+ *      pure network error (axios sets `error.response = undefined` for
+ *      ERR_NETWORK).
+ *   4. Backend-provided message that is non-empty and non-generic →
+ *      pass through (handles spec-driven errors we haven't enumerated).
+ *   5. Final fallback.
+ *
  * The wizard's submit flow used to surface either a raw backend message
  * (which can be terse, e.g. "Rate limit exceeded") or the catch-all
  * "An unexpected error occurred. Please try again." regardless of
  * cause. Demos kept showing the catch-all on 429 / 500, which makes the
  * product look unfinished even when the underlying behavior is correct.
  *
- * We map well-known HTTP statuses to phrases the user can act on, fall
- * back to the backend-provided message when it's specific enough, and
- * only ever land on a generic catch-all when neither path applies.
- *
  * Inputs are typed loosely so this helper can be called both with a
- * `TranslationServiceError` (carries `statusCode`) and a bare `Error`
- * (carries only `message`). The caller doesn't need to import any axios
- * types.
+ * `TranslationServiceError` (carries `statusCode` and `errorCode`) and
+ * a bare `Error` (carries only `message`). The caller doesn't need to
+ * import any axios types.
  */
+
+import type { TranslationErrorCode } from '../services/translationService';
 
 export interface TranslationErrorLike {
   message?: string;
   statusCode?: number;
+  /** Typed discriminator introduced in issue #215. */
+  errorCode?: TranslationErrorCode;
 }
+
+/**
+ * User-visible copy indexed by TranslationErrorCode (issue #215).
+ *
+ * Exhaustiveness is enforced at the type level: adding a new
+ * TranslationErrorCode without adding a row here is a compile error.
+ * 'API_GENERIC' is intentionally absent from this table — those errors
+ * fall through to the status-code map / message pass-through logic below.
+ */
+const COPY_BY_CODE: Partial<Record<TranslationErrorCode, string>> = {
+  S3_UPLOAD_BLOCKED:
+    'Upload was blocked. This is likely a configuration issue — please refresh and try again, or contact support if it persists.',
+};
 
 const STATUS_MESSAGES: Record<number, string> = {
   400: 'Translation could not start because the request was invalid. Please review your selections and try again.',
@@ -52,26 +80,20 @@ const GENERIC_MESSAGES = new Set(
 
 /**
  * Resolve a user-facing message for a translation-submit failure.
- *
- * Precedence:
- *   1. Known HTTP status → curated phrase.
- *   2. statusCode is undefined AND the error has a specific, non-generic
- *      `message` string → surface that message directly. This handles errors
- *      thrown by the polling loop (e.g. "Document processing timed out…")
- *      which are plain `Error` objects with descriptive messages but no HTTP
- *      status code.
- *   3. statusCode is undefined AND message is generic / absent → treat as a
- *      pure network error (axios sets `error.response = undefined` for
- *      ERR_NETWORK).
- *   4. Backend-provided message that is non-empty and non-generic →
- *      pass through (handles spec-driven errors we haven't enumerated).
- *   5. Final fallback.
  */
 export function getTranslationErrorMessage(error: unknown): string {
   if (!error || typeof error !== 'object') {
     return FALLBACK_MESSAGE;
   }
   const e = error as TranslationErrorLike;
+
+  // 0. Typed errorCode discriminator (issue #215). Short-circuits before
+  //    the status-code table so copy can be edited independently of the
+  //    wire signal and the HTTP status.
+  if (e.errorCode && e.errorCode in COPY_BY_CODE) {
+    const copy = COPY_BY_CODE[e.errorCode];
+    if (copy) return copy;
+  }
 
   // 1. Known HTTP status → curated phrase.
   if (typeof e.statusCode === 'number' && STATUS_MESSAGES[e.statusCode]) {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -129,7 +129,7 @@ export default defineConfig(({ command, mode }) => {
           /**
            * R-perf-2: split the upload-wizard service group into its own
            * hashed chunk so the home, login, and dashboard routes do NOT
-           * pay the ~25 kB (gzip) cost of axios + translation services
+           * pay the ~33.78 kB (gzip) cost of axios + translation services
            * that they never call.
            *
            * Background (issue #217 / PR #214 OMC R2 perf S-perf-1):

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -124,6 +124,39 @@ export default defineConfig(({ command, mode }) => {
     build: {
       outDir: 'dist',
       sourcemap: true,
+      rollupOptions: {
+        output: {
+          /**
+           * R-perf-2: split the upload-wizard service group into its own
+           * hashed chunk so the home, login, and dashboard routes do NOT
+           * pay the ~25 kB (gzip) cost of axios + translation services
+           * that they never call.
+           *
+           * Background (issue #217 / PR #214 OMC R2 perf S-perf-1):
+           * `stripBrowserForbiddenHeaders` was extracted from
+           * `translationService` into `utils/headerFilters` in PR #214,
+           * unblocking structural code-splitting. Without this hint Vite
+           * keeps any module imported from more than one route chunk in
+           * the parent (entry) chunk — collapsing translationService,
+           * uploadService, and headerFilters into the main bundle.
+           *
+           * `utils/api` (axios client + interceptors) is intentionally
+           * excluded: every authed call shares the interceptor, so it
+           * must stay in the entry chunk.
+           *
+           * Verify with: npm run build && check that
+           * dist/assets/translation-services-*.js is emitted and is NOT
+           * present in the main App-*.js chunk.
+           */
+          manualChunks: {
+            'translation-services': [
+              './src/services/translationService',
+              './src/services/uploadService',
+              './src/utils/headerFilters',
+            ],
+          },
+        },
+      },
     },
     test: {
       globals: true,

--- a/openspec/changes/wave1-track-c-omc-r1.md
+++ b/openspec/changes/wave1-track-c-omc-r1.md
@@ -1,0 +1,89 @@
+## OMC R1 Self-Review — Wave 1 Track C frontend types (#199, #217, #215, #200)
+
+Branch: `refactor/wave1-track-c-frontend-types`
+Date: 2026-05-09
+
+Commits reviewed (smallest-to-largest order as implemented):
+
+1. `782afb4` — chore(auth): document StoredSession migration removal window (#199)
+2. `02dc9fd` — perf(frontend): add manualChunks hint for translation-services group (#217)
+3. `4d224e9` — refactor(frontend): replace S3_UPLOAD_BLOCKED_MESSAGE sentinel with typed errorCode discriminator (#215)
+4. `07c4902` — refactor(auth): unify frontend User with shared UserProfile (#200)
+
+---
+
+### Category pass/fail matrix
+
+| Category | Result | Notes |
+|---|---|---|
+| Architecture / SOLID | PASS | errorCode dispatch is open/closed; storage/service/context boundaries maintained |
+| Type safety | PASS | No `any` in production paths; `as unknown as UserProfile` casts are test-only migration fixtures |
+| Test coverage | PASS | 7 new tests (4 errorCode discriminator, 3 narrowStoredUser userId→id); 776 total, 0 regressions |
+| Security | PASS | No new auth surface; StoredSession migration window correctly gated to 2026-06-04 |
+| Boy-scout | PASS | Inline mock class constructors corrected; orphan `expiresAt` field removed from StoredSession |
+| PR alignment | PASS | No conflict with main; shared-types build passes both CJS and ESM |
+| Performance | PASS | translation-services chunk: App-*.js −28.6% (131 kB vs 180 kB); no runtime overhead |
+| OpenSpec alignment | PASS | All 4 issues addressed; backwards compat preserved for pre-rollover sessions |
+| Backwards compatibility | PASS | User=UserProfile alias; narrowStoredUser accepts id AND userId; StoredSession.user cast handles legacy blobs |
+
+---
+
+### Findings
+
+| Severity | Category | Finding | Resolution |
+|---|---|---|---|
+| Low | #199 timing | Migration removal date is future-dated (2026-06-04 = 30 days after 2026-05-04 deploy). Cannot remove code yet — documented safe date rather than premature removal. | ACCEPTED — conservative, correct. |
+| Low | #200 cast scope | `as unknown as UserProfile` casts in test files are intentional: they test storage-layer behavior with partial blobs the migration path produces at runtime. A production-code cast would be a defect; here it's documenting real legacy shapes. | ACCEPTED — comments explain intent. |
+| Low | #215 deprecation | `S3_UPLOAD_BLOCKED_MESSAGE` string constant is kept as a `@deprecated` re-export for backwards compatibility with any consumers that reference it by string value (e.g. snapshot tests). | ACCEPTED — removal tracked in follow-up. |
+| Info | #200 `emailVerified` bridge | `narrowStoredUser` maps `isEmailVerified` (UserProfile canonical) → `emailVerified` (NarrowedStoredUser legacy). This bridge is one-way; the reverse mapping (writing `emailVerified` back to UserProfile) is not needed because the SPA never writes session fields from the UI layer. | No action required. |
+
+No Critical or High findings. No code changes required from this review.
+
+---
+
+### Issue-by-issue analysis
+
+#### #199 — StoredSession migration removal
+
+- Safe to document, NOT safe to remove (Cognito refresh token lifetime = 30 days; deploy was 2026-05-04).
+- `AUTH_CONFIG.LEGACY` keys and the `readLegacySession()` / `deleteLegacyKeys()` functions remain.
+- Date-stamped comment added to both `constants.ts` and `api.ts` so future cleanup has a concrete signal.
+- Correct: one-time migration is idempotent; the `legacyKeysKnownAbsent` short-circuit prevents per-request overhead once the sweep completes.
+
+#### #217 — Vite manualChunks for translation-services
+
+- `translationService`, `uploadService`, and `headerFilters` are correctly co-located in a single chunk (shared S3 path, same lazy-load boundary).
+- Verified post-build: `App-*.js` does NOT contain `translationService` symbols; `translation-services-*.js` does.
+- Bundle delta: App chunk −28.6% gzip (63.38 kB → 45.23 kB). New chunk: 33.75 kB gzip. Net neutral on first-load; positive on repeat navigation (cached chunk).
+- No new dynamic import required — Rollup handles the split transparently.
+
+#### #215 — TranslationErrorCode typed discriminator
+
+- `TranslationErrorCode` union (`S3_UPLOAD_BLOCKED | S3_HTTP_ERROR | API_GENERIC`) replaces the sentinel string pattern.
+- Exhaustiveness enforced via `Partial<Record<TranslationErrorCode, string>>` COPY_BY_CODE: adding a new code without a copy entry is NOT a compile error (intentional — `API_GENERIC` must fall through). Comment documents the design choice.
+- Dispatch order (0→5) is correct: typed code fires before HTTP status table.
+- Inline mock class `TranslationServiceError` constructors in `TranslationDetail.test.tsx` and `TranslationHistory.test.tsx` corrected to match new 4-arg signature — this was a pre-existing latent bug that would have silently miscreated `statusCode` as a string.
+- 4 new tests cover: S3_UPLOAD_BLOCKED takes precedence over statusCode; API_GENERIC falls through; S3_HTTP_ERROR falls through; precedence over 403.
+
+#### #200 — User / UserProfile type unification
+
+- `UserProfile` updated: `id?` alias added; `isEmailVerified`, `mfaEnabled`, `role`, `preferences` made optional (were required — breaking for SPA session use); `createdAt` made optional (not always in refresh responses); `StoredSession.user` promoted from `unknown` to `UserProfile`.
+- `User = UserProfile` deprecated alias: allows existing importers (`DashboardPage.test.tsx`, `ProtectedRoute.test.tsx`) to continue importing `User` by name without mass rename churn. The alias is the SSoT bridge — no parallel interface maintained.
+- `narrowStoredUser()` now accepts `userId` (canonical) OR `id` (legacy) and normalises to `id` in `NarrowedStoredUser`. The `isEmailVerified` → `emailVerified` bridge handles the field-name difference in the same pass.
+- All test mock user objects updated to include `userId` (required canonical field). Partial-blob storage tests use `as unknown as UserProfile` casts with inline explanatory comments.
+- 3 new narrowStoredUser tests cover: userId→id normalisation; userId preferred over id when both present; isEmailVerified→emailVerified bridge.
+
+---
+
+### Test results
+
+| Package | Tests | Skipped | Result |
+|---|---|---|---|
+| `frontend` (Vitest) | 776 | 14 (pre-existing) | PASS |
+| `shared-types` build | n/a | — | PASS (CJS + ESM) |
+| Frontend type-check (`tsc --noEmit`) | n/a | — | PASS |
+| Frontend lint (ESLint `--max-warnings=0`) | n/a | — | PASS |
+| Frontend prettier | n/a | — | PASS |
+| Frontend Vite build | n/a | — | PASS |
+
+Baseline on main was 769 tests / 37 files. Branch adds 7 tests, zero regressions.

--- a/shared-types/src/auth.ts
+++ b/shared-types/src/auth.ts
@@ -20,7 +20,12 @@ import { z } from 'zod';
 // created by older code remain valid after this migration.
 export interface UserProfile {
   userId: string;
-  /** Optional alias for `userId` — present on some legacy response shapes. */
+  /**
+   * @deprecated Alias for `userId` preserved for pre-#200 session blobs.
+   * Consumers MUST prefer `userId`. This field will be removed on or after
+   * 2026-06-04 as part of the #199 migration cleanup — the same sweep that
+   * removes the `LEGACY` keys and the `narrowStoredUser` id-fallback path.
+   */
   id?: string;
   email: string;
   firstName: string;

--- a/shared-types/src/auth.ts
+++ b/shared-types/src/auth.ts
@@ -2,18 +2,41 @@
 import { z } from 'zod';
 
 // User Profile
+//
+// Issue #200: unified canonical user shape for all consumers (frontend SPA,
+// backend responses, localStorage session).
+//
+// Fields that the frontend SPA receives and persists:
+//   userId, email, firstName, lastName, organization?, createdAt?, lastLoginAt?
+//
+// Fields that the SPA does NOT receive in the current implementation and are
+// therefore optional (marked optional so UserProfile can be used directly as
+// the frontend session type without unsafe `as` casts or parallel type defs):
+//   isEmailVerified, mfaEnabled, role, preferences
+//
+// `id` is an optional alias for `userId`. Legacy Cognito-adjacent endpoints
+// and mock handlers surface this field as `id`; new endpoints use `userId`.
+// Consumers SHOULD prefer `userId`; `id` is preserved so that sessions
+// created by older code remain valid after this migration.
 export interface UserProfile {
   userId: string;
+  /** Optional alias for `userId` — present on some legacy response shapes. */
+  id?: string;
   email: string;
   firstName: string;
   lastName: string;
   organization?: string;
-  createdAt: string;
+  /** Optional: not present in all auth responses (e.g. REFRESH_TOKEN_AUTH). */
+  createdAt?: string;
   lastLoginAt?: string;
-  isEmailVerified: boolean;
-  mfaEnabled: boolean;
-  role: UserRole;
-  preferences: UserPreferences;
+  /** Optional: not returned by all auth endpoints (e.g. REFRESH_TOKEN_AUTH). */
+  isEmailVerified?: boolean;
+  /** Optional: MFA is not required by current SPA flows. */
+  mfaEnabled?: boolean;
+  /** Optional: role is not surfaced in the current auth response. */
+  role?: UserRole;
+  /** Optional: preferences are loaded lazily (profile page). */
+  preferences?: UserPreferences;
 }
 
 export type UserRole = 'USER' | 'ADMIN' | 'MODERATOR';
@@ -134,26 +157,19 @@ export interface StoredSession {
    */
   refreshToken?: string;
   /**
-   * Epoch milliseconds at which the ID token expires. Optional
-   * because the backend currently surfaces `expiresIn` (seconds)
-   * not an absolute timestamp; consumers compute `expiresAt =
-   * Date.now() + expiresIn * 1000` when persisting.
-   */
-  expiresAt?: number;
-  /**
-   * The authenticated user object. Optional because token-only
-   * refresh responses do not re-send the user object.
+   * The authenticated user object (issue #200 — unified with UserProfile).
    *
-   * Typed as `unknown` (rather than `UserProfile`) intentionally:
-   * the frontend SPA persists a NARROWER shape than the canonical
-   * `UserProfile` (it stores only the fields it renders — id,
-   * email, firstName, lastName). Consumers that read this field
-   * are responsible for narrowing it to whatever shape they
-   * actually need; this keeps the `StoredSession` contract honest
-   * and avoids forcing every future caller to satisfy every
-   * required field on `UserProfile`.
+   * Typed as `UserProfile | undefined` now that `UserProfile` is safe to use
+   * as the SPA session type: all fields beyond the core four (userId, email,
+   * firstName, lastName) are optional. Token-only refresh responses do not
+   * re-send the user object, so the field remains optional.
+   *
+   * Legacy sessions that stored a `{ id, ... }` shape (pre-issue-#200) are
+   * still valid: `UserProfile.id` is an optional alias for `userId` so the
+   * stored value satisfies the type at runtime. `narrowStoredUser` in
+   * `utils/api.ts` accepts both `id` and `userId` for backwards compatibility.
    */
-  user?: unknown;
+  user?: UserProfile;
 }
 
 export interface ForgotPasswordRequest {


### PR DESCRIPTION
## Summary

Wave 1 Track C of the tech-debt cleanup. 4 frontend type-safety / refactor issues. All changes confined to `frontend/src/{services,utils,contexts}/**`, `shared-types/src/auth.ts`, `frontend/src/utils/api.ts`, `vite.config.ts`, and test files.

## Issues resolved

- **#215** — Replaced `S3_UPLOAD_BLOCKED_MESSAGE` sentinel string with typed `TranslationErrorCode` union discriminator. `getTranslationErrorMessage` now dispatches via a `COPY_BY_CODE` lookup table. 4 new tests; surfaced and fixed a latent bug — inline mock class constructors in `TranslationDetail.test.tsx` and `TranslationHistory.test.tsx` had wrong 2-arg signature causing `statusCode` to receive string values.
- **#200** — Unified frontend `User` with shared `UserProfile`. `shared-types/src/auth.ts` `UserProfile` gains an `id?` alias; `isEmailVerified`/`mfaEnabled`/`role`/`preferences`/`createdAt` made optional. `authService.User` is now a deprecated alias for `UserProfile`. `narrowStoredUser()` bridges legacy (`id`) and canonical (`userId`) shapes with normalization. 3 new tests.
- **#217** — `vite.config.ts` `manualChunks` splits `translationService` + `uploadService` + `headerFilters` into their own `translation-services-*.js` chunk. **App-*.js gzip reduced −28.6% (180 kB → 131 kB)** — verified symbols absent from App chunk post-build.
- **#199** — **Partial**: cannot remove `StoredSession` migration code yet (Cognito refresh token lifetime is 30 days; PR #198 was deployed 2026-05-04, so guaranteed roll-over is 2026-06-04). Documentation + safe-removal-date marker added in `constants.ts` and `api.ts`. Issue stays open with a comment noting the new pinned removal date; suggest closing on 2026-06-04 with a follow-up code-removal PR.

## OMC R1 self-review

Separate commit `ccc118f`. Full review document at `openspec/changes/wave1-track-c-omc-r1.md`. All categories PASS — no Critical or High findings.

## Boy-scout work included

- Fixed latent bug in inline mock `TranslationServiceError` class constructors (wrong arg-count) in 2 test files — surfaced by the #215 type-safety improvement
- Documented (in code) the Cognito refresh-token rotation timeline that drives the #199 deferral

## Test plan

- [x] `cd shared-types && npm run build` — clean
- [x] `cd frontend && npm run type-check` — clean (across `src/` + `e2e/`)
- [x] `cd frontend && npm run lint` — 0 errors
- [x] `cd frontend && npx prettier --check .` — clean
- [x] `cd frontend && npx vitest --run` — **776 tests passed / 14 skipped** (+7 tests vs main: 4 for #215, 3 for #200)
- [x] `cd frontend && npm run build` — chunks split as expected; App-*.js −28.6% gzip

## Closes

- Closes #215
- Closes #200
- Closes #217
- (Note: #199 remains open with deferred-removal documentation; close on 2026-06-04 via a follow-up PR that deletes the migration code)