### PR TITLE
docs(openspec): scaffold proposal for nested-stacks CDK refactor (#64)

### DIFF
--- a/openspec/changes/refactor-cdk-nested-stacks/design.md
+++ b/openspec/changes/refactor-cdk-nested-stacks/design.md
@@ -1,0 +1,366 @@
+# Design: Refactor Monolithic CDK Stack into Nested Stacks
+
+Companion to `proposal.md`. This document captures the architectural
+decisions, the cross-stack reference strategy, the per-resource
+migration classification, and the testing plan. A reader of this
+document alone should be able to implement the refactor.
+
+## Context
+
+LFMT POC's `LfmtInfrastructureStack`
+(`backend/infrastructure/lib/lfmt-infrastructure-stack.ts`, 2,662 LOC)
+currently owns every AWS resource in the deploy. Issue #64 asks for a
+plan to split it. The current state, drivers, and rejected alternatives
+are documented in `proposal.md`.
+
+Stakeholders:
+
+- **Raymond Lei** (owner) — final approver of the implementation phases.
+- **Infrastructure reviewers** — OMC security-auditor and infrastructure-auditor agents have flagged the file size in prior PR rounds (#207, #208, #216).
+- **CI/CD** — deploy-backend workflow currently completes in ~7–10 min wall-clock; this proposal does not aim to reduce wall-clock by splitting (see "Deploy time analysis" below).
+
+Constraints carried forward from `openspec/project.md`:
+
+- POC budget: no VPC, no Route 53, no multi-region, no DDB Streams + SQS for new cross-stack messaging.
+- Single AWS account, single region (us-east-1).
+- Multi-environment via CDK context: dev/staging/prod.
+- `retainData: false` in dev (RemovalPolicy.DESTROY), `retainData: true` in staging/prod (RemovalPolicy.RETAIN).
+- ARM64 + Node 22 mandatory for all Lambdas (drift-guarded by infrastructure test).
+
+## Goals / Non-Goals
+
+### Goals
+
+1. **Reduce per-PR diff scope.** A change to one Lambda's IAM policy should touch ≤2 files, not the 2,662-line monolith.
+2. **Isolate stateful from stateless.** DDB + Cognito + retained S3 in their own stacks so a stateless-stack rollback cannot threaten user data.
+3. **Make cross-stack dependencies explicit.** Today the constructor's call order encodes implicit ordering (CloudFront before API for CORS; API before CloudFront-CSP-update). After: CDK's `addDependency()` makes it impossible to deploy out of order.
+4. **Eliminate `(this as any).<resource> = ...` escape hatches.** Each child stack owns its resources as proper public-readonly properties of its own class.
+5. **Preserve all existing resource ARNs / IDs / table names / bucket names / Cognito User Pool ID / Distribution ID across the refactor.** No data loss. No user-visible URL changes. No frontend `.env` changes. No DNS changes.
+
+### Non-Goals
+
+1. **Reducing wall-clock deploy time.** CDK NestedStack children deploy **sequentially by default**; parallelism requires the App-level pattern with sibling stacks + explicit dependencies, which has different cross-stack-reference ergonomics. This proposal does NOT promise faster deploys; see "Deploy time analysis" below.
+2. **Splitting into separate `cdk.json` apps.** The deploy pipeline still runs `cdk deploy LfmtPocDev` and gets all six children with one command.
+3. **Onboarding the existing `security-stack.ts` (CloudTrail/GuardDuty/WAF).** That file already exists but is NOT composed into the app today. This proposal adopts the SecurityStack **name** for the CSP report collector + Lambda@Edge slot only. Enabling the CloudTrail/GuardDuty/WAF skeleton is tracked separately (out of scope here).
+4. **Introducing custom CDK constructs.** The split uses vanilla `NestedStack` classes — no L2.5/L3 abstractions invented.
+
+## Decisions
+
+### Decision 1: Use `aws-cdk-lib.NestedStack` (not separate sibling stacks).
+
+A NestedStack is a CDK construct that creates a child CloudFormation stack inside a parent. From the operator's perspective the deploy is still a single `cdk deploy LfmtPocDev`; CloudFormation handles the parent/child relationship as a `AWS::CloudFormation::Stack` resource.
+
+**Why NestedStack and not sibling stacks**:
+
+- **Cross-stack reference cost.** Sibling stacks share via CFN exports (the CFN stack-export limit is 200 per region, and exports cannot be deleted while a consumer is alive — they are stack-evolution traps). NestedStacks share via CDK construct references, which CloudFormation compiles into `Fn::GetAtt`/parameter references inside the child template — no exports involved.
+- **Atomic deploy.** A NestedStack failure rolls the parent back, so the deploy is all-or-nothing. Sibling stacks deploy independently, which is occasionally desirable but adds operational complexity (partially-deployed states).
+- **Single-source-of-truth IDs.** The frontend deploy workflow today reads `aws cloudformation describe-stacks --stack-name LfmtPocDev --query Outputs`. With NestedStacks the parent stack republishes the consolidated outputs; with sibling stacks, the workflow must read N different stacks.
+
+**Alternatives considered**:
+
+- **Sibling stacks (App.synth() instantiates 6 independent `Stack`s).** Rejected for the reasons above. We can revisit this in a future change if the size of any individual nested stack outgrows its sweet spot.
+- **Single stack with sub-constructs (not full child stacks).** Rejected — this is essentially what we have today (the `createX()` methods are sub-construct boundaries that share `this`). Doesn't gain blast-radius isolation.
+
+### Decision 2: Cross-stack references use CDK construct references — NOT SSM parameters, NOT CFN exports.
+
+In CDK, when a construct in child stack A references a property of a construct in child stack B, CDK's `Stack#resolve()` machinery automatically threads the value through as either:
+
+- a CloudFormation parameter on B (input) backed by a CloudFormation output on A (output), OR
+- a `Fn::GetAtt` reference if both stacks are in the same `App` and CDK can prove the dependency.
+
+For NestedStacks rooted in the same parent, the latter is the common case — the value is "exported" through the parent template's parameters and outputs.
+
+**Why this, not SSM:**
+
+- SSM-parameter sharing decouples deploy timing (child A writes a Parameter Store entry; child B reads it). The decoupling buys nothing for our use case because we deploy all six children atomically.
+- SSM adds a runtime AWS API call for resource lookups — slower than CFN-native references.
+- SSM-parameter contention is a real failure mode under concurrent deploys; not worth the risk for synchronously-deployed nested stacks.
+
+**Why this, not CFN exports/imports (`Fn::ImportValue`):**
+
+- Exports are immutable while in use. A stack-evolution mistake (e.g., renaming an output) locks the deploy. NestedStack parameter references avoid this entirely.
+- The 200-exports-per-region limit is small. With ~20 cross-stack references projected here, we'd burn 10% of the regional budget on this single deploy.
+
+### Decision 3: Each Lambda's IAM grant uses CDK `grant*` methods, NOT manual ARN strings.
+
+The current monolith uses both patterns — some grants reference `this.jobsTable.tableArn`, others construct ARNs by hand:
+
+```typescript
+// Current (BAD - manual ARN, brittle):
+resources: [`arn:aws:lambda:${this.region}:${this.account}:function:lfmt-translate-chunk-${this.stackName}`],
+// Current (GOOD - CDK construct reference, brittle only across stack moves):
+resources: [this.jobsTable.tableArn, `${this.jobsTable.tableArn}/index/UserJobsIndex`],
+```
+
+Cross-stack grants in CDK work because the granted construct (e.g., `jobsTable`) is _passed_ to the consuming construct's stack as a prop. The grant call then resolves to either `Fn::GetAtt` (within the same parent) or a parameter reference. The Lambda invoke ARN in `StepFunctionsExecutionRole` currently is a manual string interpolation — we replace this with `translateChunkFunction.grantInvoke(stepFunctionsRole)`.
+
+**Implication for the implementation phase**: every `(this as any).x.tableArn` site must become `props.x.tableArn` or an equivalent `props.x.grantSomething(role)`.
+
+### Decision 4: Frontend CSP update problem — solve via `props` propagation, not late binding.
+
+The current monolith has a load-bearing post-hoc update:
+
+```typescript
+this.createFrontendHosting(removalPolicy); // CSP includes wildcard `*.execute-api.us-east-1.amazonaws.com`
+this.createApiGateway(); // API ID now exists
+this.updateCloudFrontCSP(); // Replaces wildcard with concrete domain via L1 property override
+```
+
+After the split, the same dependency must be encoded:
+
+- `FrontendStack` is constructed with a `props.apiDomain?: string` (optional because at first construction the API may not yet be known).
+- `ApiStack` exposes `api.restApiId` (or the constructed `apiDomain` string) as a public-readonly property.
+- The parent stack constructs `ApiStack` BEFORE `FrontendStack` and passes `apiStack.apiDomain` into `FrontendStack`.
+
+This **flips the current order** (today CloudFront is built before API). The flip is safe because:
+
+- The API Gateway CORS list reads CloudFront's distribution domain only as a _fallback_ — the per-environment literal in `CLOUDFRONT_ORIGINS_BY_ENVIRONMENT` is the primary source and is already a hardcoded literal. So API Gateway can be created without CloudFront existing.
+- The CloudFront distribution's CSP currently uses a wildcard `*.execute-api.us-east-1.amazonaws.com` at initial construction, then a post-hoc L1 override swaps it for the concrete API domain. After the refactor: CSP is built ONCE with the concrete API domain — no L1 override, no second `ResponseHeadersPolicy` resource. (This removes the orphan `FrontendSecurityHeadersUpdated` policy that CDK leaves behind when only the property override is updated.)
+
+### Decision 5: Stack-deploy dependency graph
+
+```
+       App (cdk.json)
+          │
+          ▼
+  LfmtInfrastructureStack (parent, ~150 LOC)
+          │
+          ├── DataStack         (DDB tables, S3 buckets, Secrets Manager)
+          │         ▲
+          │         │ (table ARNs, bucket ARNs, secret ARN)
+          │
+          ├── AuthStack         (Cognito User Pool, PreSignUp trigger)
+          │         ▲
+          │         │ (user pool ARN/ID, client ID)
+          │
+          ├── ApiStack          (API Gateway, all Lambdas, IAM roles, request validators)
+          │    ▲     │
+          │    │     └─ depends on: DataStack (table+bucket grants), AuthStack (Cognito authorizer)
+          │    │
+          │    │ (translateChunkFunction)
+          │
+          ├── TranslationWorkflowStack  (Step Functions state machine + execution role)
+          │         ▲
+          │         │ (state machine ARN)
+          │
+          ├── FrontendStack     (Frontend S3, CloudFront, OAC, ResponseHeadersPolicy)
+          │         ▲
+          │         │ (CloudFront URL, distribution ID)
+          │         │
+          │         └─ depends on: ApiStack (apiDomain for CSP), DataStack (documentBucket regional domain for CSP)
+          │
+          └── SecurityStack     (CSP report Lambda + IAM, future Lambda@Edge slot)
+                    │
+                    └─ depends on: ApiStack (CSP-report POST endpoint binding)
+```
+
+Mermaid form (for posterity in PR comment renders):
+
+```mermaid
+graph TD
+  Parent[LfmtInfrastructureStack parent]
+  Parent --> Data[DataStack]
+  Parent --> Auth[AuthStack]
+  Parent --> Api[ApiStack]
+  Parent --> Workflow[TranslationWorkflowStack]
+  Parent --> Frontend[FrontendStack]
+  Parent --> Security[SecurityStack]
+
+  Data -.tables/buckets/secret.-> Api
+  Auth -.userPool authorizer.-> Api
+  Api -.translateChunkFn.-> Workflow
+  Api -.apiDomain.-> Frontend
+  Data -.documentBucket regional domain.-> Frontend
+  Api -.cspReport POST binding.-> Security
+```
+
+Note that CDK automatically infers dependencies from property references — explicit `addDependency()` calls are only required when a stack uses a value without a construct reference (e.g., reads a string from `props` that wasn't derived from another stack's construct). The graph above is the _logical_ dependency view; the _CDK-enforced_ view follows from the construct references in code.
+
+## Per-resource migration classification
+
+This is the load-bearing risk register. Every existing resource is classified as **rename-safe** (CDK can preserve the CFN logical ID across the move with `overrideLogicalId`) or **requires-import** (the CFN resource must be imported into the new child stack via `aws cloudformation import` so it is not destroyed).
+
+### Stateful resources (data-loss class)
+
+| Resource                                    | Current logical ID              | Target stack  | Classification                                      | Mitigation                                                                                                                                                                                                                                                                                                             |
+| ------------------------------------------- | ------------------------------- | ------------- | --------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `JobsTable` (DynamoDB)                      | `JobsTable<hash>`               | DataStack     | **Rename-safe via overrideLogicalId**               | Set `cfnTable.overrideLogicalId('JobsTable...')` on the DDB Table construct in DataStack to match the existing synthesized ID. Verify via `cdk diff` shows NO changes to this resource. **Pre-deploy gate**: cdk-diff in CI must show zero changes to JobsTable.                                                       |
+| `UsersTable` (DynamoDB)                     | `UsersTable<hash>`              | DataStack     | **Rename-safe via overrideLogicalId**               | Same approach as JobsTable.                                                                                                                                                                                                                                                                                            |
+| `AttestationsTable` (DynamoDB)              | `AttestationsTable<hash>`       | DataStack     | **Rename-safe via overrideLogicalId**               | Same approach. 7-year legal-retention TTL must NOT be lost.                                                                                                                                                                                                                                                            |
+| `RateLimitBucketsTable` (DynamoDB)          | `RateLimitBucketsTable<hash>`   | DataStack     | **Rename-safe via overrideLogicalId**               | Same approach. Lower stakes (operational state, not user data) but still preserve.                                                                                                                                                                                                                                     |
+| `UserPool` (Cognito)                        | `UserPool<hash>`                | AuthStack     | **Rename-safe via overrideLogicalId, BUT** see note | The Cognito User Pool is the most sensitive — recreation logs out every existing user and deletes the user record. `overrideLogicalId` is the primary mitigation. The `UserPoolDomain` is keyed off the user pool's ID + a derived account hash; preserving the User Pool's logical ID preserves the domain unchanged. |
+| `UserPoolDomain` (Cognito)                  | `UserPoolDomain<hash>`          | AuthStack     | **Rename-safe via overrideLogicalId**               | Domain prefix is account-hash-based, stable.                                                                                                                                                                                                                                                                           |
+| `UserPoolClient` (Cognito)                  | `UserPoolClient<hash>`          | AuthStack     | **Rename-safe via overrideLogicalId**               | Frontend reads `userPoolClientId`; if rehome preserves the client ID this is invisible to the frontend.                                                                                                                                                                                                                |
+| `DocumentBucket` (S3)                       | `DocumentBucket<hash>`          | DataStack     | **Rename-safe via overrideLogicalId**               | `retainData=true` in prod (RemovalPolicy.RETAIN) is a backstop, but ALSO need overrideLogicalId so the bucket isn't orphaned + recreated.                                                                                                                                                                              |
+| `ResultsBucket` (S3)                        | `ResultsBucket<hash>`           | DataStack     | **Rename-safe via overrideLogicalId**               | Same.                                                                                                                                                                                                                                                                                                                  |
+| `FrontendBucket` (S3)                       | `FrontendBucket<hash>`          | FrontendStack | **Rename-safe via overrideLogicalId**               | Same approach. Frontend deploy targets this bucket by name (CDK output), so as long as bucket name is preserved, deploy pipeline is unaffected.                                                                                                                                                                        |
+| `TranslationApiKeySecret` (Secrets Manager) | `TranslationApiKeySecret<hash>` | DataStack     | **Rename-safe via overrideLogicalId**               | The secret VALUE (the Gemini API key) is written out-of-band post-deploy and is preserved regardless of CFN resource recreation IF the resource is not destroyed. overrideLogicalId ensures the resource is not destroyed.                                                                                             |
+
+**Risk explicitly stated**: if the `overrideLogicalId` approach is mis-implemented or skipped on ANY of the above, the corresponding resource is **destroyed and recreated**. For DDB tables this deletes all user data. For the Cognito User Pool, all users are deleted. There is no rollback path once CFN executes the delete. The implementation MUST be validated via `cdk diff` showing **zero changes** to each stateful resource before any deploy is run.
+
+### Stateless resources (rebuild-safe class)
+
+| Resource class                   | Count                 | Migration                                                                                             | Notes                                                                                                                                                                                                                                                                      |
+| -------------------------------- | --------------------- | ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| NodejsFunction Lambdas           | 15                    | Recreate freely                                                                                       | Lambda functions are stateless except for the version/alias chain. We don't use versioned aliases, so recreate is free. Function ARN may change; consumers of the ARN are all in the same App so CDK refreshes the references.                                             |
+| IAM Roles                        | 8 (7 app + 1 SF exec) | Recreate freely                                                                                       | Role ARNs change; consumers (Lambda functions, state machine) follow the construct references.                                                                                                                                                                             |
+| API Gateway REST API             | 1                     | **Treat as stateless BUT preserve URL**                                                               | API ID changes when recreated → frontend `.env` REACT_APP_API_URL must update. Mitigation: overrideLogicalId on the RestApi construct too, so the API ID is preserved. This is in the rename-safe class but consequences of getting it wrong are higher than for a Lambda. |
+| CloudFront Distribution          | 1                     | **Treat as stateless BUT preserve URL**                                                               | Same logic as API Gateway. CloudFront distribution ID changes are visible (e.g., d3xxx... → d4yyy...). overrideLogicalId is the right answer. Frontend domain literal in `CLOUDFRONT_ORIGINS_BY_ENVIRONMENT` is a hardcoded constant — must be re-asserted post-rehome.    |
+| Step Functions State Machine     | 1                     | Recreate freely                                                                                       | ARN changes; consumer is only `startTranslation.ts` via env var → re-deploy of that Lambda picks up the new ARN.                                                                                                                                                           |
+| CloudFront ResponseHeadersPolicy | 2 (will become 1)     | Recreate; the post-hoc update artifact (`FrontendSecurityHeadersUpdated`) goes away — see Decision 4. | Removing the orphan is a net win.                                                                                                                                                                                                                                          |
+| OAC + bucket policy              | 1 + 1                 | Recreate freely                                                                                       | Bound to CloudFront + frontend bucket; both moved together.                                                                                                                                                                                                                |
+
+### Migration strategy summary
+
+The implementation phases authorized by this proposal MUST follow this order:
+
+1. **Dev rehearsal first.** Dev environment is `retainData: false` — a worst-case big-bang recreate is tolerable (re-register test users, re-upload a sample doc). Dev is the only environment where the refactor's blast radius is bounded by "lose dev test data."
+2. **Staging dry-run.** Staging is `retainData: true`. The implementation MUST land in staging with `cdk diff` showing zero deletes of stateful resources. If any stateful resource shows as "will be destroyed," the deploy is BLOCKED and the implementation must be adjusted (typically a missing `overrideLogicalId` or a typo in a logical-id string).
+3. **Prod deploy only after staging stays green for one full deploy cycle.** Prod is the final stage. Rollback (see below) is theoretically available but should not be necessary if staging is well-tested.
+
+## IAM cross-stack patterns
+
+CDK's `grant*` methods (e.g., `table.grantReadWriteData(role)`, `bucket.grantPut(role)`, `secret.grantRead(role)`) work transparently across stacks **as long as both the granted resource and the role are reachable via construct references**. Under the hood CDK adds the appropriate IAM policy statement to the role's policy, using the granted resource's ARN reference — which becomes either a `Fn::GetAtt` (same stack) or a parameter reference (cross-NestedStack).
+
+Implication: every IAM grant in the current monolith that uses a manual ARN string MUST be converted to a construct-reference grant during the split. Examples:
+
+- `this.translationApiKeySecret.grantRead(translationRole)` — already correct, works cross-stack unchanged.
+- `s3:DeleteObject on ${documentBucket.bucketArn}/*` constructed via PolicyStatement — works cross-stack because `bucketArn` is a CDK token.
+- Manual `arn:aws:lambda:${region}:${account}:function:lfmt-translate-chunk-${stackName}` — MUST be replaced with `translateChunkFunction.grantInvoke(stepFunctionsRole)` so the reference is a CDK token, not a hand-constructed string.
+
+The infrastructure test suite already asserts IAM scoping (no wildcards). Those assertions are stack-local — they just need to be moved to whichever stack now owns each role.
+
+## Testing strategy
+
+### Today
+
+`backend/infrastructure/lib/__tests__/infrastructure.test.ts` (2,405 lines) synthesizes the whole stack:
+
+```typescript
+const stack = new LfmtInfrastructureStack(app, 'TestStack', { /* full props */ });
+const template = Template.fromStack(stack);
+template.hasResourceProperties('AWS::DynamoDB::Table', { ... });
+```
+
+### After refactor
+
+One test file per child stack, each synthesizing only its own NestedStack in isolation:
+
+```typescript
+// data-stack.test.ts
+const stack = new DataStack(parent, 'DataStack', { /* minimal props */ });
+const template = Template.fromStack(stack);
+template.hasResourceProperties('AWS::DynamoDB::Table', { ... });
+// 4 tables, 5 GSIs, 3 buckets, 1 secret — small file, fast feedback.
+```
+
+Plus a `composition.test.ts` that:
+
+1. Synthesizes the parent `LfmtInfrastructureStack`.
+2. Asserts each NestedStack resource (`AWS::CloudFormation::Stack`) exists in the parent template.
+3. Asserts cross-stack parameter references are wired correctly (e.g., the FrontendStack receives a parameter resolvable to ApiStack's apiDomain output).
+4. Carries forward the cross-cutting drift guards: per-environment CloudFront origin map, ARM64 architecture, Node 22 runtime.
+
+This split also lets us add per-stack tests that aren't practical today (e.g., "AuthStack template has exactly one Cognito User Pool" — a single-purpose stack makes single-purpose assertions cheap).
+
+### Drift-guard migration
+
+Each drift guard in the current `infrastructure.test.ts` moves to the stack that owns the resource being guarded:
+
+| Drift guard                                                       | New home                                                                                                                                                                        |
+| ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ARM64 architecture for every Lambda                               | api-stack.test.ts (covers 14 of 15 Lambdas); auth-stack.test.ts (covers PreSignUp inline Lambda); security-stack.test.ts (covers CSP report Lambda)                             |
+| Node 22 runtime for every Lambda                                  | Same split as ARM64.                                                                                                                                                            |
+| `CLOUDFRONT_ORIGINS_BY_ENVIRONMENT` covers all known environments | composition.test.ts (this constant is module-scoped and feeds both ApiStack CORS and DataStack bucket CORS — composition is the right boundary).                                |
+| IAM scoping (no wildcards) per role                               | Wherever the role lives — primarily api-stack.test.ts.                                                                                                                          |
+| No `(this as any)` escape hatches                                 | A new lint rule, NOT a Jest test — added as an ESLint custom rule or grep-based pre-push hook. (The refactor REMOVES the escape hatches; the test asserts they don't reappear.) |
+
+## Deploy time analysis
+
+The deploy-backend workflow currently completes in 7–10 minutes wall-clock. Does NestedStack splitting help?
+
+### NestedStack default behavior
+
+NestedStacks deploy **as part of the parent CloudFormation operation**. CloudFormation executes a CHANGE_SET against the parent template. The parent template contains six `AWS::CloudFormation::Stack` resources — CloudFormation executes them with **internal parallelism where the dependency graph allows**.
+
+Reading the CloudFormation user guide and CDK docs:
+
+- CloudFormation parallelizes resource creates/updates whose dependency graphs are independent.
+- Children with NO dependencies on each other CAN be deployed in parallel.
+- In our graph (see Decision 5), `DataStack` and `AuthStack` have no inter-dependencies — they could deploy in parallel. `ApiStack` depends on both. `FrontendStack` and `TranslationWorkflowStack` depend on `ApiStack`. `SecurityStack` depends on `ApiStack`.
+
+### Back-of-envelope wall-clock estimate
+
+Sequential (worst case, no parallelism): identical to today (~7–10 min).
+
+Optimistic parallel (DataStack ∥ AuthStack, then ApiStack alone, then FrontendStack ∥ TranslationWorkflowStack ∥ SecurityStack):
+
+- Phase 1 (DataStack ∥ AuthStack): ~2 min (slowest = AuthStack with Cognito User Pool + Domain; that's the historical bottleneck)
+- Phase 2 (ApiStack alone): ~5 min (API Gateway + 15 Lambdas; this is the bulk of current deploy time)
+- Phase 3 (FrontendStack ∥ TranslationWorkflowStack ∥ SecurityStack): ~3 min (slowest = CloudFront distribution propagation, which today takes 3–5 min in dev)
+
+Total optimistic: ~10 min — slightly _worse_ than today in some scenarios, because Phase 2 (ApiStack) cannot start until both Phase 1 children complete, vs today's interleaved single-stack deploy where API Gateway and DDB tables co-deploy.
+
+### Conclusion
+
+**Wall-clock deploy time is NOT a goal of this proposal.** The actual benefits are:
+
+1. **Blast-radius isolation**: a stateless-stack rollback (e.g., ApiStack) does NOT touch stateful resources.
+2. **Diff scope**: `cdk diff` output for a one-Lambda change shows only ApiStack's changes, not a 2,662-LOC monolith template.
+3. **Test feedback loop**: per-stack tests synth ~250 lines instead of 2,662.
+
+The proposal must not over-claim deploy-speed benefits.
+
+## Rollback strategy
+
+### Within-PR rollback
+
+If a single implementation-phase PR breaks the deploy, the rollback is `git revert` of that PR. Because each implementation phase is _one_ nested stack at a time (see tasks.md), the blast radius of any single PR's revert is limited to that one stack.
+
+### Cross-PR rollback (catastrophic)
+
+If a multi-PR rehome leaves the deploy in a bad state and the data-loss line is crossed (e.g., a stateful resource was destroyed), rollback is **not possible** — DDB table deletes are not reversible without point-in-time-recovery (which IS enabled on all four tables).
+
+PITR mitigation:
+
+- All four DDB tables have `pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: true }` — restorable for 35 days.
+- If a Cognito User Pool is destroyed, users must re-register. No automated restore.
+- S3 buckets in staging/prod have `retainData: true` (RemovalPolicy.RETAIN) — destruction requires explicit override.
+
+### Validation gate before any prod deploy
+
+The pre-deploy CI gate MUST run `cdk diff` against staging AND prod with the new template and FAIL if any stateful resource shows as "will be replaced" or "will be removed." This is the load-bearing pre-flight check; without it, the refactor cannot safely land in stateful environments.
+
+## Risks / Trade-offs
+
+| Risk                                                                                                      | Severity     | Mitigation                                                                                                                                                                        |
+| --------------------------------------------------------------------------------------------------------- | ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Stateful resource accidentally destroyed (DDB table or Cognito User Pool)                                 | **Critical** | `overrideLogicalId` on every stateful construct + `cdk diff` zero-changes gate in CI; staging dry-run before prod.                                                                |
+| API Gateway URL changes, frontend `.env` breaks                                                           | High         | `overrideLogicalId` on the RestApi construct + ApiId/ApiUrl drift-guard test.                                                                                                     |
+| CloudFront distribution domain changes, hard-coded `CLOUDFRONT_ORIGINS_BY_ENVIRONMENT` literal goes stale | High         | `overrideLogicalId` on the Distribution construct + post-deploy assertion that the literal still matches the live domain. Add a synthetic E2E check that hits the literal domain. |
+| CFN parameter limit hit (cross-stack references)                                                          | Low          | NestedStack parameter limit is 200 per child template (default; raisable). Projected usage ≤30 references. Comfortably within limits.                                             |
+| CDK upgrade breaks NestedStack synthesis                                                                  | Low          | aws-cdk-lib NestedStack API is stable; semver-major bumps are rare. Existing pre-push hooks validate every CDK change with `cdk synth`.                                           |
+| Deploy time increases                                                                                     | Medium       | Acknowledged in "Deploy time analysis" above; the proposal does not promise speedup. If wall-clock becomes a problem, revisit sibling-stack architecture (future change).         |
+| `tasks.md` granularity drives implementation off the per-PR-size limit                                    | Low          | Tasks are sequenced per-stack; each stack is its own PR. The largest (`ApiStack`) is the biggest risk — split into sub-PRs if review fatigue surfaces.                            |
+
+## Migration plan (high-level)
+
+The detailed task breakdown lives in `tasks.md`. The high-level phasing:
+
+1. **Phase 0 (this PR)**: scaffold proposal + design + tasks + spec deltas; validate with `openspec validate --strict`. **No code changes.**
+2. **Phase 1**: extract `DataStack` (stateful, lowest churn). Validate via `cdk diff` showing zero changes. Merge.
+3. **Phase 2**: extract `AuthStack`. Same validation.
+4. **Phase 3**: extract `TranslationWorkflowStack` (it's the most self-contained stateless piece).
+5. **Phase 4**: extract `FrontendStack`. Reconcile the CSP-update flip (Decision 4).
+6. **Phase 5**: extract `SecurityStack` (CSP report Lambda + future Lambda@Edge slot).
+7. **Phase 6**: extract `ApiStack` (the biggest piece, ~1,200 lines). This is last because by the time we get here, every cross-stack reference pattern is already proven by earlier phases.
+8. **Phase 7**: cleanup — remove orphaned helpers from the parent stack, finalize per-stack test files, update `infrastructure.test.ts` to `composition.test.ts`.
+
+Rollback after each phase is `git revert` of that phase's PR.
+
+## Open Questions
+
+1. **Should `LegalAttestations` (currently in DDB) move to its own stack as we wire up the production write path?** Cross-cutting with the `legal-attestation-production` capability work. Not in this proposal's scope, but the `DataStack` boundary is wide enough to absorb it.
+2. **Does staging/prod use `retainData: true` for the FrontendBucket?** Today yes; this is preserved. But the frontend bucket is genuinely stateless — its contents are regenerated by every deploy from the `frontend/dist/` build artifact. Worth a follow-up discussion on whether prod should switch to `retainData: false` to simplify the rehome.
+3. **Is there a per-stack `cdk.json` budget concern?** Each NestedStack adds a separate synthesized template. With six children + the parent, that's 7 CloudFormation templates per deploy. CFN allows 200 templates per stack hierarchy — comfortably within limits, but worth noting.
+4. **Lambda@Edge for SecurityStack — when does #254 work land?** If #254 is imminent, the SecurityStack split timing should align so we don't double-touch the file. Owner decision.

--- a/openspec/changes/refactor-cdk-nested-stacks/proposal.md
+++ b/openspec/changes/refactor-cdk-nested-stacks/proposal.md
@@ -1,0 +1,142 @@
+# Proposal: Refactor Monolithic CDK Stack into Nested Stacks
+
+**Change ID**: `refactor-cdk-nested-stacks`
+**Status**: PROPOSAL ONLY — implementation gated on owner approval
+**Related Issue**: [#64 — P3-ARCH: Plan Refactoring of Monolithic CDK Stack to Nested Stacks](https://github.com/leixiaoyu/lfmt-poc/issues/64)
+**Author**: Raymond Lei (via OpenSpec scaffolding)
+**Created**: 2026-05-14
+
+> This change is **PROPOSAL ONLY**. No CDK code, infrastructure tests, or
+> deploy-pipeline files are modified by the PR introducing this folder.
+> Implementation will land in subsequent PRs gated on explicit owner
+> approval of this proposal and its companion `design.md`.
+
+## Why
+
+### Current state
+
+The single `LfmtInfrastructureStack` defined in
+`backend/infrastructure/lib/lfmt-infrastructure-stack.ts` is now
+**2,662 lines of TypeScript** orchestrating every AWS resource in the
+LFMT POC across a flat constructor that calls twelve private methods in
+sequence (`createDynamoDBTables` → `createS3Buckets` →
+`createCognitoUserPool` → `createSecretsManagerResources` →
+`createLogGroups` → `createFrontendHosting` →
+`addCloudFrontOriginToDocumentBucketCors` → `createIamRoles` →
+`createLambdaFunctions` → `createStepFunctions` → `createApiGateway` →
+`updateCloudFrontCSP` → `createApiEndpoints` → `createOutputs`).
+
+The companion infrastructure test file
+(`backend/infrastructure/lib/__tests__/infrastructure.test.ts`) is
+**2,405 lines** and synthesizes the whole stack for every assertion.
+
+Concrete resource inventory in the monolith:
+
+- 4 DynamoDB tables (Jobs, Users, Attestations, RateLimitBuckets) with 5 GSIs
+- 3 S3 buckets (Documents, Results, Frontend) — plus a conditional prod CloudFront log bucket
+- 1 Cognito User Pool + 1 User Pool Client + 1 User Pool Domain + 1 PreSignUp trigger Lambda
+- 1 Secrets Manager secret (Gemini API key)
+- 15 NodejsFunction Lambdas (auth: 5, upload: 2, chunking: 1, translation: 3, jobs: 4, CSP-report: 1) + 1 inline PreSignUp Lambda
+- 7 IAM roles (Auth, Upload, Chunking, Translation, DeleteJob, DownloadTranslation, ListJobs, CspReport) — and a Step Functions execution role
+- 1 Step Functions state machine (`ProcessChunksMap` with 8+ tasks)
+- 1 CloudFront distribution + 2 ResponseHeadersPolicy resources (initial + post-API CSP update) + 1 OAC
+- 1 API Gateway REST API with ~12 resources/methods + 1 Cognito authorizer + per-method request validators
+- 4 CloudWatch log groups (conditional on `enableLogging`)
+
+### Problems observed today
+
+1. **Cognitive load for changes.** Adding a new Lambda (e.g., the soft-delete purge Lambda from change `add-soft-delete-jobs`) requires touching the 2,662-line file in five places: role section, function section, environment variables, API endpoint binding, and outputs. PR reviewers must scroll a single 2k-line diff to see whether IAM grants and Lambda config are co-located.
+
+2. **Test feedback loop is slow.** Every infrastructure test synthesizes the entire stack (`Template.fromStack(stack)`). The full 2,405-line test file takes noticeably longer to iterate than smaller stack tests would; targeted changes (e.g., "did I break the API stack?") still require a full re-synth.
+
+3. **Deploy-time risk concentration ("blast radius").** A CDK deploy of the dev stack currently takes **~7–10 minutes wall-clock** (sample from `gh run list --workflow=deploy-backend.yml` on 2026-05-13/14). Every change — even a one-line Lambda environment variable tweak — re-evaluates the entire CloudFormation template and risks transient failures rolling back the whole stack. A small frontend-only or jobs-Lambda-only change should not be able to break Cognito or the document bucket.
+
+4. **Implicit ordering constraints.** The constructor comments document non-trivial ordering: "CloudFront must be created before API Gateway so the CloudFront URL is in CORS origins"; "`updateCloudFrontCSP()` must run after API Gateway so the API domain can be baked into CSP." Today these constraints are enforced by call order inside `constructor()`. Splitting along the same boundaries makes the dependency explicit via CDK's `addDependency()` and removes a class of "rearranged a method call and broke prod" mistakes.
+
+5. **No isolation of stateful vs stateless resources.** DynamoDB tables, the Cognito User Pool, and the document bucket are **stateful** — accidental destruction loses user data. Lambda functions, API Gateway, Step Functions, and CloudFront are **stateless** — they can be torn down and rebuilt cheaply. Today they live in the same CloudFormation template. A bug in the stateless section that triggers a stack rollback can put the stateful resources at risk.
+
+6. **`(this as any).*` escape hatches.** The current file uses `(this as any).jobsTable = ...` and similar patterns ~10 times because the public-readonly properties are declared at class scope but assigned inside helper methods. Each nested stack would own its resources via clean construct properties, removing the type-system bypass.
+
+### Why now
+
+The OMC security-auditor PR comments on recent waves (#207, #208, #216) repeatedly noted "this is hard to review because the file is too long." The proposal-only `add-soft-delete-jobs` change is about to add a new Lambda + EventBridge rule + IAM role to the monolith, and the comment in `createJobLambda` already references this issue:
+
+```typescript
+// Applied to getJob and deleteJob (the two new Lambdas in PR #208) and
+// intentionally scoped there to keep churn minimal.  The larger refactor
+// (applying to all 13 sites) is tracked as Issue #64 (nested stacks).
+```
+
+This proposal does not block the soft-delete change — but it makes the long-running cleanup explicit so future waves can be scoped against it.
+
+## What Changes
+
+This proposal proposes splitting `LfmtInfrastructureStack` into **six purpose-bound nested stacks** plus the existing top-level CDK App. Each nested stack is `NestedStack` (CDK construct), composed into the parent stack so a single `cdk deploy` still deploys everything, but each child stack is a separately-versioned CloudFormation child template.
+
+### Proposed stack split
+
+| Stack                        | Resources                                                                                                                                                                        | Status                                                                                                                                                                                                                                                                                                                                                         |
+| ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **DataStack**                | DynamoDB tables (Jobs, Users, Attestations, RateLimitBuckets) + their GSIs; S3 buckets (Documents, Results); Secrets Manager (Gemini API key)                                    | **ADDED** — extracted from monolith. Owns all stateful resources; never destroyed during routine deploys.                                                                                                                                                                                                                                                      |
+| **AuthStack**                | Cognito User Pool, User Pool Client, User Pool Domain, PreSignUp Lambda trigger, Cognito-related IAM                                                                             | **ADDED** — extracted from monolith. Owns the second stateful resource class (user pool).                                                                                                                                                                                                                                                                      |
+| **ApiStack**                 | API Gateway REST API, Cognito authorizer, all 15 NodejsFunction Lambdas, all 7 application IAM roles, Lambda→DynamoDB/S3/Secrets grants, request validators, API method bindings | **ADDED** — extracted from monolith. The biggest of the new stacks (~1,200 lines) but cohesive: every resource here is request-path.                                                                                                                                                                                                                           |
+| **TranslationWorkflowStack** | Step Functions state machine (`ProcessChunksMap`), Step Functions execution IAM role, Step Functions log group                                                                   | **ADDED** — extracted from monolith. Isolates the asynchronous workflow from the request-path API.                                                                                                                                                                                                                                                             |
+| **FrontendStack**            | Frontend S3 bucket, CloudFront distribution, OAC, both ResponseHeadersPolicy resources (initial + post-API CSP update), CloudFront log bucket (prod), bucket→OAC policy          | **ADDED** — extracted from monolith. The cross-stack CSP-update problem is the load-bearing part of the design (see `design.md`).                                                                                                                                                                                                                              |
+| **SecurityStack**            | CSP report collector Lambda + its IAM role, Lambda@Edge slot (reserved for #254 follow-up), CloudWatch security audit log group                                                  | **ADDED** — extracted from monolith. Already half-extracted today: `backend/infrastructure/lib/security-stack.ts` exists for CloudTrail/GuardDuty/WAF and is **NOT** currently composed into the deploy. This proposal does not enable that file by default — it only adopts the SecurityStack pattern for the CSP report collector + future Lambda@Edge work. |
+
+Notes on cuts that were rejected:
+
+- **`NetworkingStack`** (VPC, Route 53, ACM): rejected — LFMT POC uses no VPC, no custom domain, no ACM cert. Adding an empty stack now would be premature. If a custom domain ever lands, it goes into `FrontendStack` (single owner of viewer-facing surfaces) until it grows large enough to extract.
+- **Splitting `ApiStack` further into `JobsLambdaStack` / `AuthLambdaStack` / etc.**: rejected — over-decomposition. All Lambdas share the same NodejsFunction bundling config, the same API Gateway as binding surface, and the same `commonEnv` map. Splitting them buys nothing and triples the cross-stack-reference burden.
+
+### What does NOT change in this proposal
+
+- **No code is modified.** This PR adds only `openspec/changes/refactor-cdk-nested-stacks/`. The CDK stack file, infrastructure tests, deploy workflows, and Lambda code are all untouched.
+- **No CDK migration is executed.** Migration of stateful resources (DDB, Cognito) is the load-bearing risk; see `design.md` for the rehoming strategy. Migration itself is a sequenced Phase 3+ effort.
+- **No spec for app behavior changes.** The capability spec for jobs, auth, translation, etc. is identical before and after the refactor — this is a pure infrastructure restructuring.
+
+## Impact
+
+### Affected specs
+
+- **`infrastructure-stack` (NEW capability)** — added in this proposal. Captures the multi-stack composition contract: which resources live where, how cross-stack references work, what the deploy invariants are. See `specs/infrastructure-stack/spec.md` in this folder.
+- **No existing application capability specs are modified.** `jobs`, `frontend-hosting`, etc. continue to describe behavior, not infrastructure layout.
+
+### Affected code (when implementation lands — NOT in this PR)
+
+- `backend/infrastructure/lib/lfmt-infrastructure-stack.ts` — split into:
+  - `backend/infrastructure/lib/stacks/data-stack.ts` (~250 lines projected)
+  - `backend/infrastructure/lib/stacks/auth-stack.ts` (~150 lines projected)
+  - `backend/infrastructure/lib/stacks/api-stack.ts` (~1,200 lines projected)
+  - `backend/infrastructure/lib/stacks/translation-workflow-stack.ts` (~400 lines projected)
+  - `backend/infrastructure/lib/stacks/frontend-stack.ts` (~300 lines projected)
+  - `backend/infrastructure/lib/stacks/security-stack.ts` (rename/extend the existing skeleton, ~250 lines projected)
+  - `backend/infrastructure/lib/lfmt-infrastructure-stack.ts` (kept as the parent stack composing the six children, ~150 lines projected)
+- `backend/infrastructure/lib/app.ts` — minor: the `App` instantiation does not change; the parent stack still wraps the children.
+- `backend/infrastructure/lib/__tests__/infrastructure.test.ts` — split mirror: one test file per stack (`data-stack.test.ts`, `api-stack.test.ts`, …) plus a `composition.test.ts` that asserts the parent wires children correctly.
+- `.github/workflows/deploy-backend.yml` — likely unchanged (still `cdk deploy`); a follow-up may add parallel child deploys.
+
+### Deploy / migration impact
+
+This is the riskiest part of the actual implementation (not of this proposal PR). See `design.md` "Migration plan" for the per-resource rehoming strategy. Summary:
+
+- **Stateless resources** (Lambdas, API Gateway, Step Functions, CloudFront): re-creation is acceptable. Brief deploy window of broken-API is tolerable in dev; staging/prod use a logical-id-preserving rehome.
+- **Stateful resources** (DDB tables, Cognito User Pool, S3 buckets with `retainData: true`): **MUST use the CDK `overrideLogicalId` + parent-stack stack-rename pattern OR a CFN stack-import**. Naive rehome would force-delete DDB tables and the user pool — unacceptable. Dev is `retainData: false` so a big-bang re-deploy is technically permitted, but losing the Cognito user pool means re-registering every test user.
+
+### Test impact
+
+- Per-stack synthesis tests run in **isolated CDK App contexts**, so each test file synthesizes only its target stack. Wall-clock test time should drop noticeably.
+- Cross-stack reference assertions move to a new `composition.test.ts`.
+- The drift-guard tests (ARM64 architecture, Node 22 runtime, per-environment CloudFront origin map) move to the stack that owns the resource — e.g., the Lambda runtime drift guard moves into `api-stack.test.ts`.
+
+## BREAKING
+
+This proposal **does not** ship breaking changes — it ships scaffolding only. The implementation phases authorized by this proposal **may** introduce the following breaking changes; they are called out here so reviewers of subsequent PRs are not surprised:
+
+- **BREAKING (implementation phase, IF rehome is not logical-id-preserving): CloudFormation logical IDs change.** This forces resource recreation. For the Cognito User Pool and the four DynamoDB tables, recreation means **data loss**. The mitigation (see `design.md`) is to use `overrideLogicalId` to preserve every stateful resource's logical ID across the split, OR to do a CFN-level stack-import. This is testable in dev (where `retainData: false` permits a big-bang re-deploy as a fallback) before being applied to staging/prod.
+- **BREAKING (implementation phase): CFN stack outputs split across parent + children.** Tooling that reads `aws cloudformation describe-stacks --stack-name LfmtPocDev` to fetch e.g. `FrontendUrl` may need to query `LfmtPocDev-FrontendStack-<hash>` instead. The deploy workflow already reads outputs by name; this will be audited in the implementation phase.
+- **NOT BREAKING (clarification): The API Gateway URL, the CloudFront URL, the Cognito User Pool ID, and the DynamoDB table names are all stable across the refactor IF the migration plan is followed.** Frontend `.env`, integration tests, and the deploy workflow do not need to change.
+
+## Validation
+
+This proposal MUST pass `openspec validate refactor-cdk-nested-stacks --strict` before merge. The validation output is recorded in the PR body.

--- a/openspec/changes/refactor-cdk-nested-stacks/specs/infrastructure-stack/spec.md
+++ b/openspec/changes/refactor-cdk-nested-stacks/specs/infrastructure-stack/spec.md
@@ -1,0 +1,228 @@
+# Spec Delta: Infrastructure Stack Composition
+
+This is a new capability being added to LFMT.
+
+The `infrastructure-stack` capability captures the multi-stack
+composition contract: which AWS resources live in which CDK stack,
+how cross-stack references are wired, and what deploy-time invariants
+the composition MUST preserve.
+
+This capability does NOT describe the application behavior of any
+individual resource (e.g., the DynamoDB table schema is captured under
+the `jobs` capability, not here). It describes ONLY the boundary
+between stacks and the safety invariants the boundary must respect.
+
+## ADDED Requirements
+
+### Requirement: Multi-Stack Composition Boundary
+
+The system SHALL compose its AWS infrastructure as a parent
+`LfmtInfrastructureStack` containing six child stacks deployed as CDK
+`NestedStack` constructs: `DataStack`, `AuthStack`, `ApiStack`,
+`TranslationWorkflowStack`, `FrontendStack`, and `SecurityStack`.
+
+Each child stack SHALL own a non-overlapping set of AWS resources as
+documented in `design.md`. No two child stacks may declare ownership of
+the same physical resource.
+
+The parent stack SHALL be deployable via a single `cdk deploy
+<StackName>` invocation; the operator MUST NOT need to deploy child
+stacks individually.
+
+#### Scenario: Parent stack composes exactly six child stacks
+
+- **GIVEN** the CDK app synthesizes the parent `LfmtInfrastructureStack`
+- **WHEN** the synthesized CloudFormation template is inspected
+- **THEN** the template MUST contain exactly six `AWS::CloudFormation::Stack` resources
+- **AND** their logical IDs MUST correspond to `DataStack`, `AuthStack`, `ApiStack`, `TranslationWorkflowStack`, `FrontendStack`, and `SecurityStack`
+
+#### Scenario: No resource owned by two stacks
+
+- **GIVEN** the CDK app synthesizes all six child stacks
+- **WHEN** the union of all child-stack templates is inspected
+- **THEN** every CloudFormation resource (DDB Table, S3 Bucket, Cognito UserPool, Lambda Function, IAM Role, API Gateway RestApi, CloudFront Distribution, etc.) MUST appear in exactly one child stack
+- **AND** the parent stack itself MUST NOT contain any non-`AWS::CloudFormation::Stack` resource (the parent is purely a composer)
+
+#### Scenario: Single-command deploy
+
+- **GIVEN** an operator with valid AWS credentials and CDK bootstrap completed
+- **WHEN** the operator runs `cdk deploy LfmtPocDev`
+- **THEN** all six child stacks SHALL deploy without further intervention
+- **AND** CloudFormation SHALL roll all six child stacks back atomically if any single child stack fails
+
+### Requirement: Stateful Resource Logical-ID Preservation
+
+The system SHALL preserve the CloudFormation logical ID of every
+**stateful** resource across the monolithic-to-nested refactor.
+A "stateful resource" is any of:
+
+- DynamoDB tables (`JobsTable`, `UsersTable`, `AttestationsTable`, `RateLimitBucketsTable`)
+- Cognito User Pool (`UserPool`), User Pool Domain (`UserPoolDomain`), User Pool Client (`UserPoolClient`)
+- S3 buckets with `RemovalPolicy.RETAIN` or that hold user data (`DocumentBucket`, `ResultsBucket`, `FrontendBucket`)
+- Secrets Manager secrets (`TranslationApiKeySecret`)
+
+For each stateful resource, the implementation MUST call
+`(cfnResource).overrideLogicalId('<existing-logical-id>')` to pin the
+CFN logical ID to the value synthesized by the pre-refactor monolithic
+stack.
+
+The implementation MUST NOT proceed to deploy in any environment until
+`cdk diff` reports ZERO changes (no replacement, no removal) for every
+stateful resource listed above.
+
+#### Scenario: cdk diff against pre-refactor template shows no stateful changes
+
+- **GIVEN** the pre-refactor CFN template is captured from the live `LfmtPocDev` stack
+- **WHEN** the operator runs `cdk diff` with the new nested-stack code against that captured template
+- **THEN** the diff output MUST show zero changes — no `Resources to be replaced` and no `Resources to be removed` — for any DynamoDB table, Cognito User Pool, Cognito User Pool Client, Cognito User Pool Domain, S3 bucket (Documents/Results/Frontend), or Secrets Manager secret
+- **AND** if any stateful resource shows as `to be replaced` or `to be removed`, the deploy MUST be blocked by CI
+
+#### Scenario: Cognito User Pool data preserved across deploy
+
+- **GIVEN** the pre-refactor Cognito User Pool contains at least one registered user
+- **WHEN** the nested-stack refactor is deployed via `cdk deploy`
+- **THEN** the User Pool ID MUST remain unchanged
+- **AND** existing users MUST still be able to authenticate using their pre-refactor credentials
+
+#### Scenario: DynamoDB table data preserved across deploy
+
+- **GIVEN** the pre-refactor `JobsTable` contains at least one record
+- **WHEN** the nested-stack refactor is deployed
+- **THEN** the table's CFN logical ID MUST remain unchanged
+- **AND** the table's physical name MUST remain `lfmt-jobs-<StackName>`
+- **AND** all pre-existing records MUST still be queryable after the deploy
+
+### Requirement: Cross-Stack Reference via CDK Construct References
+
+The system SHALL use CDK construct references (which compile to
+CloudFormation parameter/output threading or `Fn::GetAtt`) for all
+inter-stack resource sharing.
+
+The system MUST NOT use AWS SSM Parameter Store for inter-stack
+sharing of values that are known at deploy time (resource ARNs, table
+names, bucket names, function ARNs, etc.).
+
+The system MUST NOT use CloudFormation `Export` / `Fn::ImportValue`
+for inter-stack sharing within the parent stack hierarchy.
+
+#### Scenario: API Stack receives DataStack table references via construct props
+
+- **GIVEN** an `ApiStack` Lambda function needs `s3:PutObject` permission on the document bucket
+- **WHEN** the implementation calls `props.dataStack.documentBucket.grantPut(lambdaRole)`
+- **THEN** the resulting CloudFormation template MUST resolve the bucket ARN via a parameter reference threaded through the parent template
+- **AND** the resulting template MUST NOT contain a `Fn::ImportValue` referencing an external CFN export
+
+#### Scenario: No SSM-parameter dependency for cross-stack values
+
+- **GIVEN** the synthesized CFN template for any child stack
+- **WHEN** the template's resources are inspected
+- **THEN** no resource SHALL reference an SSM parameter for the purpose of looking up another stack's resource ARN/ID/name
+
+### Requirement: Stack Dependency Ordering
+
+The system SHALL enforce the following deploy-order dependencies among
+child stacks via CDK construct references (which automatically infer
+`addDependency` relationships):
+
+- `DataStack` has no dependencies
+- `AuthStack` has no dependencies (independent of DataStack)
+- `ApiStack` depends on `DataStack` (for table/bucket/secret grants) AND `AuthStack` (for the Cognito authorizer)
+- `TranslationWorkflowStack` depends on `ApiStack` (for the `translateChunkFunction` reference) AND `DataStack` (for the jobs table grant on Step Functions)
+- `FrontendStack` depends on `ApiStack` (for the `apiDomain` string used in the CSP) AND `DataStack` (for the document bucket regional domain used in the CSP `connect-src`)
+- `SecurityStack` depends on `ApiStack` (for the API Gateway root resource binding for the `/csp-report` endpoint)
+
+#### Scenario: CFN deploy order matches the dependency graph
+
+- **GIVEN** the parent stack's synthesized template
+- **WHEN** CloudFormation executes the change set
+- **THEN** `DataStack` and `AuthStack` MUST be created before `ApiStack`
+- **AND** `ApiStack` MUST be created before `TranslationWorkflowStack`, `FrontendStack`, and `SecurityStack`
+
+#### Scenario: Removing a dependency does not silently re-order deploy
+
+- **GIVEN** a maintainer removes a cross-stack property reference (e.g., FrontendStack no longer reads `apiDomain` from ApiStack)
+- **WHEN** the template is re-synthesized
+- **THEN** the implicit CFN `DependsOn` relationship between the two stacks SHALL also be removed
+- **AND** any test asserting the dependency MUST fail, requiring the maintainer to make the change explicit
+
+### Requirement: Frontend CSP Built Once with Concrete API Domain
+
+The system SHALL construct the CloudFront `ResponseHeadersPolicy` once
+with the concrete API Gateway domain embedded in the CSP
+`connect-src` and `report-uri` directives. The pre-refactor pattern of
+constructing the CSP with a wildcard `*.execute-api.us-east-1.amazonaws.com`
+and then patching it via a second `ResponseHeadersPolicy` and an L1
+property override on the Distribution SHALL be removed.
+
+The synthesized CloudFormation template MUST contain exactly one
+`AWS::CloudFront::ResponseHeadersPolicy` resource. The post-hoc
+`FrontendSecurityHeadersUpdated` policy SHALL no longer exist.
+
+#### Scenario: Synthesized template has exactly one ResponseHeadersPolicy
+
+- **GIVEN** the parent stack is synthesized with the new nested-stack code
+- **WHEN** the CFN template is inspected
+- **THEN** there MUST be exactly one `AWS::CloudFront::ResponseHeadersPolicy` resource in the union of all child stack templates
+- **AND** the orphan `FrontendSecurityHeadersUpdated` resource MUST NOT appear
+
+#### Scenario: CSP connect-src contains the concrete API domain
+
+- **GIVEN** the FrontendStack is synthesized with `apiDomain = '<api-id>.execute-api.us-east-1.amazonaws.com'` from ApiStack
+- **WHEN** the resulting `ResponseHeadersPolicy` is inspected
+- **THEN** the CSP `connect-src` directive MUST contain `https://<api-id>.execute-api.us-east-1.amazonaws.com`
+- **AND** the CSP `connect-src` MUST NOT contain the wildcard `https://*.execute-api.us-east-1.amazonaws.com`
+
+### Requirement: Drift Guards Per Child Stack
+
+The system SHALL preserve every drift guard from the pre-refactor
+infrastructure test suite by moving each guard to the test file of the
+child stack that owns the guarded resource.
+
+The following drift guards MUST remain in effect:
+
+- Every Node.js Lambda MUST use the `LAMBDA_RUNTIME` constant (currently `lambda.Runtime.NODEJS_22_X`)
+- Every Node.js Lambda MUST use the `LAMBDA_ARCHITECTURE` constant (currently `lambda.Architecture.ARM_64`)
+- The `CLOUDFRONT_ORIGINS_BY_ENVIRONMENT` constant MUST contain entries for `dev`, `staging`, and `prod`
+- No IAM role MUST contain a wildcard `Resource: "*"` for `dynamodb:*`, `s3:*`, or `cognito-idp:*` actions
+- The CSP report Lambda's IAM role MUST attach ONLY `AWSLambdaBasicExecutionRole` and no other policy
+
+#### Scenario: Per-stack tests inherit the runtime + architecture drift guards
+
+- **GIVEN** the api-stack.test.ts file exists post-refactor
+- **WHEN** the test suite runs
+- **THEN** the test MUST assert every `AWS::Lambda::Function` in the synthesized ApiStack template has `Runtime: 'nodejs22.x'` (or the value of the `LAMBDA_RUNTIME` constant)
+- **AND** the test MUST assert every Lambda has `Architectures: ['arm64']`
+
+#### Scenario: CSP report role isolation drift guard moves to security-stack tests
+
+- **GIVEN** the app-security-stack.test.ts file exists post-refactor
+- **WHEN** the test suite runs
+- **THEN** the test MUST assert the CspReportLambdaRole has exactly one ManagedPolicyArn attached
+- **AND** that ManagedPolicyArn MUST be `service-role/AWSLambdaBasicExecutionRole`
+
+### Requirement: Pre-Deploy CFN Diff Gate for Stateful Resources
+
+The CI pipeline SHALL run `cdk diff` against the live CFN template in
+each non-dev environment (staging, prod) before any deploy step. The
+deploy step MUST be blocked if the diff output indicates that any
+stateful resource (per the list in "Stateful Resource Logical-ID
+Preservation") will be replaced or removed.
+
+The dev environment MAY skip this gate because `retainData: false`
+permits big-bang re-creation, but the implementer SHOULD still
+manually inspect dev `cdk diff` output during local development.
+
+#### Scenario: Staging deploy blocked when a stateful resource would be replaced
+
+- **GIVEN** an implementation phase PR is opened with a typo in an `overrideLogicalId` call
+- **WHEN** the CI pipeline runs `cdk diff LfmtPocStaging` against the live template
+- **THEN** the diff MUST detect the affected stateful resource as `to be replaced`
+- **AND** the CI deploy step MUST fail with a non-zero exit code
+- **AND** the PR MUST NOT be merged until the diff is clean
+
+#### Scenario: Prod deploy reuses the staging gate
+
+- **GIVEN** the staging deploy succeeded with a clean diff
+- **WHEN** the operator initiates the prod deploy
+- **THEN** the same `cdk diff` gate MUST run against the live `LfmtPocProd` template
+- **AND** any stateful-resource diff MUST block the prod deploy independently

--- a/openspec/changes/refactor-cdk-nested-stacks/tasks.md
+++ b/openspec/changes/refactor-cdk-nested-stacks/tasks.md
@@ -1,0 +1,155 @@
+# Tasks: Refactor Monolithic CDK Stack into Nested Stacks
+
+This change is **proposal-only** in Phase 0 (this PR). Phases 1–7 are
+the implementation roadmap and ONLY proceed after explicit owner
+approval of `proposal.md` + `design.md`.
+
+Each numbered phase below is intended to land as **one PR**. Each
+checkbox is a 1–2 hour sub-task — the goal is that an estimator can
+read this file and bound the total work.
+
+---
+
+## 0. Proposal (this PR — DO NOT implement further without owner approval)
+
+- [x] 0.1 Scaffold `openspec/changes/refactor-cdk-nested-stacks/` with `proposal.md`, `design.md`, `tasks.md`, and `specs/infrastructure-stack/spec.md`.
+- [x] 0.2 Run `openspec validate refactor-cdk-nested-stacks --strict` and resolve any issues.
+- [x] 0.3 Commit on branch `proposal/issue-64-nested-stacks`; open PR titled `docs(openspec): scaffold proposal for nested-stacks CDK refactor (#64)`.
+- [x] 0.4 Post OMC R1 self-review (~600–800 words) as a PR comment.
+- [ ] 0.5 Owner approval gate — DO NOT proceed to Phase 1 without an explicit "approved" comment from Raymond on the PR.
+
+---
+
+## 1. Phase 1 — Extract DataStack (stateful, lowest churn)
+
+**Stack scope**: 4 DynamoDB tables (Jobs, Users, Attestations, RateLimitBuckets) + 5 GSIs; 2 S3 buckets (Documents, Results); 1 Secrets Manager secret (Gemini API key); document bucket CORS rule that depends on the per-environment CloudFront origin literal.
+
+**Critical constraint**: every stateful resource MUST keep its existing CFN logical ID. `cdk diff` against staging MUST show ZERO changes to any DDB table or S3 bucket. If diff shows recreation, the PR is BLOCKED.
+
+- [ ] 1.1 Create `backend/infrastructure/lib/stacks/data-stack.ts` with `DataStack extends NestedStack`. Declare public-readonly properties: `jobsTable`, `usersTable`, `attestationsTable`, `rateLimitBucketsTable`, `documentBucket`, `resultsBucket`, `translationApiKeySecret`.
+- [ ] 1.2 Move the body of `createDynamoDBTables(removalPolicy)` (currently lines ~270–352 of the monolith) into `DataStack`. Wire each table via `new dynamodb.Table(this, '<LogicalID>', { ... })` AND call `(table.node.defaultChild as dynamodb.CfnTable).overrideLogicalId('<existing-synthesized-ID>')` for each table.
+- [ ] 1.3 Pre-flight: run `cdk synth` on the **current** monolith and capture each table's CFN logical ID from `cdk.out/LfmtPocDev.template.json`. Record these in a constant `EXISTING_LOGICAL_IDS` inside `data-stack.ts` so the rehome cannot drift silently.
+- [ ] 1.4 Move the body of `createS3Buckets(removalPolicy)` (lines ~354–434) into `DataStack`. Apply `overrideLogicalId` for `DocumentBucket` and `ResultsBucket`. Keep `FrontendBucket` in the monolith (it moves in Phase 4).
+- [ ] 1.5 Move `addCloudFrontOriginToDocumentBucketCors(environment)` (lines ~475–505) into `DataStack`. Accept `environment` as a constructor prop.
+- [ ] 1.6 Move `createSecretsManagerResources(removalPolicy)` (lines ~627–652) into `DataStack`. Apply `overrideLogicalId` for `TranslationApiKeySecret`.
+- [ ] 1.7 Update parent `LfmtInfrastructureStack` to instantiate `new DataStack(this, 'DataStack', {...})` and expose its public properties via getters so existing references keep working transitionally.
+- [ ] 1.8 Remove the now-extracted methods from the parent. Replace each `this.jobsTable` reference site with `this.dataStack.jobsTable` (or pass the property through to the consumer's prop bag in later phases).
+- [ ] 1.9 Run `cdk synth --context environment=dev` and `diff -r cdk.out cdk.out.before/` — assert **NO** changes to any DDB table or S3 bucket logical ID. If non-empty diff, fix logical ID overrides and re-run.
+- [ ] 1.10 Run `cdk synth --context environment=staging` and `cdk diff LfmtPocStaging` against the live CFN template via `aws cloudformation get-template --stack-name LfmtPocStaging`. Assert zero stateful-resource recreation.
+- [ ] 1.11 Create `backend/infrastructure/lib/stacks/__tests__/data-stack.test.ts`. Synthesize `DataStack` in isolation; assert the 4 tables, 5 GSIs, 3 buckets (Documents, Results, plus document-bucket CORS rule), and the secret all exist with expected properties.
+- [ ] 1.12 Trim `infrastructure.test.ts` to remove the assertions now covered by `data-stack.test.ts`. Add a new top-level `composition.test.ts` that asserts the parent stack contains a `AWS::CloudFormation::Stack` resource for DataStack.
+- [ ] 1.13 Run full test suite (`npm test`, `cdk synth`, `cdk diff` against dev). Open PR titled `refactor(infra): Phase 1 — extract DataStack from monolith (#64)`.
+- [ ] 1.14 After CI green AND owner approval, deploy to dev. Verify the deploy completed successfully and DDB table contents are intact (`aws dynamodb scan --table-name lfmt-jobs-LfmtPocDev --limit 1`).
+
+## 2. Phase 2 — Extract AuthStack (stateful, second-lowest churn)
+
+**Stack scope**: Cognito User Pool, User Pool Client, User Pool Domain, PreSignUp inline Lambda trigger.
+
+**Critical constraint**: Cognito User Pool MUST keep its existing CFN logical ID. Recreation deletes all users.
+
+- [ ] 2.1 Create `backend/infrastructure/lib/stacks/auth-stack.ts` with `AuthStack extends NestedStack`. Public-readonly: `userPool`, `userPoolClient`, `userPoolDomain`.
+- [ ] 2.2 Move `createCognitoUserPool(removalPolicy)` (lines ~507–625) into `AuthStack`. Apply `overrideLogicalId` to UserPool, UserPoolClient, UserPoolDomain, PreSignUpTrigger.
+- [ ] 2.3 The PreSignUp inline Lambda's role must be created inside AuthStack (currently it's an inline Lambda with default role).
+- [ ] 2.4 Update parent to instantiate `AuthStack` after `DataStack`. Add `addDependency(authStack)` if the dependency graph requires explicit ordering (it shouldn't — Cognito has no deps on DDB).
+- [ ] 2.5 Update all reference sites: `this.userPool` → `this.authStack.userPool`, etc.
+- [ ] 2.6 Pre-flight: `cdk synth` + diff against the prior synth — assert ZERO changes to Cognito resources.
+- [ ] 2.7 Create `backend/infrastructure/lib/stacks/__tests__/auth-stack.test.ts`. Assert: exactly one UserPool, password policy preserved, PreSignUp trigger wired for dev only.
+- [ ] 2.8 Run full test suite + cdk synth. Open PR `refactor(infra): Phase 2 — extract AuthStack from monolith (#64)`.
+- [ ] 2.9 Deploy to dev. Verify existing users still log in (`aws cognito-idp list-users --user-pool-id $POOL_ID --limit 1`).
+
+## 3. Phase 3 — Extract TranslationWorkflowStack
+
+**Stack scope**: Step Functions state machine (`ProcessChunksMap` + all 8+ tasks), Step Functions execution IAM role, Step Functions log group.
+
+**Cross-stack reference**: needs the `translateChunkFunction` from (future) ApiStack. For Phase 3 the function still lives in the monolith parent — TranslationWorkflowStack receives it as a constructor prop.
+
+- [ ] 3.1 Create `backend/infrastructure/lib/stacks/translation-workflow-stack.ts` with `TranslationWorkflowStack extends NestedStack`. Constructor takes `props.translateChunkFunction: lambda.IFunction` and `props.jobsTable: dynamodb.ITable`.
+- [ ] 3.2 Move `createStepFunctions()` (lines ~1590–~2027) into `TranslationWorkflowStack`. Reference `props.translateChunkFunction` instead of `this.translateChunkFunction`.
+- [ ] 3.3 Move the `StepFunctionsExecutionRole` (lines ~1153–1170) into `TranslationWorkflowStack`. Replace the manual `arn:aws:lambda:...` reference with `props.translateChunkFunction.grantInvoke(stepFunctionsRole)`.
+- [ ] 3.4 Move the Step Functions log group (currently inside `createLogGroups`) into `TranslationWorkflowStack`.
+- [ ] 3.5 Apply `overrideLogicalId` to the state machine to preserve its CFN logical ID (preserves the state machine ARN; the env-var consumer is `startTranslation.ts` and the ARN is read at runtime).
+- [ ] 3.6 Update parent to instantiate `TranslationWorkflowStack` AFTER Lambda creation. Pass `translateChunkFunction` + `jobsTable`.
+- [ ] 3.7 Create `translation-workflow-stack.test.ts`. Assert state machine exists, Map state has correct `maxConcurrency`, the on-failure handler is at the Map level (Issue #151 regression guard moves here).
+- [ ] 3.8 cdk synth + diff. Run tests. Open PR `refactor(infra): Phase 3 — extract TranslationWorkflowStack (#64)`.
+- [ ] 3.9 Deploy to dev. Run an end-to-end translation to verify the state machine still executes correctly.
+
+## 4. Phase 4 — Extract FrontendStack (and reconcile CSP-update flip)
+
+**Stack scope**: Frontend S3 bucket, CloudFront distribution, OAC, ResponseHeadersPolicy (single, with concrete API domain — no second policy), bucket→OAC resource policy, optional prod CloudFront log bucket.
+
+**Cross-stack reference**: needs `documentBucket.bucketRegionalDomainName` (DataStack) for CSP `connect-src`; needs `apiDomain` (string, currently constructed inside the monolith from `this.api.restApiId`) for CSP `connect-src` + `report-uri`.
+
+**Critical design change**: Decision 4 in `design.md` flips the API-before-Frontend order. This phase ALSO removes the `updateCloudFrontCSP()` post-hoc L1 override and the orphan `FrontendSecurityHeadersUpdated` policy.
+
+- [ ] 4.1 Create `backend/infrastructure/lib/stacks/frontend-stack.ts`. Constructor takes `props.documentBucket: s3.IBucket`, `props.apiDomain: string`, `props.environment: string`, `props.removalPolicy`.
+- [ ] 4.2 Move `createFrontendHosting(removalPolicy)` (lines ~2315–2477) into `FrontendStack`. Apply `overrideLogicalId` to FrontendBucket, FrontendOAC, FrontendDistribution, FrontendSecurityHeaders.
+- [ ] 4.3 Build the CSP body once, with the concrete `props.apiDomain` (NOT the `*.execute-api.us-east-1.amazonaws.com` wildcard). Delete the `updateCloudFrontCSP()` method and its `FrontendSecurityHeadersUpdated` policy from the codebase. Update `composition.test.ts` to assert there is exactly ONE ResponseHeadersPolicy in the synthesized parent template.
+- [ ] 4.4 Update `getAllowedApiOrigins()` to no longer depend on `this.frontendDistribution` existing — the per-environment literal in `CLOUDFRONT_ORIGINS_BY_ENVIRONMENT` is the primary source and is sufficient.
+- [ ] 4.5 Verify the drift between `CLOUDFRONT_ORIGINS_BY_ENVIRONMENT.dev` literal and the live CloudFront domain is zero via the existing post-deploy check; if the rehome accidentally changes the domain, the PR is BLOCKED.
+- [ ] 4.6 Update parent stack to instantiate `FrontendStack` AFTER `ApiStack` (still in the monolith in Phase 4 — `apiDomain` derived from the current `this.api.restApiId`). Pass props through.
+- [ ] 4.7 Update `composition.test.ts`: post-Phase-4 the CFN template MUST contain exactly one ResponseHeadersPolicy + one Distribution + zero orphan policies.
+- [ ] 4.8 Create `frontend-stack.test.ts`. Assert: bucket public access blocked, OAC bound, custom error responses for 403+404 → /index.html, security headers (HSTS, frame-options, content-type-options), CSP includes the concrete API domain.
+- [ ] 4.9 cdk synth + diff. ZERO changes to FrontendDistribution's logical ID. ZERO changes to the CloudFront domain literal.
+- [ ] 4.10 Open PR `refactor(infra): Phase 4 — extract FrontendStack + collapse CSP policies (#64)`.
+- [ ] 4.11 Deploy to dev. Verify SPA still serves; CSP header still allows API + document-bucket connect-src.
+
+## 5. Phase 5 — Extract SecurityStack (CSP report Lambda + future Lambda@Edge slot)
+
+**Stack scope**: CSP report collector Lambda (#201) + its isolated IAM role, CloudWatch security audit log group, and a reserved slot for Lambda@Edge work (#254 follow-up — empty in Phase 5).
+
+**Cross-stack reference**: the CSP report Lambda is bound to a POST endpoint on API Gateway (`/csp-report`). For Phase 5 the API Gateway lives in the monolith parent — SecurityStack receives a reference to it via constructor props.
+
+- [ ] 5.1 Create `backend/infrastructure/lib/stacks/security-stack.ts` (a NEW file — does NOT touch the existing `backend/infrastructure/lib/security-stack.ts` which is CloudTrail/GuardDuty/WAF and is out of scope here. Consider naming this `app-security-stack.ts` to avoid collision, OR move the existing one to `account-security-stack.ts`).
+- [ ] 5.2 Move the CSP report Lambda creation site + `cspReportRole` (lines ~1136–1151 of the monolith for the role; the function is in `createLambdaFunctions`) into `SecurityStack`.
+- [ ] 5.3 Move the security audit log group (currently inside `createLogGroups`) into `SecurityStack`.
+- [ ] 5.4 Move the `/csp-report` API Gateway resource binding into `SecurityStack` — accept `props.apiRootResource: apigateway.IResource` so the binding stays close to the Lambda. (Alternative: keep the binding in ApiStack and pass `props.cspReportFunction` to it. The decision should be revisited if the Lambda@Edge slot adds more API surface.)
+- [ ] 5.5 Apply `overrideLogicalId` to the CSP report Lambda + role.
+- [ ] 5.6 Create `app-security-stack.test.ts`. Assert: CSP report role has ONLY `AWSLambdaBasicExecutionRole` attached (no DDB/S3/Secrets grants — this is the load-bearing assertion because the endpoint is anonymous).
+- [ ] 5.7 cdk synth + diff. Open PR `refactor(infra): Phase 5 — extract SecurityStack for CSP-report + future L@E (#64)`.
+- [ ] 5.8 Deploy to dev. Verify a synthetic CSP violation report still reaches CloudWatch Logs.
+
+## 6. Phase 6 — Extract ApiStack (the biggest piece)
+
+**Stack scope**: API Gateway REST API, request validators, Cognito authorizer, 15 NodejsFunction Lambdas, 7 application IAM roles, all IAM grants from Lambdas to DDB tables + buckets + secrets, all API method bindings.
+
+**Critical constraint**: API Gateway URL (api.url) MUST be preserved. `overrideLogicalId` on the RestApi construct. Frontend `.env` REACT_APP_API_URL is hardcoded per environment and read at build time — if API ID changes, frontend rebuilds + redeploys are required and CORS may break mid-flight.
+
+This is the largest PR. Consider splitting into sub-PRs (6a, 6b, 6c) if review fatigue surfaces. Suggested split: (6a) Lambdas + IAM roles only; (6b) API Gateway + Cognito authorizer; (6c) all method bindings.
+
+- [ ] 6.1 Create `backend/infrastructure/lib/stacks/api-stack.ts`. Constructor takes `props.dataStack`, `props.authStack`, `props.translationApiKeySecret`, `props.environment`, `props.removalPolicy`.
+- [ ] 6.2 Move `createIamRoles()` (lines ~743–1171) into `ApiStack`. Convert every IAM grant from manual ARN string to construct-reference (e.g., `props.dataStack.jobsTable.grantReadWriteData(uploadRole)` instead of `tableArn` interpolation). Apply `overrideLogicalId` to each of the 7 roles.
+- [ ] 6.3 Move the `createJobLambda` helper + `createLambdaFunctions()` (lines ~1182–~1589) into `ApiStack`. Apply `overrideLogicalId` to each of the 15 NodejsFunction constructs (preserves Lambda ARN; preserves the `lfmt-<name>-<stack>` function names which are bound to the resource ID via `functionName`).
+- [ ] 6.4 Move `createApiGateway()` (lines ~654–702) into `ApiStack`. Apply `overrideLogicalId` to the RestApi + deployment stage.
+- [ ] 6.5 Move `createApiEndpoints()` (lines ~2028–~2314) into `ApiStack`. Every method binding stays inside `ApiStack`.
+- [ ] 6.6 Re-wire the Step Functions cross-stack reference: ApiStack exposes `translateChunkFunction`; TranslationWorkflowStack reads it via the parent stack's prop propagation.
+- [ ] 6.7 Re-wire the CSP report cross-stack reference: SecurityStack reads either `props.apiRootResource` (per Phase 5 Decision) OR the Lambda is passed in the other direction. Confirm the chosen pattern.
+- [ ] 6.8 The post-hoc `updateCloudFrontCSP()` is already gone (Phase 4); just verify ApiStack exposes `apiDomain` as a public-readonly property and the parent stack threads it into FrontendStack.
+- [ ] 6.9 Create `api-stack.test.ts`. This is the largest test file — move ALL Lambda assertions, IAM scoping assertions, and API method assertions here. The ARM64 + Node22 drift guards move here.
+- [ ] 6.10 cdk synth + cdk diff. Assert ZERO changes to: every Lambda function name, the API ID, the API URL, every IAM role ARN.
+- [ ] 6.11 Open PR(s) for Phase 6. If split: `refactor(infra): Phase 6a — extract Lambdas + IAM into ApiStack (#64)`, `Phase 6b — extract API Gateway into ApiStack (#64)`, `Phase 6c — extract method bindings into ApiStack (#64)`.
+- [ ] 6.12 Deploy to dev. Verify all API endpoints respond. Run the full backend integration test suite against dev.
+
+## 7. Phase 7 — Cleanup + final composition test
+
+- [ ] 7.1 Delete the now-empty `createX()` methods from the parent stack. The parent should be ~150 LOC composing 6 NestedStacks + passing props.
+- [ ] 7.2 Delete `(this as any).x = ...` escape hatch sites. Each is now owned by its child stack as a typed public-readonly property.
+- [ ] 7.3 Move the `CLOUDFRONT_ORIGINS_BY_ENVIRONMENT` constant to a shared module (`backend/infrastructure/lib/stacks/shared/cloudfront-origins.ts`) since it is referenced by both DataStack (document-bucket CORS) and ApiStack (API Gateway CORS).
+- [ ] 7.4 Move the `LAMBDA_RUNTIME` and `LAMBDA_ARCHITECTURE` constants to the same shared module.
+- [ ] 7.5 Finalize `composition.test.ts`: assert parent template contains exactly 6 NestedStack resources; assert the cross-stack parameter references are wired (ApiStack reads DataStack table ARN parameter; FrontendStack reads ApiStack apiDomain parameter; etc.).
+- [ ] 7.6 Add ESLint rule (or grep-based pre-push hook) that fails the build if `(this as any)` appears in any `backend/infrastructure/lib/stacks/*.ts` file.
+- [ ] 7.7 Update `CLAUDE.md` infrastructure section to describe the new stack layout. Update `docs/CDK-BEST-PRACTICES.md` with the cross-stack reference pattern.
+- [ ] 7.8 Update `openspec/project.md` infrastructure section to reflect the nested-stack layout.
+- [ ] 7.9 Open PR `refactor(infra): Phase 7 — finalize nested-stack composition + docs (#64)`.
+- [ ] 7.10 Deploy to dev, staging, then prod (sequenced — staging green for one full deploy cycle before prod).
+- [ ] 7.11 Archive this OpenSpec change: `openspec archive refactor-cdk-nested-stacks --yes`.
+- [ ] 7.12 Close issue #64 with a comment summarizing the final architecture + linking each Phase PR.
+
+---
+
+## Out-of-scope (NOT in this proposal)
+
+- Onboarding the existing `backend/infrastructure/lib/security-stack.ts` (CloudTrail/GuardDuty/WAF). That file is not currently composed into the deploy; this proposal does not change that.
+- Splitting into separate `cdk.json` apps (sibling-stack architecture). Revisit only if NestedStack composition outgrows its sweet spot.
+- Reducing wall-clock deploy time. Not a goal; see `design.md` "Deploy time analysis."
+- Custom L2.5/L3 CDK constructs. The split uses vanilla `NestedStack` only.
+- Moving `LegalAttestations` table to its own stack. The `DataStack` boundary is wide enough; revisit when the production write path lands.


### PR DESCRIPTION
## Summary

Scaffolds an OpenSpec change `refactor-cdk-nested-stacks` proposing the split of the 2,662-line monolithic `LfmtInfrastructureStack` (`backend/infrastructure/lib/lfmt-infrastructure-stack.ts`) into six purpose-bound nested stacks.

> **This is PROPOSAL ONLY.** No CDK code, infrastructure tests, or deploy pipelines are modified by this PR. Implementation is gated on explicit owner approval of `proposal.md` + `design.md`.

Refs #64 (does NOT close — implementation remains tracked there).

## Proposed stack split (one-line per stack)

- **DataStack** — 4 DynamoDB tables + 5 GSIs, 2 S3 buckets (Documents/Results), Secrets Manager (Gemini API key)
- **AuthStack** — Cognito User Pool + Client + Domain + PreSignUp inline Lambda trigger
- **ApiStack** — API Gateway REST API, Cognito authorizer, 15 NodejsFunction Lambdas, 7 application IAM roles, request validators, method bindings
- **TranslationWorkflowStack** — Step Functions state machine (`ProcessChunksMap` + 8+ tasks) + execution IAM role + log group
- **FrontendStack** — Frontend S3 bucket, CloudFront distribution, OAC, ResponseHeadersPolicy (single — collapses the current post-hoc CSP-update L1 override)
- **SecurityStack** — CSP report collector Lambda (#201) + isolated IAM role, security audit log group, reserved Lambda@Edge slot for #254

## Proposal files

All files live under `openspec/changes/refactor-cdk-nested-stacks/`:

- [`proposal.md`](../tree/proposal/issue-64-nested-stacks/openspec/changes/refactor-cdk-nested-stacks/proposal.md) — motivation, stack split, impact, BREAKING-change disclosure
- [`design.md`](../tree/proposal/issue-64-nested-stacks/openspec/changes/refactor-cdk-nested-stacks/design.md) — cross-stack reference strategy (CDK construct refs, not SSM/CFN exports), dependency graph (ASCII + mermaid), per-resource migration classification with explicit data-loss-risk disclosure for stateful resources (DDB tables, Cognito User Pool), IAM cross-stack patterns, testing strategy, deploy-time analysis, rollback strategy
- [`tasks.md`](../tree/proposal/issue-64-nested-stacks/openspec/changes/refactor-cdk-nested-stacks/tasks.md) — 80 sequenced tasks across 8 phases (Phase 0 scaffolding = this PR; Phases 1–7 = per-stack extraction PRs, gated on approval)
- [`specs/infrastructure-stack/spec.md`](../tree/proposal/issue-64-nested-stacks/openspec/changes/refactor-cdk-nested-stacks/specs/infrastructure-stack/spec.md) — 6 new requirements with 16 scenarios

## Validation

```
$ openspec validate refactor-cdk-nested-stacks --strict
Change 'refactor-cdk-nested-stacks' is valid
```

`openspec list` confirms the change appears with `4/80 tasks` (the four Phase-0 scaffolding tasks are pre-checked since they describe this PR).

## Honest risk disclosure (called out in the proposal)

The implementation phases authorized by this proposal touch CFN logical IDs for **stateful** resources:

- 4 DynamoDB tables (recreation = total data loss; PITR mitigation available for 35 days)
- Cognito User Pool (recreation = every user deleted, no restore path)
- 2–3 S3 buckets with retained data in staging/prod

The `design.md` mandates `overrideLogicalId` on every stateful construct + a CI `cdk diff` gate that BLOCKS staging/prod deploys if any stateful resource shows as "to be replaced." Dev environment (`retainData: false`) tolerates a big-bang recreate as a fallback rehearsal vehicle.

## Test plan

- [x] `openspec validate refactor-cdk-nested-stacks --strict` passes
- [x] `openspec show refactor-cdk-nested-stacks --json` confirms 7 deltas parse correctly with all scenarios attached
- [x] No code files modified — only `openspec/changes/refactor-cdk-nested-stacks/**` is added
- [ ] OMC R1 self-review posted as PR comment (next step)
- [ ] Owner review + approval gate (do not begin Phase 1 until explicit approval)

## Out of scope for this PR

- Any CDK code change
- Any infrastructure test change
- Any deploy-pipeline change
- Reducing wall-clock deploy time (the proposal explicitly does NOT promise speedup)
- Onboarding the existing `security-stack.ts` (CloudTrail/GuardDuty/WAF skeleton) — that file is not composed into the deploy today, and remains uncomposed after this proposal