### PR TITLE
chore(infra): staging/prod deploy-pipeline parity sweep — bootstrap guard + diff-short-circuit decision (#253)

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -148,6 +148,16 @@ jobs:
     name: Deploy Backend to Development
     runs-on: ubuntu-latest
     needs: test
+    # Boy-scout (#253 expansion round): mirror the `timeout-minutes` discipline
+    # that `smoke-tests` (15) and `integration-tests` (30) already enforce
+    # (added by PR #240). A stuck `cdk deploy` against a hung CloudFormation
+    # update would otherwise hold the `deploy-${ref}` concurrency lock
+    # indefinitely, blocking every subsequent deploy + the parallel
+    # deploy-frontend.yml workflow (shared concurrency group). Observed noop
+    # deploy-dev runs finish in <5 min (e.g. run 25770555446: 3m48s); a real
+    # deploy with frontend rebuild + CloudFront invalidation lands well inside
+    # 15 min. 30 gives ~6x headroom while still failing loud if CFN hangs.
+    timeout-minutes: 30
     # Trigger conditions:
     #   - push to main → automatic deploy
     #   - workflow_dispatch with environment=dev → manual deploy (escape hatch)
@@ -520,6 +530,13 @@ jobs:
     name: Deploy Backend to Staging
     runs-on: ubuntu-latest
     needs: test
+    # Boy-scout (#253 expansion round): same `timeout-minutes` discipline as
+    # deploy-dev above. Staging deploys are always full (no diff short-circuit
+    # — see Gap 2 rationale block below `Configure AWS credentials`) so the
+    # expected wall-clock is closer to dev's full-deploy path: ~5-8 min CDK
+    # + ~2-3 min frontend rebuild + ~3 min CloudFront wait. 30 gives ~2x
+    # headroom and still trips before the GitHub Actions 6-hour cap would.
+    timeout-minutes: 30
     # Issue #160 (branch-guard asymmetry): previously only checked environment
     # input but not github.ref, allowing any branch to deploy to staging via
     # `gh workflow run deploy-backend.yml --ref feature/foo -f environment=staging`.
@@ -566,6 +583,14 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           role-session-name: GitHubActions-LFMT-Deploy-Staging
           aws-region: ${{ env.AWS_REGION }}
+
+      # Boy-scout (#253 expansion round): mirror deploy-dev (line 209) and
+      # deploy-prod (analogous step). Surfacing the assumed-role ARN in the
+      # workflow log is part of the audit trail for any staging deploy and
+      # gives operators a fast triage signal when an OIDC misconfiguration
+      # silently lands the workflow in the wrong account.
+      - name: Verify AWS identity
+        run: aws sts get-caller-identity
 
       - name: Install shared-types dependencies
         working-directory: shared-types
@@ -648,6 +673,19 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           node-version: ${{ env.NODE_VERSION }}
 
+      # Boy-scout (#253 expansion round): mirror deploy-dev's `Test API Health`
+      # step (line 312). Without this, a deploy that succeeded at the CFN
+      # layer but produced an unreachable API Gateway (DNS lag, custom-domain
+      # misconfig, broken Lambda authorizer) would only be caught by the
+      # operator's manual smoke. The curl is non-blocking (`|| echo …`)
+      # because API Gateway can take a few seconds post-deploy to propagate
+      # custom-domain mappings — a transient 5xx is not a deploy failure,
+      # but the line in the run log is the audit signal that the operator
+      # should re-check if the manual smoke later reveals trouble.
+      - name: Test API Health (staging)
+        run: |
+          curl -f ${{ steps.frontend.outputs.api_url }}/v1/auth || echo "API not yet ready, may need warm-up"
+
       - name: Staging Deployment Summary
         run: |
           echo "========================================="
@@ -661,6 +699,15 @@ jobs:
     name: Deploy Backend to Production
     runs-on: ubuntu-latest
     needs: test
+    # Boy-scout (#253 expansion round): same `timeout-minutes` discipline as
+    # deploy-dev/deploy-staging above, with extra headroom. Prod runs the
+    # additional `CDK Diff (show changes for audit trail)` step (~30s) on top
+    # of the full deploy + frontend rebuild + CloudFront wait, and a prod
+    # CFN update can take longer than staging if there are more resources to
+    # update (Cognito user-pool changes, in particular, can take 5-10 min on
+    # their own). 45 min gives ~3x headroom over a typical full deploy while
+    # still tripping before the GitHub Actions 6-hour cap.
+    timeout-minutes: 45
     # Issue #160 (branch-guard asymmetry): mirrors the fix applied to
     # deploy-staging above. See that job's comment block for rationale.
     if: github.ref == 'refs/heads/main' && github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'prod'
@@ -750,6 +797,18 @@ jobs:
           stack-name: LfmtPocProd
           aws-region: ${{ env.AWS_REGION }}
           node-version: ${{ env.NODE_VERSION }}
+
+      # Boy-scout (#253 expansion round): mirror deploy-dev's `Test API Health`
+      # step (line 312) and the analogous staging step above. Same rationale:
+      # cheap audit signal for the CFN-succeeds-but-API-unreachable failure
+      # mode. Non-blocking by design (`|| echo …`) — a transient 5xx during
+      # custom-domain propagation should not fail the prod deploy run, but
+      # the line in the run log is the audit signal that lets the operator
+      # know to re-check via manual smoke if the production-frontend traffic
+      # later shows trouble.
+      - name: Test API Health (prod)
+        run: |
+          curl -f ${{ steps.frontend.outputs.api_url }}/v1/auth || echo "API not yet ready, may need warm-up"
 
       - name: Production Deployment Summary
         run: |

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -579,6 +579,61 @@ jobs:
         working-directory: backend/infrastructure
         run: npm ci
 
+      # Issue #253 (Gap 1) — staging/prod deploy-pipeline parity:
+      # mirror deploy-dev's idempotent CDKToolkit guard. Without this, the
+      # first-ever staging deploy against a fresh account/region fails with
+      # "This stack uses assets, so the toolkit stack must be deployed to
+      # the environment (Run `cdk bootstrap aws://...`)" — a footgun that
+      # only fires once but blocks the very first stand-up of a new staging
+      # account. The block is textually identical to the one in deploy-dev
+      # and deploy-prod (grep for `CDK Bootstrap (if needed)`); do not
+      # refactor into a composite action without keeping all three call-
+      # sites parallel — operators rely on the inline form for run-log
+      # readability when triaging a fresh-account bootstrap.
+      - name: CDK Bootstrap (if needed)
+        working-directory: backend/infrastructure
+        run: |
+          if ! aws cloudformation describe-stacks --stack-name CDKToolkit --region ${{ env.AWS_REGION }} 2>/dev/null; then
+            echo "CDKToolkit not found, bootstrapping..."
+            ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+            npx cdk bootstrap aws://${ACCOUNT_ID}/${{ env.AWS_REGION }}
+          else
+            echo "CDKToolkit already exists, skipping bootstrap"
+          fi
+
+      # Issue #253 (Gap 2) — intentional asymmetry with deploy-dev:
+      #
+      # deploy-dev runs a `cdk diff` short-circuit (Issue #163, the
+      # `Check for CDK infrastructure changes` step + the `if:
+      # steps.cdk-diff.outputs.has_changes == 'true'` gate above its
+      # `CDK Deploy to Dev` step) that skips `cdk deploy` when no
+      # infrastructure changes are detected. deploy-staging and
+      # deploy-prod deliberately DO NOT replicate that optimization.
+      # Rationale:
+      #
+      #   1. Trigger semantics differ. deploy-dev fires on every push to
+      #      main AND on workflow_dispatch (default env=dev). The push-
+      #      triggered path runs on shared-types-only or backend-only
+      #      commits that may have no infra impact — that's the noop case
+      #      #163 optimizes away. deploy-staging/prod are workflow_dispatch
+      #      ONLY (see their job-level `if:` guards), so every invocation
+      #      carries explicit operator intent to deploy.
+      #
+      #   2. UX. A manual dispatch that exits in ~30s with "no changes" is
+      #      ambiguous: did the deploy run? Was the frontend rebuild step
+      #      gated out? Did the smoke check actually validate the new code?
+      #      Operators expect a manual staging/prod deploy to be a full
+      #      deploy, not a conditional fast-path.
+      #
+      #   3. Audit-trail-first design. deploy-prod already has a `CDK Diff
+      #      (show changes for audit trail)` step that records the proposed
+      #      change-set in the workflow log BEFORE the deploy runs. Adding
+      #      a has_changes gate would either duplicate that diff (wasted
+      #      ~30s) or remove the audit step (lost paper trail). Both are
+      #      worse than the current always-deploy behaviour.
+      #
+      # Do NOT replicate the deploy-dev short-circuit here without first
+      # re-evaluating points 1-3 against the then-current trigger semantics.
       - name: CDK Deploy to Staging
         working-directory: backend/infrastructure
         run: npx cdk deploy --context environment=staging --require-approval never
@@ -674,6 +729,14 @@ jobs:
         working-directory: backend/infrastructure
         run: npx cdk diff --context environment=prod || true
 
+      # Issue #253 (Gap 2) — intentional asymmetry with deploy-dev:
+      # see the matching block in deploy-staging (above the `CDK Deploy to
+      # Staging` step) for the full rationale. Short version: deploy-prod
+      # is workflow_dispatch-only, so every invocation is explicit operator
+      # intent — a has_changes gate would surprise operators and would
+      # either duplicate or supplant the audit-trail `cdk diff` step above.
+      # Keep this `cdk deploy` call unconditional. Do NOT add a has_changes
+      # gate without re-reading the rationale on deploy-staging.
       - name: CDK Deploy Main Infrastructure
         working-directory: backend/infrastructure
         run: npx cdk deploy LfmtPocProd --context environment=prod --require-approval never


### PR DESCRIPTION
## Summary

Closes #253. Pipeline-consistency sweep on `.github/workflows/deploy-backend.yml`. Originally scoped to two gaps from the issue body; expanded in a second commit to fold in three additional out-of-scope items at owner request, where each fold-in was mechanical and self-contained. The fourth originally out-of-scope item is genuinely architectural and deferred to #260.

**Diff size**: 1 file changed, 122 insertions (+) across two commits.

## Gap 1 — staging missing `cdk bootstrap` guard (mechanical fix, commit 1a84bc4)

**Problem**: `deploy-dev` and `deploy-prod` already have an idempotent `CDKToolkit` check; `deploy-staging` did not. First-ever deploy of staging against a fresh account/region would fail with `This stack uses assets, so the toolkit stack must be deployed to the environment`.

**Fix**: Added the same `if ! aws cloudformation describe-stacks --stack-name CDKToolkit ...` block immediately before the staging `cdk deploy` step. The block is **textually identical** to the dev and prod versions for grep-ability — operators triaging a fresh-account bootstrap can search the same string across all three jobs.

## Gap 2 — `#163` diff short-circuit is dev-only (design decision: keep unconditional on staging/prod, commit 1a84bc4)

**Problem statement**: `deploy-dev` runs a `cdk diff` short-circuit (Issue #163) that skips `cdk deploy` when no infrastructure changes are detected, saving ~10 min per noop deploy. `deploy-staging` and `deploy-prod` deploy unconditionally. The issue body flagged this as a design question, not a clear bug — strong arguments existed both ways.

**Decision**: **keep staging/prod unconditional.** Add documenting comment blocks on both the staging and prod `cdk deploy` steps so a future contributor reading the asymmetry doesn't "fix" it by reflex.

**Reasoning** (in priority order):

1. **Trigger semantics differ**. `deploy-dev` fires on every push to `main` AND on `workflow_dispatch`. The push-triggered path runs on shared-types-only or backend-only commits that may have zero infra impact — that's exactly the noop case #163 optimizes away. `deploy-staging` and `deploy-prod` are **`workflow_dispatch` ONLY** (job-level `if:` guard explicitly excludes the push event). Every staging/prod invocation carries explicit operator intent to deploy.
2. **UX of a manual dispatch exiting in ~30s with "no changes"** is ambiguous: did the deploy actually run? Was the frontend rebuild step gated out? Did the smoke check validate the new code? Operators dispatching a staging/prod deploy expect a full deploy, not a conditional fast-path. The cost savings (5-8 min on a noop) doesn't outweigh the operator-confidence cost.
3. **Audit-trail-first design**. `deploy-prod` already has a `CDK Diff (show changes for audit trail)` step that records the proposed change-set in the workflow log BEFORE the deploy runs. Adding a `has_changes` gate would either (a) duplicate that diff invocation (wasted ~30s) or (b) replace it (lost paper trail). Both are strictly worse than the current always-deploy behaviour.

The inline comment block on both staging and prod explicitly enumerates these three points so this decision is grep-able and self-explaining when the workflow is read in isolation.

## Expansion round — three additional parity gaps folded in (commit e284b69)

Owner reviewed the original PR + report and asked for the previously out-of-scope items to be folded in where each was mechanical and self-contained. Three folded in; one deferred (see "Deliberately deferred" below).

### Gap 3 — `timeout-minutes` missing on all three deploy jobs

**Problem**: `smoke-tests` (15min) and `integration-tests` (30min) got timeouts in PR #240 to keep a hung run from holding the `deploy-${ref}` concurrency lock indefinitely. The three actual deploy jobs (`deploy-dev`, `deploy-staging`, `deploy-prod`) were skipped in that pass — a hung `cdk deploy` against a stuck CloudFormation update would hold the lock for the GitHub Actions 6-hour cap.

**Fix**: Added `timeout-minutes` to all three:

- `deploy-dev`: `30` (line 152). Observed noop run 25770555446 finished in 3m48s; a real deploy with frontend rebuild lands inside 15. 30 gives ~6x headroom.
- `deploy-staging`: `30` (line 533). Full-deploy path (no diff short-circuit per Gap 2). ~5-8 min CDK + ~2-3 min frontend + ~3 min CloudFront. 30 gives ~2x headroom.
- `deploy-prod`: `45` (line 702). Extra room for the additional `CDK Diff (audit trail)` step and Cognito user-pool updates which can take 5-10 min on their own.

### Gap 4 — `Verify AWS identity` step missing from `deploy-staging`

**Problem**: Present on `deploy-dev` (line 209) and `deploy-prod` (line 736), missing on `deploy-staging`. Without it, a misconfigured OIDC trust that silently lands the workflow in the wrong account has no audit signal until something downstream breaks.

**Fix**: Added the same `aws sts get-caller-identity` step on staging immediately after the `Configure AWS credentials (OIDC)` step (line 587). 4-line copy/paste; ~200ms operational cost.

### Gap 5 — No post-deploy API health check on `deploy-staging` / `deploy-prod`

**Problem**: `deploy-dev` has a `Test API Health` curl step (line 312) that catches the CFN-succeeds-but-API-unreachable failure mode (DNS lag, custom-domain misconfig, broken Lambda authorizer). Staging and prod had nothing equivalent — a deploy that succeeded at the CFN layer but produced an unreachable API would only be caught by the operator's manual smoke.

**Fix**: Mirrored the dev curl on both staging (line 683) and prod (line 808). The composite `rebuild-frontend` action already exports `steps.frontend.outputs.api_url`, so adapting was a single-line URL swap. The curl is non-blocking (`|| echo …`) by design — a transient 5xx during custom-domain propagation should not fail a manual staging/prod dispatch, but the line in the run log is the audit signal that lets operators re-check if the manual smoke later reveals trouble.

## Validation

| Check | Result |
|---|---|
| `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy-backend.yml'))"` | **PASS** |
| `python3 tests/workflows/test_deploy_path_filters.py` | **PASS** (`All deploy workflow path-filter contracts satisfied.`) |
| `/tmp/actionlint .github/workflows/deploy-backend.yml` | **40 warnings before, 40 after** — zero new warning classes. The new curl steps use `${{ steps.frontend.outputs.api_url }}` GitHub-expression interpolation (not shell expansion), so they don't add SC2086 warnings. The staging bootstrap SC2086 from commit 1a84bc4 is unchanged (copy-fidelity with dev/prod per #253 brief). |

## Deliberately deferred (out of scope — issue #260 filed)

### Item 4 (original) — `smoke-tests` / `integration-tests` only run after `deploy-dev`

**Why deferred**: This is **architectural work, not a hygiene fix**.

The smoke test (`backend/tests/smoke/smoke.test.ts`) and integration tests (`backend/functions/**/*.integration.test.ts`) consume `secrets.DEV_USER_POOL_ID` and the dev OIDC role + dev Cognito pool. Routing equivalent credentials per environment touches:

1. **GitHub Secrets routing**: needs `STAGING_USER_POOL_ID`, `PROD_USER_POOL_ID` (or environment-protection-scoped secrets, which is the GitHub-native answer).
2. **IAM trust**: OIDC role's trust policy needs broadening, OR per-env roles need minting.
3. **Cognito test-user isolation**: the per-day test-email pattern (#171) is currently dev-only and would need to be replicated for staging/prod with cleanup.
4. **Failure-mode design**: staging smoke against a prod-like pool would create real-looking user rows; needs a policy on whether these tests are isolated, idempotent, or destructive.

Folding into this PR would significantly grow scope and introduce new failure modes (broken IAM, leaked test users in staging/prod) — exactly the criteria the owner gave for declining.

**Tracking**: [#260](https://github.com/leixiaoyu/lfmt-poc/issues/260) — `ci(deploy): add post-deploy smoke + integration tests to staging/prod`.

## Test plan

- [x] `python3 tests/workflows/test_deploy_path_filters.py` — passes (both commits)
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — passes (both commits)
- [x] `/tmp/actionlint .github/workflows/deploy-backend.yml` — no new warning classes after expansion-round commit (verified: 40 warnings on the pre-expansion stash vs 40 warnings on the post-expansion working tree)
- [x] Mental-model trace of the bootstrap guard: fresh account (describe-stacks fails → bootstrap runs) and existing account (describe-stacks succeeds → bootstrap skipped) — both paths produce the desired behaviour
- [x] Mental-model trace of Gap 2 decision against the issue body's pro/con list — operator-dispatch intent + audit-trail-first design outweigh the ~10min cost savings on the noop case
- [x] Diff review of expansion commit: 5 distinct additive blocks, each `Boy-scout (#253 expansion round)` annotated for grep-ability
- [ ] Owner review of the Gap 2 decision (this remains the load-bearing review item) and the expansion fold-in choices
