### PR TITLE
feat(security): CSP style-src build-time static nonce (#254)

### DIFF
--- a/.github/actions/rebuild-frontend/action.yml
+++ b/.github/actions/rebuild-frontend/action.yml
@@ -47,6 +47,19 @@ runs:
         BUCKET=$(echo "$OUTPUTS" | jq -r '.[] | select(.OutputKey=="FrontendBucketName") | .OutputValue')
         DIST_ID=$(echo "$OUTPUTS" | jq -r '.[] | select(.OutputKey=="CloudFrontDistributionId") | .OutputValue')
         FRONTEND_URL=$(echo "$OUTPUTS" | jq -r '.[] | select(.OutputKey=="FrontendUrl") | .OutputValue')
+        # Issue #254 — read the per-deploy CSP style-src nonce so we can stamp
+        # it into dist/index.html before uploading. The value is also written
+        # into the response-headers policy CSP header by the CDK custom
+        # resource; if it is missing here the upload would ship the literal
+        # `__CSP_NONCE__` placeholder and every MUI style would be CSP-blocked.
+        # The output is created on first CDK deploy that includes #254 —
+        # an empty value means the backend has not yet been re-deployed with
+        # the new stack, in which case we fall back to skipping the
+        # substitution and emit a CI warning rather than failing the upload
+        # (the previous-generation index.html shipped without the meta tag
+        # at all, so a missing nonce is recoverable; a stale-placeholder
+        # upload is the hard regression to prevent).
+        CSP_NONCE=$(echo "$OUTPUTS" | jq -r '.[] | select(.OutputKey=="CspStyleSrcNonce") | .OutputValue')
         # OMC R2 L-2: guard against empty outputs. jq returns empty string (not
         # an error) when a key is absent — e.g. if CDK deploy failed mid-way and
         # the stack is in a partial state. An empty VITE_API_URL would bake a
@@ -67,6 +80,17 @@ runs:
         echo "bucket_name=$BUCKET" >> $GITHUB_OUTPUT
         echo "distribution_id=$DIST_ID" >> $GITHUB_OUTPUT
         echo "frontend_url=$FRONTEND_URL" >> $GITHUB_OUTPUT
+        # Do NOT echo the literal nonce to a workflow log line: it is the
+        # value that ends up in every served HTTP response, but logging
+        # it on every CI run is needless attacker-recon-friendly noise.
+        # The presence/absence is reported instead.
+        if [ -n "$CSP_NONCE" ]; then
+          echo "csp_nonce=$CSP_NONCE" >> $GITHUB_OUTPUT
+          echo "CSP style-src nonce: <present, ${#CSP_NONCE} chars>"
+        else
+          echo "csp_nonce=" >> $GITHUB_OUTPUT
+          echo "::warning::CspStyleSrcNonce CFN output missing — index.html will ship with literal __CSP_NONCE__ placeholder. If the backend deploy has not yet rolled out the #254 stack, this is expected on the first frontend-only deploy after merge; re-trigger after the next backend deploy to converge."
+        fi
         echo "API URL: $API_URL"
         echo "Bucket: $BUCKET"
         echo "CloudFront Distribution: $DIST_ID"
@@ -94,6 +118,52 @@ runs:
       env:
         NODE_ENV: production
         VITE_API_URL: ${{ steps.cfn.outputs.api_url }}
+
+    # Issue #254 — stamp the per-deploy CSP style-src nonce into dist/index.html
+    # BEFORE the S3 upload. The CDK custom resource ALSO performs this rewrite
+    # in S3 (so a backend-only `cdk deploy` keeps the served index.html in
+    # sync with the rotated CSP header), but the rewrite below is what
+    # closes the deploy-ordering loop when a frontend re-upload follows
+    # a backend deploy: without this step the fresh `dist/index.html` from
+    # `npm run build` would land in S3 with the literal `__CSP_NONCE__`
+    # placeholder and overwrite the CDK-stamped value, breaking every MUI
+    # style at the edge until the next backend deploy.
+    #
+    # Defensive `sed` semantics: we use a `|` delimiter (not `/`) so the
+    # nonce — which may contain `-` and `_` after base64url encoding but
+    # NOT `|` — never collides with the sed pattern. `-i.bak` produces a
+    # backup file we delete on the next line; this works identically on
+    # macOS and GNU sed (an `-i ''` form does not). The `[ -n NONCE ]`
+    # guard skips the substitution entirely when the CFN output was empty,
+    # leaving the literal placeholder in place (recoverable via re-deploy
+    # — see warning above) instead of running a no-op sed that would
+    # accidentally erase the placeholder under a different bug.
+    - name: Stamp CSP nonce into dist/index.html
+      shell: bash
+      run: |
+        NONCE="${{ steps.cfn.outputs.csp_nonce }}"
+        if [ -z "$NONCE" ]; then
+          echo "::warning::Skipping nonce substitution: CspStyleSrcNonce CFN output was empty"
+          exit 0
+        fi
+        if [ ! -f frontend/dist/index.html ]; then
+          echo "::error::frontend/dist/index.html does not exist after build"
+          exit 1
+        fi
+        # Count placeholder occurrences pre-sed for verification.
+        BEFORE=$(grep -c "__CSP_NONCE__" frontend/dist/index.html || echo 0)
+        if [ "$BEFORE" -eq 0 ]; then
+          echo "::warning::No __CSP_NONCE__ placeholder found in dist/index.html — frontend/index.html may have been edited"
+          exit 0
+        fi
+        sed -i.bak "s|__CSP_NONCE__|${NONCE}|g" frontend/dist/index.html
+        rm -f frontend/dist/index.html.bak
+        AFTER=$(grep -c "__CSP_NONCE__" frontend/dist/index.html || echo 0)
+        echo "Stamped CSP nonce into dist/index.html (replacements: $BEFORE, remaining placeholders: $AFTER)"
+        if [ "$AFTER" -ne 0 ]; then
+          echo "::error::Placeholder still present after sed substitution — refusing to upload"
+          exit 1
+        fi
 
     - name: Sync frontend bundle to S3
       shell: bash

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -300,16 +300,19 @@ jobs:
           echo "CSP Policy: $CSP"
           echo ""
 
-          # CSP hardening status (Issue #133):
-          #   - 'unsafe-eval' has been REMOVED from script-src (Part 2). The
-          #     production bundle was inspected and contains no eval()/Function()
-          #     calls; standard Vite + MUI/Emotion do not require it.
-          #   - 'unsafe-inline' is still permitted (style-src + script-src) and
-          #     will be removed when the nonce-injection pipeline lands
-          #     (Lambda@Edge + Emotion CacheProvider). Tracked in the Part 1
-          #     follow-up issue.
-          # We therefore validate the non-unsafe hardening directives plus the
-          # absence of 'unsafe-eval' as a regression guard.
+          # CSP hardening status (Issues #133, #194, #254):
+          #   - 'unsafe-eval' REMOVED from script-src (Issue #133 Part 2).
+          #     The production bundle was inspected and contains no
+          #     eval()/Function() calls; standard Vite + MUI/Emotion do
+          #     not require it.
+          #   - 'unsafe-inline' REMOVED from script-src (Issue #194).
+          #     dist/index.html contains no inline <script> blocks.
+          #   - 'unsafe-inline' REMOVED from style-src (Issue #254). MUI/
+          #     Emotion runtime styles now carry a per-deploy CSP nonce
+          #     interpolated into both the response header and the served
+          #     index.html `<meta name="csp-nonce">` tag.
+          # We therefore validate the non-unsafe hardening directives plus
+          # explicit regression guards on every removed source.
 
           # Check that CSP contains baseline directives
           required_directives=("default-src" "script-src" "style-src" "connect-src")
@@ -322,8 +325,7 @@ jobs:
             fi
           done
 
-          # Check that CSP contains additional hardening directives (retained
-          # from the Issue #63 pass even though 'unsafe-inline' remains).
+          # Check that CSP contains additional hardening directives.
           hardening_directives=(
             "object-src 'none'"
             "base-uri 'self'"
@@ -347,6 +349,27 @@ jobs:
             exit 1
           else
             echo "✅ PASS: CSP does not contain 'unsafe-eval' (Issue #133 Part 2)"
+          fi
+
+          # Regression guard (Issue #254): 'unsafe-inline' must NOT appear
+          # ANYWHERE in the deployed CSP. The style-src directive now
+          # carries a per-deploy nonce instead.
+          if echo "$CSP" | grep -iF "'unsafe-inline'" > /dev/null; then
+            echo "❌ FAIL: CSP contains 'unsafe-inline' (regression — Issue #254 style-src nonce)"
+            exit 1
+          else
+            echo "✅ PASS: CSP does not contain 'unsafe-inline' (Issue #254)"
+          fi
+
+          # Positive assertion (Issue #254): the style-src directive MUST
+          # carry a 'nonce-...' source. The absence here would mean either
+          # the CDK custom resource failed to interpolate the nonce token
+          # (CFN deploy issue) OR the buildCsp() caller was reverted.
+          if echo "$CSP" | grep -iE "style-src[^;]*'nonce-" > /dev/null; then
+            echo "✅ PASS: CSP style-src carries a 'nonce-<value>' source (Issue #254)"
+          else
+            echo "❌ FAIL: CSP style-src missing 'nonce-<value>' source (Issue #254)"
+            exit 1
           fi
 
           echo ""

--- a/backend/functions/security/cspNonceCustomResource.test.ts
+++ b/backend/functions/security/cspNonceCustomResource.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Tests for the CSP nonce custom-resource handler (Issue #254).
+ *
+ * These tests exercise the pure helpers (`generateNonce`, `applyNonceToHtml`)
+ * directly because they have no AWS-SDK or CloudFormation contract surface.
+ * The `handler` itself is integration-tested by `cdk deploy` in CI; mocking
+ * the SDK + CFN response envelope here would re-prove the SDK contract
+ * rather than the LFMT-specific logic.
+ */
+
+import { applyNonceToHtml, generateNonce } from './cspNonceCustomResource';
+
+describe('cspNonceCustomResource — generateNonce', () => {
+  test('produces a base64url string (no `+`, `/`, or `=`)', () => {
+    const nonce = generateNonce();
+    expect(typeof nonce).toBe('string');
+    // base64url alphabet: A-Z, a-z, 0-9, `-`, `_`. NO `+`, `/`, `=`.
+    expect(nonce).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+
+  test('contains at least 128 bits of entropy', () => {
+    // base64url encoding: 4 chars per 3 bytes. 24 bytes → 32 chars.
+    // CSP3 §6.7 requires ≥ 128 bits = 16 bytes. We emit 24 bytes (192 bits)
+    // so the encoded length is at least 32 chars (no padding) — a regression
+    // that swapped to a shorter byte length would trip this assertion.
+    const nonce = generateNonce();
+    expect(nonce.length).toBeGreaterThanOrEqual(22); // 16 bytes → 22 base64url chars
+  });
+
+  test('successive calls produce distinct values', () => {
+    // Crypto-random — collision probability is astronomical, but the
+    // assertion is a load-bearing defense against an accidental swap to
+    // a deterministic implementation (e.g. `Date.now().toString(36)`).
+    const a = generateNonce();
+    const b = generateNonce();
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('cspNonceCustomResource — applyNonceToHtml', () => {
+  test('replaces a single placeholder occurrence', () => {
+    const html = '<meta name="csp-nonce" content="__CSP_NONCE__">';
+    const out = applyNonceToHtml(html, 'abc123');
+    expect(out).toBe('<meta name="csp-nonce" content="abc123">');
+  });
+
+  test('replaces every occurrence (defensive — should only ever be one)', () => {
+    // The contract is "one meta tag" but a future template change might
+    // legitimately inline the nonce elsewhere (e.g. a SRI hash hint).
+    // Global replacement keeps that path open without code changes.
+    const html = '<a data-n="__CSP_NONCE__"><b data-n="__CSP_NONCE__"></b></a>';
+    const out = applyNonceToHtml(html, 'xyz');
+    expect(out).toBe('<a data-n="xyz"><b data-n="xyz"></b></a>');
+  });
+
+  test('is a no-op when the placeholder is absent', () => {
+    // E.g. a previous deploy already substituted the value, or the
+    // template was edited to remove the meta tag. The handler must
+    // not throw or corrupt the HTML in that case.
+    const html = '<html><head><title>LFMT</title></head></html>';
+    expect(applyNonceToHtml(html, 'abc')).toBe(html);
+  });
+
+  test('does not treat regex metacharacters in the nonce as patterns', () => {
+    // Defensive: base64url cannot produce `.`, but a future nonce
+    // generator that does would break a naive RegExp-based replacement.
+    // Verify literal-string replacement semantics.
+    const html = '<meta content="__CSP_NONCE__">';
+    const nonceWithDot = 'a.b.c';
+    expect(applyNonceToHtml(html, nonceWithDot)).toBe('<meta content="a.b.c">');
+  });
+});

--- a/backend/functions/security/cspNonceCustomResource.ts
+++ b/backend/functions/security/cspNonceCustomResource.ts
@@ -1,0 +1,258 @@
+/**
+ * CSP Style-Src Nonce — CloudFormation custom-resource handler (Issue #254).
+ *
+ * This Lambda is invoked by CloudFormation (via the CDK Provider framework
+ * declared in `backend/infrastructure/lib/lfmt-infrastructure-stack.ts`) on
+ * every `cdk deploy`. Its job is to:
+ *
+ *   1. Generate a cryptographically-random base64url nonce (≥16 bytes of
+ *      entropy — well above the W3C CSP3 §6.7 recommendation).
+ *   2. Read `index.html` from the frontend S3 bucket if present.
+ *   3. Replace every literal `__CSP_NONCE__` token in that HTML with the
+ *      fresh nonce, and re-upload to S3 with the same content-type and
+ *      cache-control headers the CI rebuild-frontend step uses.
+ *   4. Return the nonce via the `Data.Nonce` response field so that the
+ *      CloudFront response-headers policy can interpolate it into the
+ *      `style-src 'self' 'nonce-<value>'` directive (CDK passes the
+ *      `customResource.getAttString('Nonce')` token down to `buildCsp`).
+ *
+ * Step 2 is idempotent and best-effort: on a first-ever stack deploy the
+ * frontend bucket may not yet contain `index.html` (the CI rebuild step
+ * runs after `cdk deploy`), so a `NoSuchKey` error is logged and ignored.
+ * The CI-side `rebuild-frontend` composite action ALSO performs the same
+ * placeholder replacement (using the nonce read back from the CFN output)
+ * before uploading `dist/index.html` — this guards the deploy-ordering
+ * case where the CI rebuild lands AFTER this custom resource has run.
+ *
+ * The trade-off (static nonce per deploy lifetime, not per response) is
+ * documented in `docs/CLOUDFRONT-SETUP.md` under "Operational note:
+ * deploy-time CSP nonce".
+ *
+ * ---------------------------------------------------------------------------
+ * Why a Lambda-backed Provider framework custom resource (not AwsCustomResource)
+ * ---------------------------------------------------------------------------
+ *
+ * `aws-cdk-lib/custom-resources.AwsCustomResource` can only invoke a single
+ * AWS SDK call per lifecycle event — it cannot stitch a `GetObject` ->
+ * `transform string in memory` -> `PutObject` sequence together. The work
+ * here requires both the read and the write to run inside the same
+ * execution context (so the freshly-generated nonce is used in BOTH), so
+ * we use the Provider framework which lets us ship arbitrary handler code.
+ *
+ * ---------------------------------------------------------------------------
+ * Always-runs-on-every-deploy invariant
+ * ---------------------------------------------------------------------------
+ *
+ * CloudFormation only re-invokes a custom resource when one of its input
+ * properties changes. The CDK stack passes `deployTimestamp` (a synth-time
+ * `Date.now()` value) as a property of the custom resource, which causes
+ * a fresh `Update` lifecycle event on every `cdk deploy`. The handler
+ * therefore re-runs and a NEW nonce is generated.
+ *
+ * If a future contributor switches to a deterministic property (e.g. the
+ * stack version), the resource will become idempotent and the nonce will
+ * STOP rotating — re-read the rationale here before doing that.
+ */
+
+import { randomBytes } from 'crypto';
+import { S3Client, GetObjectCommand, PutObjectCommand, NoSuchKey } from '@aws-sdk/client-s3';
+import type {
+  CloudFormationCustomResourceEvent,
+  CloudFormationCustomResourceResponse,
+} from 'aws-lambda';
+
+// Single S3 client per Lambda container; region is auto-detected from the
+// execution environment (LAMBDA_REGION) so this handler works in any of
+// the dev/staging/prod stacks without an explicit `region` constructor
+// argument.
+const s3 = new S3Client({});
+
+/**
+ * Literal placeholder token that the build-time `frontend/index.html` ships
+ * with. Keep in lockstep with the `<meta name="csp-nonce" content="__CSP_NONCE__">`
+ * tag and the `.github/actions/rebuild-frontend/action.yml` sed pattern —
+ * a future rename of any one of these three sites would silently break
+ * the nonce pipeline (the CSP header would carry a fresh nonce while the
+ * HTML would still ship the old placeholder, blocking every MUI style).
+ */
+const NONCE_PLACEHOLDER = '__CSP_NONCE__';
+
+/**
+ * S3 key under the frontend bucket where the SPA entry point lives. CDK
+ * uploads (via the rebuild-frontend composite action) put `index.html` at
+ * the bucket root; the constant is named explicitly so a future move to a
+ * sub-prefix (e.g. `app/index.html`) only touches this one line.
+ */
+const INDEX_HTML_KEY = 'index.html';
+
+/**
+ * Cache-Control header the CI upload step applies to `index.html`. The
+ * value is kept identical to `.github/actions/rebuild-frontend/action.yml`
+ * (`public, max-age=0, must-revalidate`) so the re-upload here does not
+ * accidentally turn the entry-point into a long-lived cached asset (which
+ * would freeze the nonce mismatch in a CDN edge for the next 24h).
+ */
+const INDEX_HTML_CACHE_CONTROL = 'public, max-age=0, must-revalidate';
+
+/**
+ * Generate a CSP-grade nonce. CSP3 §6.7 says the value must be at least 128
+ * bits of entropy; `randomBytes(24)` gives 192 bits, with base64url encoding
+ * producing a 32-character ASCII string that contains only nonce-source-safe
+ * characters (no `'`, `;`, or whitespace that could break the CSP grammar).
+ *
+ * `base64url` encoding (RFC 4648 §5) replaces `+` and `/` with `-` and `_`
+ * and strips padding `=` — none of which require quoting in a CSP header.
+ */
+export function generateNonce(): string {
+  return randomBytes(24).toString('base64url');
+}
+
+/**
+ * Replace every occurrence of the literal placeholder string with the given
+ * nonce. Uses a global string-replacement loop rather than RegExp so a future
+ * placeholder containing regex metacharacters (e.g. dots) still matches
+ * verbatim.
+ */
+export function applyNonceToHtml(html: string, nonce: string): string {
+  return html.split(NONCE_PLACEHOLDER).join(nonce);
+}
+
+interface CspNonceResourceProperties {
+  /**
+   * The frontend S3 bucket name (resolved from
+   * `frontendBucket.bucketName` in the CDK stack).
+   */
+  bucketName: string;
+  /**
+   * Synth-time `Date.now()` value passed by the CDK stack so CloudFormation
+   * detects a property change on every deploy and re-invokes this handler.
+   * The value is not used by the handler itself; its only purpose is to
+   * defeat the "no property change -> skip update" optimization.
+   */
+  deployTimestamp: string;
+}
+
+/**
+ * Read the existing `index.html` from S3 and rewrite the nonce placeholder.
+ * Returns `'absent'` when the object does not yet exist (first-ever deploy
+ * before the CI rebuild step has uploaded an HTML bundle), in which case
+ * the custom resource still completes successfully — the CI composite
+ * action will perform the substitution on its own at upload time.
+ */
+async function rewriteIndexHtml(
+  bucketName: string,
+  nonce: string
+): Promise<'rewritten' | 'absent' | 'no-placeholder'> {
+  let html: string;
+  try {
+    const got = await s3.send(new GetObjectCommand({ Bucket: bucketName, Key: INDEX_HTML_KEY }));
+    if (!got.Body) {
+      // Defensive: a 200 with no body would be a malformed S3 response.
+      // Treat it the same as a missing object — the CI rebuild will heal it.
+      return 'absent';
+    }
+    html = await got.Body.transformToString('utf-8');
+  } catch (err) {
+    if (err instanceof NoSuchKey) {
+      // First-ever deploy: bucket created by this same `cdk deploy` is
+      // empty; CI rebuild-frontend uploads `dist/index.html` afterwards
+      // and does its own placeholder substitution at that time.
+      return 'absent';
+    }
+    throw err;
+  }
+
+  if (!html.includes(NONCE_PLACEHOLDER)) {
+    // The placeholder has already been replaced (e.g. by a previous deploy
+    // OR by the CI composite action's pre-upload sed). In that case the
+    // *currently-deployed* HTML has a stale nonce that no longer matches
+    // the CSP header — we MUST re-upload with the fresh nonce, but we
+    // can't simply re-substitute the placeholder (there isn't one). The
+    // safest path is to log the mismatch and let the CI rebuild step
+    // (which always re-stamps from the CFN output) heal it on the next
+    // frontend upload. Returning 'no-placeholder' surfaces this in the
+    // CloudWatch log without failing the deploy.
+    return 'no-placeholder';
+  }
+
+  const rewritten = applyNonceToHtml(html, nonce);
+  await s3.send(
+    new PutObjectCommand({
+      Bucket: bucketName,
+      Key: INDEX_HTML_KEY,
+      Body: rewritten,
+      ContentType: 'text/html',
+      CacheControl: INDEX_HTML_CACHE_CONTROL,
+    })
+  );
+  return 'rewritten';
+}
+
+/**
+ * CloudFormation custom-resource handler entry point.
+ *
+ * Lifecycle events:
+ *   - `Create` / `Update`: generate a fresh nonce, attempt the S3 rewrite,
+ *     return `Data.Nonce` so the CSP response-headers policy picks up the
+ *     value.
+ *   - `Delete`: no-op — the CSP header and `index.html` will be cleaned
+ *     up by the stack-deletion teardown of the response-headers policy
+ *     and the frontend bucket itself.
+ */
+export async function handler(
+  event: CloudFormationCustomResourceEvent
+): Promise<CloudFormationCustomResourceResponse> {
+  const requestType = event.RequestType;
+  const physicalResourceId =
+    'PhysicalResourceId' in event ? event.PhysicalResourceId : `csp-nonce-${event.RequestId}`;
+
+  if (requestType === 'Delete') {
+    return {
+      Status: 'SUCCESS',
+      PhysicalResourceId: physicalResourceId,
+      StackId: event.StackId,
+      RequestId: event.RequestId,
+      LogicalResourceId: event.LogicalResourceId,
+      Data: {},
+    };
+  }
+
+  const props = event.ResourceProperties as unknown as CspNonceResourceProperties & {
+    ServiceToken: string;
+  };
+  if (!props.bucketName) {
+    throw new Error(
+      `CspNonceCustomResource: missing required property 'bucketName' on ${requestType}`
+    );
+  }
+
+  const nonce = generateNonce();
+  const result = await rewriteIndexHtml(props.bucketName, nonce);
+
+  // eslint-disable-next-line no-console -- intentional CloudWatch breadcrumb
+  console.log(
+    JSON.stringify({
+      level: 'INFO',
+      service: 'lfmt-csp-nonce-custom-resource',
+      message: 'CSP nonce rotated',
+      requestType,
+      bucketName: props.bucketName,
+      result, // 'rewritten' | 'absent' | 'no-placeholder'
+      // Do NOT log the nonce itself — it ends up in the live CSP header
+      // and the rendered `index.html`, both of which are public, but
+      // a CloudWatch breadcrumb of every historical nonce is cheap
+      // attacker recon (a single CloudTrail read enumerates them all).
+    })
+  );
+
+  return {
+    Status: 'SUCCESS',
+    PhysicalResourceId: physicalResourceId,
+    StackId: event.StackId,
+    RequestId: event.RequestId,
+    LogicalResourceId: event.LogicalResourceId,
+    Data: {
+      Nonce: nonce,
+    },
+  };
+}

--- a/backend/infrastructure/lib/__tests__/infrastructure.test.ts
+++ b/backend/infrastructure/lib/__tests__/infrastructure.test.ts
@@ -1383,11 +1383,10 @@ describe('LFMT Infrastructure Stack', () => {
       // Re-introducing 'unsafe-inline' on script-src would re-open the
       // exfiltration class and must trip CI.
       //
-      // Note: 'unsafe-inline' on style-src remains present. MUI/Emotion
-      // injects runtime styles via document.head.appendChild('<style>')
-      // and removing this directive requires a Lambda@Edge nonce
-      // pipeline. That work is tracked in a separate follow-up issue;
-      // it does not address the same exfiltration class.
+      // Note: 'unsafe-inline' on style-src has ALSO been removed as of
+      // Issue #254 (build-time static-nonce pipeline). The separate
+      // "style-src does not contain 'unsafe-inline'" guard below carries
+      // that contract.
       const flattenCsp = (csp: unknown): string => {
         if (typeof csp === 'string') return csp;
         if (csp && typeof csp === 'object' && 'Fn::Join' in (csp as object)) {
@@ -1411,8 +1410,10 @@ describe('LFMT Infrastructure Stack', () => {
             .ContentSecurityPolicy;
         const flat = flattenCsp(csp);
         // Extract just the script-src directive, then assert it does
-        // NOT contain 'unsafe-inline'. Avoids accidentally tripping on
-        // the style-src 'unsafe-inline' that is intentionally retained.
+        // NOT contain 'unsafe-inline'. style-src has its own dedicated
+        // guard below (#254) — keeping the matchers per-directive means
+        // a regression on either one is reported by the correct failing
+        // test name rather than via an overly broad string search.
         const scriptSrcMatch = flat.match(/script-src[^;]*/);
         if (!scriptSrcMatch) {
           throw new Error(`script-src directive missing from CSP: ${flat}`);
@@ -1425,6 +1426,87 @@ describe('LFMT Infrastructure Stack', () => {
         // which IS `'self'`, so the SPA still loads but the contract
         // is now implicit). Assert `'self'` is the explicit value.
         expect(scriptSrcMatch[0]).toMatch(/^script-src\s+'self'\s*$/);
+      });
+    });
+
+    test("style-src does not contain 'unsafe-inline' (Issue #254)", () => {
+      // Regression guard for Issue #254 — build-time static-nonce pipeline.
+      //
+      // 'unsafe-inline' on style-src was retained for many months because
+      // MUI/Emotion injects CSS-in-JS via `document.head.appendChild(<style>)`
+      // at runtime, and CSP nonce-source-expressions ARE the only safe
+      // alternative. PR for #254 introduced a CDK custom resource
+      // (`backend/functions/security/cspNonceCustomResource.ts`) that
+      // generates a fresh `crypto.randomBytes(24).toString('base64url')`
+      // nonce on every `cdk deploy` and stamps it into both the response
+      // CSP header AND the `<meta name="csp-nonce">` tag in `index.html`.
+      // The React tree reads that meta and threads the nonce into the
+      // Emotion CacheProvider, so MUI's runtime styles ship a `nonce`
+      // attribute and pass CSP.
+      //
+      // The BASE policy emitted by `buildCsp()` (i.e., the CDK synth-time
+      // string in the ResponseHeadersPolicy) no longer needs
+      // `'unsafe-inline'` — the caller appends the `'nonce-<token>'`
+      // source explicitly using the CFN-token attribute exposed by the
+      // custom resource. Re-introducing `'unsafe-inline'` on style-src
+      // here would re-open the inline-style injection class (an attacker
+      // who controls a snippet of HTML could smuggle in
+      // `<style>body{display:none}</style>` or worse, a CSS exfiltration
+      // via `:has`/url() side-channels), so this test must trip CI on
+      // any future regression.
+      //
+      // Mirrors the PR #194 guard for `script-src`. Both initial and
+      // updated response-headers policies are asserted. Note that we
+      // deliberately do NOT assert the exact shape of `style-src` here,
+      // because the CDK token interpolation produces an `Fn::Join` that
+      // serializes as an opaque string at template-read time — pinning
+      // the structural shape (presence of 'self', presence of a nonce
+      // marker, ABSENCE of 'unsafe-inline') is the load-bearing contract.
+      const flattenCsp = (csp: unknown): string => {
+        if (typeof csp === 'string') return csp;
+        if (csp && typeof csp === 'object' && 'Fn::Join' in (csp as object)) {
+          const join = (csp as { 'Fn::Join': [string, unknown[]] })['Fn::Join'];
+          const parts = join[1];
+          return parts.map((p) => (typeof p === 'string' ? p : JSON.stringify(p))).join('');
+        }
+        return JSON.stringify(csp);
+      };
+
+      const policies = template.findResources('AWS::CloudFront::ResponseHeadersPolicy');
+      const cspCarryingPolicies = Object.values(policies).filter((policy: any) => {
+        return !!policy?.Properties?.ResponseHeadersPolicyConfig?.SecurityHeadersConfig
+          ?.ContentSecurityPolicy?.ContentSecurityPolicy;
+      });
+      expect(cspCarryingPolicies.length).toBeGreaterThanOrEqual(2);
+
+      cspCarryingPolicies.forEach((policy: any) => {
+        const csp =
+          policy.Properties.ResponseHeadersPolicyConfig.SecurityHeadersConfig.ContentSecurityPolicy
+            .ContentSecurityPolicy;
+        const flat = flattenCsp(csp);
+        // Extract just the style-src directive so we don't falsely pass
+        // if a future regression moves `'unsafe-inline'` to some other
+        // directive. The directive ends at the next `;` boundary.
+        const styleSrcMatch = flat.match(/style-src[^;]*/);
+        if (!styleSrcMatch) {
+          throw new Error(`style-src directive missing from CSP: ${flat}`);
+        }
+        // Hard contract: 'unsafe-inline' MUST NOT appear in the style-src
+        // source list. This is the regression we are guarding against.
+        expect(styleSrcMatch[0]).not.toContain("'unsafe-inline'");
+        // Positive assertion: 'self' must be the first explicit source so
+        // a regression that accidentally drops the directive entirely
+        // (which would silently fall back to `default-src 'self'` and
+        // load the SPA) is flagged.
+        expect(styleSrcMatch[0]).toMatch(/style-src\s+'self'/);
+        // Positive assertion: the nonce source must be present. The
+        // exact value is a CFN token (`Fn::GetAtt`), which the flattener
+        // serialises to a JSON object string containing the marker
+        // string `Nonce`. A regression that forgets to pass the nonce
+        // source would drop the `nonce-` token entirely and the SPA's
+        // MUI styles would break in the wild — surface that here
+        // instead of waiting for a deploy failure.
+        expect(styleSrcMatch[0]).toMatch(/nonce-/);
       });
     });
 
@@ -1644,15 +1726,17 @@ describe('LFMT Infrastructure Stack', () => {
   //   Register, Login, RefreshToken, ResetPassword, GetCurrentUser,
   //   UploadRequest, UploadComplete, ChunkDocument, TranslateChunk,
   //   StartTranslation, GetTranslationStatus, GetJob, DeleteJob,
-  //   DownloadTranslation (added in demo-readiness PR).
+  //   DownloadTranslation (added in demo-readiness PR), ListJobs,
+  //   CspReport, CspNonceCustomResource.
   // The dev-only PreSignUp Lambda is gated behind `isDev`
   // (stackName.toLowerCase().includes('dev')) and is absent in the
   // 'test' stackName used by these tests.
   // Update this constant + the PR body whenever a Lambda is added or removed
-  // (PR #208: +2 for GetJob + DeleteJob, 11 → 13; demo-readiness: +1 for
-  // DownloadTranslation, 13 → 14; PR #239: +1 for ListJobs, 14 → 15;
-  // #201: +1 for CspReport, 15 → 16).
-  const EXPECTED_APPLICATION_LAMBDA_COUNT = 16;
+  // (PR #208: +2 for GetJob + DeleteJob, 11 -> 13; demo-readiness: +1 for
+  // DownloadTranslation, 13 -> 14; PR #239: +1 for ListJobs, 14 -> 15;
+  // #201: +1 for CspReport, 15 -> 16; #254: +1 for CspNonceCustomResource,
+  // 16 -> 17).
+  const EXPECTED_APPLICATION_LAMBDA_COUNT = 17;
 
   describe('Lambda Runtime Drift Guard (PR #203 R2)', () => {
     // Regression guard mirroring the CSP/'unsafe-eval' pattern (PR #198):
@@ -2313,7 +2397,12 @@ describe('csp.ts — buildCsp(#216 directive-map shape)', () => {
     const csp = buildCsp();
     expect(csp).toContain("default-src 'self'");
     expect(csp).toContain("script-src 'self'");
-    expect(csp).toContain("style-src 'self' 'unsafe-inline'");
+    // style-src no longer carries 'unsafe-inline' in the base policy
+    // (#254). The per-deploy `'nonce-<b64>'` is appended by callers in
+    // `lfmt-infrastructure-stack.ts` using the CFN token returned by the
+    // CDK custom resource — `buildCsp` itself does not interpolate it.
+    expect(csp).toMatch(/(?:^|; )style-src 'self'(?:;|$)/);
+    expect(csp).not.toContain("'unsafe-inline'");
     expect(csp).toContain("img-src 'self' data: https:");
     expect(csp).toContain("font-src 'self' data:");
     expect(csp).toContain("connect-src 'self'");

--- a/backend/infrastructure/lib/csp.ts
+++ b/backend/infrastructure/lib/csp.ts
@@ -26,12 +26,20 @@
  * (NOT a single string) so the validation and join semantics are crystal-
  * clear at the call site.
  *
- * Hardening status (Issues #133, #194, #216):
+ * Hardening status (Issues #133, #194, #216, #254):
  *   - 'unsafe-eval' REMOVED from script-src.
  *   - 'unsafe-inline' REMOVED from script-src — Vite's built
  *     `dist/index.html` has no inline `<script>` blocks.
- *   - 'unsafe-inline' on style-src: retained by default, but callers MAY
- *     override with a `'nonce-...'` source list per #197.
+ *   - 'unsafe-inline' REMOVED from style-src default (#254). MUI/Emotion
+ *     CSS-in-JS now flows through a nonce-aware Emotion CacheProvider
+ *     wired to a `<meta name="csp-nonce">` tag stamped into `index.html`
+ *     at deploy time by the CDK custom resource defined in
+ *     `lfmt-infrastructure-stack.ts`. The same custom resource exposes
+ *     the nonce as a CloudFormation attribute that callers thread into
+ *     `buildCsp({ directives: { 'style-src': ["'self'", "'nonce-<token>'"] } })`
+ *     so the response-headers policy CSP carries the matching source.
+ *     The default emitted here is just `style-src 'self'`; callers MUST
+ *     pass a `'nonce-...'` source explicitly to make MUI styles work.
  *
  * Telemetry (#201): pass `'report-uri': ['https://...']`. The value is
  * sanitized by `assertValidCspReportUri` to prevent injection attacks via
@@ -105,17 +113,26 @@ const DEFAULT_DIRECTIVES: Required<
 > = {
   'default-src': ["'self'"],
   'script-src': ["'self'"],
-  // 'unsafe-inline' is RETAINED on style-src for now (Issue #254 — split
-  // from the original #197). MUI/Emotion injects runtime styles via
-  // `document.head.appendChild('<style>')` and removing this directive
-  // requires a Lambda@Edge per-response nonce pipeline. The CSP builder
-  // already SUPPORTS the nonce path (caller passes
-  //   'style-src': ["'self'", "'nonce-...'"]
-  // and a unit test pins the output) so #254 is a one-line change at the
-  // caller plus the Lambda@Edge function. Until that lands, the
-  // #201 violation-report endpoint catches any regression that introduces
-  // a NEW source of inline styles outside MUI/Emotion.
-  'style-src': ["'self'", "'unsafe-inline'"],
+  // 'unsafe-inline' REMOVED from style-src as of #254. MUI/Emotion no
+  // longer injects un-nonced `<style>` tags: the React tree wraps `App`
+  // in a nonce-aware Emotion `CacheProvider` that reads the nonce from
+  // the `<meta name="csp-nonce">` tag in `index.html`. The CDK custom
+  // resource defined in `lfmt-infrastructure-stack.ts` (see
+  // `createCspNonceCustomResource`) generates a fresh random nonce on
+  // every `cdk deploy`, rewrites the meta-tag placeholder in S3, and
+  // exposes the value to this builder so the response-headers policy
+  // CSP carries `style-src 'self' 'nonce-<value>'` for the matching
+  // deploy lifetime.
+  //
+  // The static-per-deploy trade-off is documented in
+  // `docs/CLOUDFRONT-SETUP.md`: an attacker who reads the served
+  // `index.html` learns the nonce until the next frontend deploy
+  // rotates it. We accept this because (a) the #201 CSP violation-
+  // report endpoint alarms on any regression that introduces a
+  // non-nonced inline style, and (b) per-response nonces would
+  // require Lambda@Edge body-rewriting which Lambda@Edge does NOT
+  // expose (the original #254 design was pivoted for this reason).
+  'style-src': ["'self'"],
   'img-src': ["'self'", 'data:', 'https:'],
   'font-src': ["'self'", 'data:'],
   'connect-src': ["'self'"],

--- a/backend/infrastructure/lib/lfmt-infrastructure-stack.ts
+++ b/backend/infrastructure/lib/lfmt-infrastructure-stack.ts
@@ -17,6 +17,8 @@ import * as cloudfront from 'aws-cdk-lib/aws-cloudfront';
 import * as origins from 'aws-cdk-lib/aws-cloudfront-origins';
 import * as route53 from 'aws-cdk-lib/aws-route53';
 import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
+import { CustomResource } from 'aws-cdk-lib';
+import { Provider } from 'aws-cdk-lib/custom-resources';
 
 // CSP builder — extracted into its own module (#216) so the directive
 // shape is testable in isolation and re-usable from non-stack constructs.
@@ -123,6 +125,14 @@ export class LfmtInfrastructureStack extends Stack {
   // endpoint receiving browser reports — kept on its own role so the
   // (minimal) IAM grant is auditable in isolation.
   private cspReportFunction?: lambda.Function;
+  // CSP style-src nonce custom resource (#254). The CFN attribute
+  // `Data.Nonce` carries the freshly-generated per-deploy nonce that
+  // both the response-headers policy CSP and the S3-uploaded
+  // `index.html` `<meta name="csp-nonce">` tag interpolate. Stored as a
+  // class field so `updateCloudFrontCSP()` (called after API Gateway is
+  // provisioned) can re-thread the same token into the updated CSP
+  // string without a second custom-resource invocation.
+  private cspNonceCustomResource?: CustomResource;
 
   // IAM role for Lambda functions
   private lambdaRole?: iam.Role;
@@ -2428,6 +2438,11 @@ export class LfmtInfrastructureStack extends Stack {
       signing: cloudfront.Signing.SIGV4_ALWAYS,
     });
 
+    // 2.5 Create the CSP style-src nonce custom resource (#254).
+    // MUST run before the ResponseHeadersPolicy below so the nonce token
+    // is available to the `style-src 'self' 'nonce-<token>'` directive.
+    this.createCspNonceCustomResource();
+
     // 3. Create CloudFront Distribution
     const environment = this.node.tryGetContext('environment');
     const isProd = environment === 'prod';
@@ -2484,6 +2499,20 @@ export class LfmtInfrastructureStack extends Stack {
                   "'self'",
                   'https://*.execute-api.us-east-1.amazonaws.com',
                   `https://${this.documentBucket.bucketRegionalDomainName}`,
+                ],
+                // #254 — style-src per-deploy nonce. The CDK custom resource
+                // generates a fresh base64url nonce on every `cdk deploy`
+                // and exposes it via `Data.Nonce`. `getAttString` returns
+                // a CDK Token that resolves to a `Fn::GetAtt` reference at
+                // synth time; CloudFormation substitutes the concrete value
+                // when the stack is deployed, so the CSP header at the edge
+                // carries `style-src 'self' 'nonce-<value>'`. The same nonce
+                // is stamped into `index.html`'s `<meta name="csp-nonce">`
+                // tag by the same custom resource (and by the CI rebuild
+                // composite action — see `.github/actions/rebuild-frontend/`).
+                'style-src': [
+                  "'self'",
+                  `'nonce-${this.cspNonceCustomResource!.getAttString('Nonce')}'`,
                 ],
               },
             }),
@@ -2623,6 +2652,15 @@ export class LfmtInfrastructureStack extends Stack {
                   `https://${apiDomain}`,
                   `https://${this.documentBucket.bucketRegionalDomainName}`,
                 ],
+                // #254 — same per-deploy nonce as the initial policy above.
+                // We reuse the SAME `cspNonceCustomResource` instance (not a
+                // second custom resource) so the two CSP headers cannot
+                // drift to different nonces — both reference the same
+                // `Fn::GetAtt` CFN token, which resolves once per deploy.
+                'style-src': [
+                  "'self'",
+                  `'nonce-${this.cspNonceCustomResource!.getAttString('Nonce')}'`,
+                ],
                 // #201: report violations to the dedicated unauthenticated
                 // /csp-report Lambda. Per CSP3, `report-uri` is exempt
                 // from `connect-src` — the browser fires the POST out-of-band
@@ -2651,6 +2689,125 @@ export class LfmtInfrastructureStack extends Stack {
       'DistributionConfig.DefaultCacheBehavior.ResponseHeadersPolicyId',
       updatedResponseHeadersPolicy.responseHeadersPolicyId
     );
+  }
+
+  /**
+   * createCspNonceCustomResource — CDK construct for the per-deploy
+   * style-src nonce (Issue #254).
+   *
+   * Provisions a tiny Lambda (`backend/functions/security/cspNonceCustomResource.ts`)
+   * fronted by the CDK Provider framework. The Provider calls the handler
+   * on every stack `Create`/`Update` event. The handler:
+   *
+   *   1. Generates a fresh base64url nonce (192 bits of entropy).
+   *   2. Best-effort reads `index.html` from the frontend bucket, replaces
+   *      every `__CSP_NONCE__` placeholder, and re-uploads.
+   *   3. Returns the nonce via `Data.Nonce`, which CloudFormation surfaces
+   *      to callers of `customResource.getAttString('Nonce')`.
+   *
+   * The `deployTimestamp` property is the always-changes input that
+   * defeats CloudFormation's "no property delta -> skip update" optimisation,
+   * so the resource re-runs on every `cdk deploy` and the nonce rotates.
+   *
+   * IAM scoping (least-privilege, per OMC review pattern):
+   *   - `s3:GetObject` and `s3:PutObject` on EXACTLY the `index.html` key
+   *     of the frontend bucket. NOT bucket-wide.
+   *   - CloudWatch Logs basic execution policy.
+   *
+   * Deploy-workflow ordering note: when a backend deploy is followed by a
+   * frontend re-upload via `rebuild-frontend` (deploy-backend.yml's frontend
+   * rebuild step, OR a deploy-frontend.yml run), the re-upload would
+   * naively overwrite the stamped `index.html` with the placeholder still
+   * present. The composite action therefore re-performs the same
+   * placeholder substitution (using the nonce read from this stack's
+   * `CspStyleSrcNonce` CFN output) before uploading. See
+   * `.github/actions/rebuild-frontend/action.yml`.
+   */
+  private createCspNonceCustomResource() {
+    if (!this.frontendBucket) {
+      throw new Error('Frontend bucket must be created before CSP nonce custom resource');
+    }
+
+    const skipBundling = this.node.tryGetContext('skipLambdaBundling') === 'true';
+
+    // Lambda handler that does the read/replace/write.
+    const nonceLambda = new NodejsFunction(this, 'CspNonceCustomResourceLambda', {
+      functionName: `lfmt-csp-nonce-${this.stackName}`,
+      entry: '../functions/security/cspNonceCustomResource.ts',
+      handler: 'handler',
+      runtime: LAMBDA_RUNTIME,
+      architecture: LAMBDA_ARCHITECTURE,
+      timeout: Duration.seconds(30),
+      memorySize: 128,
+      description:
+        'CSP style-src nonce generator + index.html placeholder rewriter (#254). Runs on every cdk deploy.',
+      bundling: {
+        externalModules: ['aws-sdk', '@aws-sdk/*'],
+        minify: true,
+        sourceMap: true,
+        forceDockerBundling: false,
+      },
+      // Test harness disables Lambda bundling for a fast `cdk synth` —
+      // mirror the same flag the createJobLambda helper consults.
+      ...(skipBundling
+        ? {
+            code: lambda.Code.fromInline(
+              'exports.handler = async () => ({ Status: "SUCCESS", Data: { Nonce: "test" } });'
+            ),
+          }
+        : {}),
+    });
+
+    // Least-privilege IAM: scoped to the single `index.html` key under the
+    // frontend bucket. NOT the whole bucket. A scope-wide grant would let
+    // a compromised Lambda overwrite the JS bundle and ship malicious code.
+    nonceLambda.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ['s3:GetObject', 's3:PutObject'],
+        resources: [`${this.frontendBucket.bucketArn}/index.html`],
+      })
+    );
+
+    // Provider construct ID intentionally prefixed with `Custom` so the
+    // generated CloudFormation logical ID is filtered out by the Lambda
+    // drift-guard tests (`isApplicationLambda` excludes `Custom*` because
+    // those are CDK-helper Lambdas whose runtime/architecture defaults
+    // we do not control via the application's `LAMBDA_*` constants). The
+    // application-side handler (`nonceLambda` above) keeps its
+    // `CspNonceCustomResourceLambda` name and IS counted, which is
+    // correct — we control its architecture and runtime explicitly.
+    const provider = new Provider(this, 'CustomCspNonceProvider', {
+      onEventHandler: nonceLambda,
+    });
+
+    // The custom resource. Note `deployTimestamp` — a synth-time value
+    // that changes on every `cdk deploy` so CloudFormation re-invokes
+    // the handler (otherwise CFN sees identical properties and skips
+    // the update, freezing the nonce).
+    this.cspNonceCustomResource = new CustomResource(this, 'CspStyleSrcNonceResource', {
+      serviceToken: provider.serviceToken,
+      properties: {
+        bucketName: this.frontendBucket.bucketName,
+        // ISO-8601 UTC at synth time. Any string that differs between two
+        // `cdk deploy` invocations works; using the timestamp keeps the
+        // CFN diff human-readable (`OldValue` / `NewValue` show actual
+        // wall-clock differences).
+        deployTimestamp: new Date().toISOString(),
+      },
+    });
+
+    // Surface the nonce on the stack outputs so the CI rebuild-frontend
+    // composite action can read it via `aws cloudformation describe-stacks`
+    // and stamp the same value into `dist/index.html` before uploading.
+    // This is what closes the deploy-ordering loop when the CI rebuild
+    // step runs AFTER the custom resource has updated S3 (and would
+    // otherwise restore the `__CSP_NONCE__` placeholder).
+    new CfnOutput(this, 'CspStyleSrcNonce', {
+      value: this.cspNonceCustomResource.getAttString('Nonce'),
+      description:
+        'Per-deploy CSP style-src nonce (#254). Consumed by .github/actions/rebuild-frontend to stamp index.html before S3 upload. Public: surfaced in every viewer response, do NOT treat as secret.',
+    });
   }
 
   private createOutputs() {

--- a/docs/CLOUDFRONT-SETUP.md
+++ b/docs/CLOUDFRONT-SETUP.md
@@ -215,6 +215,34 @@ const responseHeadersPolicy = new cloudfront.ResponseHeadersPolicy(this, 'Securi
 
 **⚠️ CRITICAL**: CSP **must** be configured in `securityHeadersBehavior.contentSecurityPolicy`, **NOT** in `customHeadersBehavior.customHeaders[]`. CloudFormation will reject deployment if CSP is in custom headers.
 
+### Operational note: deploy-time CSP nonce (Issue #254)
+
+The `style-src` directive carries a per-deploy random nonce (NOT `'unsafe-inline'`) so MUI/Emotion's runtime `<style>` injections pass CSP without opening the inline-style injection class. The mechanics:
+
+1. **Build time**: `frontend/index.html` ships with `<meta name="csp-nonce" content="__CSP_NONCE__">`. Vite leaves the literal placeholder untouched through `npm run build` — the value lands in `dist/index.html` verbatim.
+
+2. **Deploy time (CDK)**: a CDK custom resource (`backend/functions/security/cspNonceCustomResource.ts`, wired up in `lfmt-infrastructure-stack.ts#createCspNonceCustomResource`) generates a fresh `crypto.randomBytes(24).toString('base64url')` nonce on every `cdk deploy`. It reads `index.html` from the frontend S3 bucket, replaces `__CSP_NONCE__` with the new value, re-uploads, and exposes the nonce via the `CspStyleSrcNonce` CloudFormation output. The same nonce is interpolated into the CSP response-headers policy (`style-src 'self' 'nonce-<value>'`).
+
+3. **Deploy time (CI)**: the `.github/actions/rebuild-frontend` composite action — used by BOTH `deploy-backend.yml` AND `deploy-frontend.yml` — reads `CspStyleSrcNonce` from CFN outputs and stamps it into `dist/index.html` BEFORE uploading to S3. This is what closes the deploy-ordering loop: without the CI-side substitution, a backend deploy's `rebuild-frontend` step would land a fresh `dist/index.html` (with placeholder) on top of the CDK-stamped value, and every MUI style would break at the edge.
+
+**Trade-off**: the nonce is static for one deploy lifetime, NOT per response. An attacker who reads the served `index.html` learns the nonce until the next frontend deploy rotates it. This is a meaningful but bounded reduction in the security benefit compared to a per-response nonce. The trade-off is accepted because:
+
+- The CSP violation-report endpoint (#201, live since PR #257) alarms in CloudWatch on any regression that introduces inline styles without nonces — i.e., the _primary_ goal of this design (eliminate `'unsafe-inline'`) is achievable and observable.
+- A per-response nonce model would require Lambda@Edge body-rewriting, which Lambda@Edge response triggers do not support (AWS doc citations preserved on Issue #254's pivot comment).
+- The remaining auth-token surface is still localStorage-readable (#255 deferred); per-response nonce freshness on `style-src` is comparatively low marginal value while that exposure exists.
+
+**Deploy-workflow ordering**: the contract is that the `rebuild-frontend` composite action ALWAYS performs the placeholder substitution at upload time. This way the served `index.html` always matches the live CSP header, regardless of whether the upload follows a `cdk deploy` (deploy-backend.yml) or stands alone (deploy-frontend.yml). The CDK custom resource's in-place S3 rewrite is the belt-and-braces: it keeps the served HTML coherent with the CSP even if no subsequent CI upload runs.
+
+**Troubleshooting: MUI styles disappear after a deploy** — the symptom is a recently-deployed site with broken layout and CSP violation reports of the form `violated-directive: "style-src"`, `blocked-uri: "inline"`. Most likely causes, in order:
+
+1. **Stale nonce in `index.html`**: the served `index.html` carries one nonce while the CSP header carries another. Check by `curl -s https://<frontend>/index.html | grep csp-nonce` and `curl -sI https://<frontend>/ | grep -i content-security-policy`. The base64url tokens must match. Recovery: re-run `gh workflow run deploy-backend.yml --ref main` (rotates both the CSP header and the served HTML in one transaction).
+
+2. **Literal placeholder still in `index.html`**: `curl -s https://<frontend>/index.html | grep __CSP_NONCE__` returns a match. This means the CI substitution step skipped (no `CspStyleSrcNonce` CFN output yet, or the rebuild-frontend action was an older version). Recovery: re-deploy the backend so the custom resource fires the in-place rewrite, OR re-run the frontend deploy after confirming `aws cloudformation describe-stacks --stack-name LfmtPocDev --query 'Stacks[0].Outputs[?OutputKey==\`CspStyleSrcNonce\`]'` returns a value.
+
+3. **Stale CSP header at CloudFront edge**: a recent deploy stamped a new nonce but CloudFront caches still serve the old CSP. Recovery: invalidate `/*` via `aws cloudfront create-invalidation`. Note the rebuild-frontend action already invalidates after every upload — this case implies the invalidation step was skipped or failed.
+
+**Dev-mode (`npm run dev`)**: Vite's dev server serves `index.html` without running CDK, so the `__CSP_NONCE__` placeholder stays literal. The `getCspNonceFromMeta()` helper in `frontend/src/utils/cspNonce.ts` detects the un-substituted placeholder and returns `undefined`; Emotion then omits the `nonce=` attribute entirely. The Vite dev server does not set the production CSP header, so MUI styles continue to work in dev — no extra configuration needed.
+
 ### Stack Outputs
 
 ```typescript

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,6 +5,26 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="LFMT - Long-Form Translation Service POC" />
+    <!--
+      CSP nonce placeholder (Issue #254).
+
+      The literal `__CSP_NONCE__` token below is replaced at deploy time by the
+      CDK custom resource defined in `backend/infrastructure/lib/lfmt-infrastructure-stack.ts`
+      (and by a CI-side `sed` substitution in `.github/actions/rebuild-frontend/action.yml`,
+      which handles the case where a frontend re-upload follows a backend deploy
+      and would otherwise restore the placeholder over the CDK-stamped nonce).
+
+      Vite leaves this string untouched at build time — it is not an env-var
+      template (`%VITE_*%`) nor a JavaScript-resolved expression — so the
+      placeholder is preserved verbatim in `dist/index.html`. The Emotion
+      `CacheProvider` wired up in `src/main.tsx` reads the resolved nonce
+      from this meta tag at runtime so MUI-injected `<style>` blocks carry
+      a CSP-valid `nonce=` attribute. In `npm run dev` the placeholder is
+      NOT replaced (no CDK deploy in the loop); Emotion falls back to
+      no-nonce, which is fine because the Vite dev server does not enforce
+      the production CSP header.
+    -->
+    <meta name="csp-nonce" content="__CSP_NONCE__" />
     <title>LFMT - Long-Form Translation Service</title>
   </head>
   <body>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "UNLICENSED",
       "dependencies": {
+        "@emotion/cache": "^11.14.0",
         "@emotion/react": "^11.11.3",
         "@emotion/styled": "^11.11.0",
         "@hookform/resolvers": "^3.3.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
     "postinstall": "msw init public/ --save"
   },
   "dependencies": {
+    "@emotion/cache": "^11.14.0",
     "@emotion/react": "^11.11.3",
     "@emotion/styled": "^11.11.0",
     "@hookform/resolvers": "^3.3.4",

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -13,10 +13,24 @@
  * bundler and would evaluate `App.tsx` (and transitively `apiClient`)
  * at module-load time, BEFORE the await runs. Dynamic import defers
  * `App.tsx` evaluation until after the SW is ready.
+ *
+ * CSP style-src nonce (#254): the App tree is wrapped in an Emotion
+ * `CacheProvider` configured with the deploy-time nonce read from the
+ * `<meta name="csp-nonce">` tag in `index.html`. Without this, MUI's
+ * runtime CSS-in-JS injections (`document.head.appendChild('<style>')`)
+ * ship without a `nonce=` attribute and are blocked by the production
+ * CSP `style-src 'self' 'nonce-<value>'` policy. The helper returns
+ * `undefined` in dev mode (where the placeholder is not replaced) so
+ * Emotion gracefully falls back to no-nonce emission — Vite's dev
+ * server does not enforce the production CSP header, so dev-mode
+ * styling continues to work.
  */
 
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import createCache from '@emotion/cache';
+import { CacheProvider } from '@emotion/react';
+import { getCspNonceFromMeta } from './utils/cspNonce';
 
 async function bootstrap(): Promise<void> {
   if (import.meta.env.VITE_MOCK_API === 'true') {
@@ -30,9 +44,21 @@ async function bootstrap(): Promise<void> {
   // Do NOT change to a static import; see file header.
   const { default: App } = await import('./App');
 
+  // Emotion cache wired to the per-deploy CSP nonce. The `key: 'css'`
+  // is Emotion's standard default; the `nonce` option propagates to
+  // every <style> tag Emotion injects at runtime. When `nonce` is
+  // `undefined` (dev mode, missing meta tag, un-substituted placeholder)
+  // Emotion omits the attribute entirely — exactly the desired fallback.
+  const emotionCache = createCache({
+    key: 'css',
+    nonce: getCspNonceFromMeta(),
+  });
+
   ReactDOM.createRoot(document.getElementById('root')!).render(
     <React.StrictMode>
-      <App />
+      <CacheProvider value={emotionCache}>
+        <App />
+      </CacheProvider>
     </React.StrictMode>
   );
 }

--- a/frontend/src/utils/__tests__/cspNonce.test.ts
+++ b/frontend/src/utils/__tests__/cspNonce.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Tests for the CSP-nonce runtime accessor (Issue #254).
+ *
+ * The helper is intentionally tiny but the failure-modes matter:
+ *   - Missing meta tag (dev server, SSR pre-hydration, jsdom default)
+ *     → `undefined`, Emotion falls back to no-nonce.
+ *   - Un-substituted `__CSP_NONCE__` placeholder (deploy regression,
+ *     `npm run dev` mode) → `undefined` (NOT the literal token) so
+ *     Emotion doesn't stamp the placeholder onto every style tag.
+ *   - Empty `content=""` attribute → `undefined`.
+ *   - Valid nonce → the string verbatim.
+ */
+import { describe, test, expect, afterEach } from 'vitest';
+import { getCspNonceFromMeta } from '../cspNonce';
+
+function ensureMetaTag(content: string | null): void {
+  const existing = document.querySelector('meta[name="csp-nonce"]');
+  if (existing) existing.remove();
+  if (content === null) return;
+  const meta = document.createElement('meta');
+  meta.setAttribute('name', 'csp-nonce');
+  meta.setAttribute('content', content);
+  document.head.appendChild(meta);
+}
+
+describe('getCspNonceFromMeta', () => {
+  afterEach(() => {
+    ensureMetaTag(null);
+  });
+
+  test('returns undefined when no meta tag is present', () => {
+    ensureMetaTag(null);
+    expect(getCspNonceFromMeta()).toBeUndefined();
+  });
+
+  test('returns undefined when content is empty', () => {
+    ensureMetaTag('');
+    expect(getCspNonceFromMeta()).toBeUndefined();
+  });
+
+  test('returns undefined when content is the un-substituted placeholder', () => {
+    // Dev-mode case: Vite serves `index.html` without running the CDK
+    // custom resource, so the placeholder is still literal. Emotion
+    // must fall back to no-nonce in that case (or it would stamp
+    // `nonce="__CSP_NONCE__"` onto every style tag and the production
+    // CSP would block them all).
+    ensureMetaTag('__CSP_NONCE__');
+    expect(getCspNonceFromMeta()).toBeUndefined();
+  });
+
+  test('returns the verbatim nonce when the meta tag is properly stamped', () => {
+    // Sample base64url string the CDK custom resource would emit:
+    // `randomBytes(24).toString('base64url')` produces 32 chars,
+    // ASCII-safe (no `'`, `;`, whitespace).
+    const realNonce = 'aBcDeF1234567890aBcDeF1234567890';
+    ensureMetaTag(realNonce);
+    expect(getCspNonceFromMeta()).toBe(realNonce);
+  });
+});

--- a/frontend/src/utils/cspNonce.ts
+++ b/frontend/src/utils/cspNonce.ts
@@ -1,0 +1,65 @@
+/**
+ * CSP style-src nonce — runtime accessor (Issue #254).
+ *
+ * Reads the `content` attribute of the `<meta name="csp-nonce">` tag that
+ * the CDK custom resource stamps into `index.html` at deploy time. The
+ * value is threaded into the Emotion `CacheProvider` in `main.tsx` so
+ * MUI/Emotion runtime `<style>` injections carry the matching `nonce`
+ * attribute and pass the response CSP `style-src 'self' 'nonce-<value>'`
+ * directive.
+ *
+ * Dev-mode fallback
+ * -----------------
+ *
+ * In `npm run dev` (Vite dev server) the placeholder `__CSP_NONCE__` is
+ * NOT replaced (only the CDK + S3-upload pipeline performs that
+ * substitution). The literal token would be invalid as a CSP nonce
+ * source, so this helper detects the un-replaced placeholder and
+ * returns `undefined` — Emotion then falls back to emitting un-nonced
+ * `<style>` tags. The Vite dev server does not set a production CSP
+ * header, so the inline styles are not blocked.
+ *
+ * This module is intentionally side-effect-free (no `document` access at
+ * import time) so it is safe to use in SSR-style environments and in the
+ * Vitest jsdom test runner (which lacks the meta tag entirely).
+ */
+
+/**
+ * Sentinel that the CDK custom resource (and the CI rebuild composite
+ * action) replaces with the per-deploy nonce. Kept in lockstep with
+ * `frontend/index.html`, `backend/functions/security/cspNonceCustomResource.ts`,
+ * and `.github/actions/rebuild-frontend/action.yml`.
+ */
+const NONCE_PLACEHOLDER = '__CSP_NONCE__';
+
+/**
+ * Returns the runtime CSP nonce, or `undefined` if the page is being
+ * served in a mode that does not stamp the value (dev server, vitest
+ * jsdom, or a misconfigured deploy where the placeholder was left
+ * literal — the latter is reported via the #201 CSP violation endpoint
+ * because MUI styles would silently fail).
+ */
+export function getCspNonceFromMeta(): string | undefined {
+  if (typeof document === 'undefined') {
+    // SSR / pre-hydration / vitest jsdom-less mode. Nothing to read.
+    return undefined;
+  }
+  const meta = document.querySelector('meta[name="csp-nonce"]');
+  if (!meta) {
+    return undefined;
+  }
+  const value = meta.getAttribute('content');
+  if (!value) {
+    return undefined;
+  }
+  // Dev-mode guard: if the placeholder was not substituted, treat it as
+  // "no nonce available" so Emotion does not stamp the literal token
+  // onto every <style> tag (which would still fail CSP and add noise to
+  // every page load). The placeholder is a sentinel; the CSP nonce
+  // generator emits a 32-char base64url string with no underscores at
+  // the boundaries, so the equality check is a tight match.
+  if (value === NONCE_PLACEHOLDER) {
+    return undefined;
+  }
+  return value;
+}


### PR DESCRIPTION
## Summary

Closes #254. Removes `'unsafe-inline'` from CSP `style-src` and replaces it with a per-deploy random nonce, closing the inline-style injection class that previously needed `'unsafe-inline'` to let MUI/Emotion's runtime CSS-in-JS render.

## Architecture

The original #254 design (Lambda@Edge `viewer-response` body rewrite) was **pivoted on 2026-05-14** because Lambda@Edge response triggers do NOT expose the upstream response body — see the [pivot comment](https://github.com/leixiaoyu/lfmt-poc/issues/254#issuecomment-4456187177) for the AWS doc citations. This PR implements the **build-time-stamped + CDK custom resource** active design:

1. **Build time**: `frontend/index.html` ships a literal `<meta name="csp-nonce" content="__CSP_NONCE__">` placeholder. Vite leaves the token verbatim through `npm run build` — verified locally with `grep -c "__CSP_NONCE__" dist/index.html` returning 2 (the meta tag + an HTML comment).
2. **Deploy time (CDK)**: a Provider-Lambda custom resource (`backend/functions/security/cspNonceCustomResource.ts`, wired up in `lfmt-infrastructure-stack.ts#createCspNonceCustomResource`) generates a fresh `randomBytes(24).toString('base64url')` nonce on every `cdk deploy`. It reads `index.html` from the frontend S3 bucket, replaces the placeholder, re-uploads, and exposes the nonce via the `CspStyleSrcNonce` CFN output. The nonce token is threaded into the response-headers policy CSP as `style-src 'self' 'nonce-${customResource.getAttString('Nonce')}'`.
3. **Deploy time (CI)**: the `.github/actions/rebuild-frontend` composite action (used by BOTH `deploy-backend.yml` AND `deploy-frontend.yml`) reads `CspStyleSrcNonce` from CFN outputs and stamps the same value into `dist/index.html` BEFORE the S3 upload — this closes the deploy-ordering loop when a frontend re-upload follows a backend deploy. Without this CI-side stamp, `rebuild-frontend` would push a fresh `dist/index.html` (with placeholder) on top of the CDK-stamped value, breaking every MUI style at the edge until the next backend deploy.
4. **Runtime**: `frontend/src/main.tsx` wraps `<App>` in an Emotion `<CacheProvider>` created with `createCache({ key: 'css', nonce: getCspNonceFromMeta() })`. The helper (`frontend/src/utils/cspNonce.ts`) reads the meta tag content; in dev mode (un-substituted placeholder) it returns `undefined` so Emotion falls back to no-nonce emission. Vite's dev server does not set the production CSP header, so dev-mode styling continues to work.

## Trade-off (static-per-deploy, NOT per-response)

The nonce is static for one deploy lifetime. An attacker who reads the served `index.html` learns the nonce until the next frontend deploy rotates it. We accept this because:

- The #201 CSP violation-report endpoint (live since PR #257) alarms on any regression that introduces inline styles without nonces — the primary goal (eliminate `'unsafe-inline'`) is achievable and observable.
- Per-response nonces would require Lambda@Edge body-rewriting which the response trigger does not support (AWS doc citations on the #254 pivot comment).
- The localStorage auth-token surface (#255) is still readable, so per-response nonce freshness on `style-src` is comparatively low marginal value while that exposure exists.

## Deploy-workflow ordering assumption + failure mode

**Assumption**: the `rebuild-frontend` composite action ALWAYS performs the CSP nonce substitution at upload time, regardless of which workflow triggered it. This is the load-bearing contract that keeps the served `index.html` coherent with the CSP header. The CDK custom resource's in-place S3 rewrite is belt-and-braces — it keeps S3 coherent with the CSP even if no subsequent CI upload runs.

**Failure mode if the CI substitution is removed**: a backend deploy would stamp nonce-N into both the CSP header AND S3's `index.html`. The subsequent `rebuild-frontend` step in `deploy-backend.yml` would build a fresh `dist/index.html` with `__CSP_NONCE__` placeholder and upload it, overwriting the CDK-stamped value. The served `index.html` would carry the literal placeholder while the CSP header carries nonce-N → MUI styles disappear, CSP reports flood the #201 endpoint, alarms fire. Troubleshooting steps are documented in `docs/CLOUDFRONT-SETUP.md` under "Operational note: deploy-time CSP nonce".

**First-deploy edge case**: on the first-ever stack deploy, the frontend bucket exists but is empty before the CI rebuild runs. The custom resource detects the missing object (`NoSuchKey` from S3 GetObject) and returns successfully; CI rebuild then uploads `dist/index.html` and performs the substitution itself. Both paths converge cleanly.

**No CI workflow ordering changes needed**: the existing concurrency group `deploy-${ref}` serializes deploy-backend.yml and deploy-frontend.yml per ref. Both workflows use the shared composite action, so the nonce is consistently stamped on every upload path.

## Dev-mode fallback story

In `npm run dev` (Vite dev server) the placeholder is not substituted. `getCspNonceFromMeta()` returns `undefined` (detected via equality check against `'__CSP_NONCE__'`), and Emotion's `createCache({ nonce: undefined })` emits `<style>` tags without a `nonce=` attribute. The Vite dev server does not set the production CSP header, so the inline styles are not blocked — confirmed by unit test `cspNonce.test.ts`.

## Phase 1 reuse note

The csp.ts default-directive change + the new `style-src does not contain 'unsafe-inline' (#254)` regression test were sourced from the local tag `stash/254-phase1-work-blocked` (commit `8410f9a`) and re-applied. **The boy-scout `backend/infrastructure/.eslintrc.cjs` from that stash was deliberately NOT carried forward** — PR #263 already shipped one on `main`, so cherry-picking it would have created a merge conflict.

## Files changed

| Path | Change |
| --- | --- |
| `frontend/index.html` | Added `<meta name="csp-nonce" content="__CSP_NONCE__">` |
| `frontend/src/main.tsx` | Wrapped App in Emotion `CacheProvider` with nonce |
| `frontend/src/utils/cspNonce.ts` | NEW — runtime nonce accessor + dev-mode guard |
| `frontend/src/utils/__tests__/cspNonce.test.ts` | NEW — 4 tests |
| `frontend/package.json` / `package-lock.json` | `@emotion/cache` dependency |
| `backend/functions/security/cspNonceCustomResource.ts` | NEW — custom-resource handler |
| `backend/functions/security/cspNonceCustomResource.test.ts` | NEW — 7 unit tests |
| `backend/infrastructure/lib/csp.ts` | Removed `'unsafe-inline'` from style-src default |
| `backend/infrastructure/lib/lfmt-infrastructure-stack.ts` | Custom resource construct, both `buildCsp()` callers, IAM scoping, CFN output |
| `backend/infrastructure/lib/__tests__/infrastructure.test.ts` | New regression test, lambda-count bump, updated default-emission assertion |
| `.github/actions/rebuild-frontend/action.yml` | Read `CspStyleSrcNonce` output + sed-substitute `dist/index.html` |
| `.github/workflows/deploy-frontend.yml` | Extended CSP validation: assert `'unsafe-inline'` absent + `nonce-` present |
| `docs/CLOUDFRONT-SETUP.md` | Operational note + troubleshooting runbook |

## Items deliberately NOT in scope

- **Per-response nonces** — future hardening only viable if the SPA topology changes (e.g. SSR/Lambda response). Captured in the issue body's "Per-response variant" section.
- **httpOnly cookies for auth tokens** — tracked separately on #255.
- **CSP `report-to` upgrade** — #201 already covers `report-uri`; both can coexist if a future contributor adds the modern variant.
- **CSP nonce-source on `script-src`** — `dist/index.html` has no inline `<script>` blocks (verified during PR #194), so `script-src 'self'` is already sufficient.

## Test counts (before -> after)

| Package | Before | After | Delta |
| --- | --- | --- | --- |
| backend/infrastructure | 90 | 91 | +1 (style-src regression) |
| backend/functions | 619 | 626 | +7 (cspNonceCustomResource unit tests) |
| frontend | 798 | 802 | +4 (cspNonce helper tests) |
| shared-types | 24 | 24 | unchanged |

Local validation: `npm run build && npm test` in all four packages all green. `cdk synth --context environment=dev --context skipLambdaBundling=true` produces the expected `style-src 'self' 'nonce-<Fn::GetAtt[CspStyleSrcNonceResource.Nonce]>'` interpolation in BOTH the initial and updated response-headers policies.

## Test plan

- [x] `cd backend/infrastructure && npm test` — 91/91 green (was 90)
- [x] `cd backend/functions && npm test` — 626/626 green (was 619)
- [x] `cd frontend && npm run type-check && npm run build && npm test -- --run` — type-check + build clean, 802/802 green
- [x] `cd shared-types && npm test` — 24/24 green
- [x] `cd backend/infrastructure && npx cdk synth --context environment=dev --context skipLambdaBundling=true` — clean synth, `style-src` shows Fn::Join with `'nonce-` + Fn::GetAtt token
- [x] Verify `grep -c "__CSP_NONCE__" frontend/dist/index.html` returns 2 (preserved by Vite)
- [x] `actionlint .github/workflows/*.yml` — no new errors/warnings from this PR
- [x] Lint passes: `cd frontend && npm run lint`; `cd backend/functions && npm run lint`; `cd backend/infrastructure && npm run lint`
- [ ] CI on the PR branch — see status check below