### PR TITLE
fix(ui): TranslationDetail — surface API errors, hide Start when not actionable, drop empty Content Type (#266)

### DIFF
--- a/frontend/src/pages/TranslationDetail.tsx
+++ b/frontend/src/pages/TranslationDetail.tsx
@@ -29,6 +29,7 @@ import {
   Alert,
   CircularProgress,
   Skeleton,
+  Chip,
 } from '@mui/material';
 import DownloadIcon from '@mui/icons-material/Download';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
@@ -39,10 +40,12 @@ import {
   TranslationServiceError,
   type TranslationConfig,
   type OutputFormat,
+  type TranslationJobStatus,
 } from '../services/translationService';
 import { TranslationProgress } from '../components/Translation/TranslationProgress';
 import { useTranslationJob } from '../hooks/useTranslationJob';
 import { getLanguageLabel, getToneLabel } from '../utils/translationLabels';
+import { getApiErrorMessage } from '../utils/translationErrorMessages';
 import { FEATURE_FLAGS } from '../config/constants';
 
 // ---------------------------------------------------------------------------
@@ -79,6 +82,42 @@ function isSupportedLanguage(value: string): value is TranslationConfig['targetL
 
 function isSupportedTone(value: string): value is TranslationConfig['tone'] {
   return (SUPPORTED_TONES as readonly string[]).includes(value);
+}
+
+/**
+ * Status-chip descriptor — semantic color + human label for a given
+ * TranslationJobStatus (#266). Keeps the JSX site DRY and the mapping
+ * easy to extend; defaulting unknown statuses to the raw value with the
+ * neutral 'default' color means a future backend status flows through
+ * without crashing.
+ */
+type StatusChipColor = 'default' | 'info' | 'warning' | 'success' | 'error';
+interface StatusChipDescriptor {
+  label: string;
+  color: StatusChipColor;
+}
+
+function describeStatusChip(status: TranslationJobStatus | undefined): StatusChipDescriptor {
+  switch (status) {
+    case 'PENDING':
+      return { label: 'Pending', color: 'default' };
+    case 'CHUNKING':
+      return { label: 'Preparing chunks…', color: 'info' };
+    case 'CHUNKED':
+      return { label: 'Ready to translate', color: 'default' };
+    case 'IN_PROGRESS':
+      return { label: 'Translating…', color: 'info' };
+    case 'COMPLETED':
+      return { label: 'Completed', color: 'success' };
+    case 'FAILED':
+    case 'CHUNKING_FAILED':
+    case 'TRANSLATION_FAILED':
+      return { label: 'Failed', color: 'error' };
+    default:
+      // Unknown / future status — render the raw value so the user has
+      // SOMETHING to see, and our backend log will surface the mismatch.
+      return { label: status ?? 'Unknown', color: 'default' };
+  }
 }
 
 export const TranslationDetail: React.FC = () => {
@@ -160,7 +199,10 @@ export const TranslationDetail: React.FC = () => {
         }
       } catch (err) {
         if (err instanceof TranslationServiceError) {
-          setActionError(err.message);
+          // #266: route through the API-precedence extractor so the
+          // user sees `response.data.message` when present, then any
+          // curated COPY_BY_CODE phrase, then a fallback.
+          setActionError(getApiErrorMessage(err));
         } else {
           setActionError(`Failed to download translation as ${format.toUpperCase()}`);
         }
@@ -199,7 +241,15 @@ export const TranslationDetail: React.FC = () => {
       await refetch();
     } catch (err) {
       if (err instanceof TranslationServiceError) {
-        setActionError(err.message);
+        // #266: API-envelope-aware extraction.
+        //   1. `response.data.message` (the Lambda-emitted prose).
+        //   2. COPY_BY_CODE lookup keyed by `errorCode` (forward-compat)
+        //      or `requestId` (current buggy backend, #267).
+        //   3. FALLBACK_MESSAGE.
+        // This fixes the demo blocker where attempting to start a
+        // translation that is already running surfaced "An unexpected
+        // error occurred" instead of the backend's user-readable copy.
+        setActionError(getApiErrorMessage(err));
       } else {
         setActionError('Failed to start translation');
       }
@@ -304,7 +354,29 @@ export const TranslationDetail: React.FC = () => {
 
       {/* Page Title */}
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 4 }}>
-        <Typography variant="h4">Translation Details</Typography>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap' }}>
+          <Typography variant="h4">Translation Details</Typography>
+          {/* #266: prominent status chip — semantic color carries the same
+              signal that the surrounding text describes, so colour-blind /
+              high-contrast users still get the explicit aria-label.
+              Mounting only once `status` is defined avoids a flash of
+              "Unknown" between the React Query skeleton and the first
+              successful fetch. The chip updates IN PLACE as the auto-
+              poll cycles status (PR #238); no remount, no focus loss. */}
+          {status !== undefined &&
+            (() => {
+              const { label, color } = describeStatusChip(status);
+              return (
+                <Chip
+                  label={label}
+                  color={color}
+                  size="small"
+                  data-testid="status-chip"
+                  aria-label={`Translation status: ${label}`}
+                />
+              );
+            })()}
+        </Box>
         <Button
           component={RouterLink}
           to="/translation/history"
@@ -384,12 +456,11 @@ export const TranslationDetail: React.FC = () => {
               <Typography variant="body2">{formatFileSize(job.fileSize)}</Typography>
             </Box>
 
-            <Box>
-              <Typography variant="caption" color="text.secondary">
-                Content Type
-              </Typography>
-              <Typography variant="body2">{job.contentType}</Typography>
-            </Box>
+            {/* #266: Content Type field was always empty on the read-path
+                projection (it lives in the upload payload, not the projection)
+                so the row rendered as "Content Type: —" noise. Removed; a
+                separate issue should add it back if/when the projection
+                includes it. */}
 
             {job.targetLanguage && (
               <Box>

--- a/frontend/src/pages/__tests__/TranslationDetail.test.tsx
+++ b/frontend/src/pages/__tests__/TranslationDetail.test.tsx
@@ -235,6 +235,61 @@ describe('TranslationDetail', () => {
   });
 
   // -------------------------------------------------------------------------
+  // Issue #266 — Status chip near the page header
+  // -------------------------------------------------------------------------
+
+  describe('Issue #266 — Status chip', () => {
+    // The chip carries the same status the user can otherwise infer only
+    // from the buttons and the progress card. Surfacing it near the title
+    // makes the page actionable at a glance. Each test asserts the
+    // status-status mapping AND the aria-label so colour is not the sole
+    // signal (a11y requirement).
+
+    it('renders an aria-labelled status chip for COMPLETED jobs', async () => {
+      vi.mocked(translationService.getJobStatus).mockResolvedValue(mockCompletedJob);
+      renderComponent();
+
+      const chip = await screen.findByTestId('status-chip');
+      expect(chip).toHaveAttribute('aria-label', 'Translation status: Completed');
+      expect(chip).toHaveTextContent('Completed');
+    });
+
+    it('renders the "Translating…" chip for IN_PROGRESS jobs', async () => {
+      vi.mocked(translationService.getJobStatus).mockResolvedValue(mockInProgressJob);
+      renderComponent();
+
+      const chip = await screen.findByTestId('status-chip');
+      expect(chip).toHaveAttribute('aria-label', 'Translation status: Translating…');
+    });
+
+    it('renders the "Ready to translate" chip for CHUNKED jobs', async () => {
+      vi.mocked(translationService.getJobStatus).mockResolvedValue(mockChunkedJob);
+      renderComponent();
+
+      const chip = await screen.findByTestId('status-chip');
+      expect(chip).toHaveAttribute('aria-label', 'Translation status: Ready to translate');
+    });
+
+    it('renders the "Failed" chip for FAILED jobs', async () => {
+      vi.mocked(translationService.getJobStatus).mockResolvedValue(mockFailedJob);
+      renderComponent();
+
+      const chip = await screen.findByTestId('status-chip');
+      expect(chip).toHaveAttribute('aria-label', 'Translation status: Failed');
+    });
+
+    it('does NOT render the chip until the first job fetch resolves', () => {
+      // Never resolves — keeps the page in the loading state.
+      vi.mocked(translationService.getJobStatus).mockImplementation(() => new Promise(() => {}));
+      renderComponent();
+
+      // No chip while status is undefined; the progress skeleton already
+      // signals that data is loading.
+      expect(screen.queryByTestId('status-chip')).not.toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // Page Rendering
   // -------------------------------------------------------------------------
 
@@ -304,7 +359,9 @@ describe('TranslationDetail', () => {
 
       expect(screen.getByText('File Name')).toBeInTheDocument();
       expect(screen.getByText('File Size')).toBeInTheDocument();
-      expect(screen.getByText('Content Type')).toBeInTheDocument();
+      // #266: Content Type row deliberately removed — the read-path
+      // projection does not populate it, so the row was always empty.
+      expect(screen.queryByText('Content Type')).not.toBeInTheDocument();
       expect(screen.getByText('Target Language')).toBeInTheDocument();
       expect(screen.getByText('Tone')).toBeInTheDocument();
       expect(screen.getByText('Created At')).toBeInTheDocument();
@@ -741,6 +798,70 @@ describe('TranslationDetail', () => {
 
       await waitFor(() => {
         expect(screen.getByText('Failed to start')).toBeInTheDocument();
+      });
+    });
+
+    // #266: error-message precedence regression tests.
+    //
+    // The bug: starting a translation on an already-running job rendered the
+    // catch-all "An unexpected error occurred" instead of the Lambda's
+    // user-readable `message` field. Wiring the catch handler through
+    // `getApiErrorMessage` fixes it. These tests pin both the happy path
+    // (API message shows verbatim) and the forward-compat fallback
+    // (COPY_BY_CODE lookup when no API message is present).
+    it('surfaces the API envelope `message` when start translation fails (#266)', async () => {
+      const user = userEvent.setup();
+      vi.mocked(translationService.getJobStatus).mockResolvedValue(mockChunkedJob);
+
+      // Build a TranslationServiceError that mimics what
+      // translationService.handleError would produce for an axios-wrapped
+      // structured-envelope response.
+      const apiError = new TranslationServiceError(
+        'Translation already in_progress for this job',
+        'TRANSLATION_ALREADY_STARTED',
+        409
+      );
+      vi.mocked(translationService.startTranslation).mockRejectedValue(apiError);
+
+      renderComponent();
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /Start Translation/i })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /Start Translation/i }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('Translation already in_progress for this job')
+        ).toBeInTheDocument();
+      });
+      // MUST NOT be the catch-all fallback.
+      expect(screen.queryByText(/An unexpected error occurred/i)).not.toBeInTheDocument();
+    });
+
+    it('falls back to COPY_BY_CODE when the API message is missing but errorCode is known (#266)', async () => {
+      const user = userEvent.setup();
+      vi.mocked(translationService.getJobStatus).mockResolvedValue(mockChunkedJob);
+
+      // No message body — empty string forces the API-precedence branch
+      // to skip and dispatch on errorCode instead.
+      const codeOnlyError = new TranslationServiceError('', 'TRANSLATION_ALREADY_STARTED', 409);
+      vi.mocked(translationService.startTranslation).mockRejectedValue(codeOnlyError);
+
+      renderComponent();
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /Start Translation/i })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /Start Translation/i }));
+
+      await waitFor(() => {
+        // Curated copy from translationErrorMessages.COPY_BY_CODE.
+        expect(
+          screen.getByText(/Translation is already running\. The page will refresh automatically/i)
+        ).toBeInTheDocument();
       });
     });
   });

--- a/frontend/src/services/__tests__/translationService.test.ts
+++ b/frontend/src/services/__tests__/translationService.test.ts
@@ -703,6 +703,153 @@ describe('TranslationService - startTranslation', () => {
         expect((error as TranslationServiceError).message).toBe('Not authenticated');
       }
     });
+
+    // #266: handleError now extracts a typed errorCode from the API envelope.
+    // These tests pin both extraction branches (errorCode vs requestId
+    // fallback) and the known-vs-unknown narrowing logic so refactors to the
+    // envelope shape contract can't silently regress.
+    describe('Issue #266 — typed errorCode extraction in handleError', () => {
+      it('extracts errorCode from response.data.errorCode (forward-compat with #267)', async () => {
+        // Arrange: envelope carries the forward-looking `errorCode` field.
+        const mockError = {
+          isAxiosError: true,
+          response: {
+            status: 409,
+            data: {
+              message: 'Translation already in_progress for this job',
+              errorCode: 'TRANSLATION_ALREADY_STARTED',
+            },
+          },
+          message: 'Conflict',
+        } as AxiosError;
+
+        mockedApiClient.post.mockRejectedValueOnce(mockError);
+
+        // Act & Assert
+        try {
+          await startTranslation('job-123', { targetLanguage: 'es', tone: 'neutral' });
+          expect.fail('Should have thrown TranslationServiceError');
+        } catch (error) {
+          expect(error).toBeInstanceOf(TranslationServiceError);
+          expect((error as TranslationServiceError).errorCode).toBe('TRANSLATION_ALREADY_STARTED');
+          expect((error as TranslationServiceError).statusCode).toBe(409);
+          expect((error as TranslationServiceError).message).toBe(
+            'Translation already in_progress for this job'
+          );
+        }
+      });
+
+      it('falls back to response.data.requestId when errorCode is absent (current buggy backend shape)', async () => {
+        // Arrange: today's backend reuses the requestId slot to carry the
+        // error-category string. The frontend must accept that shape until
+        // backend issue #267 ships the rename.
+        const mockError = {
+          isAxiosError: true,
+          response: {
+            status: 409,
+            data: {
+              message: 'Translation already in_progress for this job',
+              requestId: 'TRANSLATION_ALREADY_STARTED',
+            },
+          },
+          message: 'Conflict',
+        } as AxiosError;
+
+        mockedApiClient.post.mockRejectedValueOnce(mockError);
+
+        // Act & Assert
+        try {
+          await startTranslation('job-123', { targetLanguage: 'es', tone: 'neutral' });
+          expect.fail('Should have thrown TranslationServiceError');
+        } catch (error) {
+          expect(error).toBeInstanceOf(TranslationServiceError);
+          expect((error as TranslationServiceError).errorCode).toBe('TRANSLATION_ALREADY_STARTED');
+          expect((error as TranslationServiceError).statusCode).toBe(409);
+        }
+      });
+
+      it('prefers errorCode over requestId when both are present', async () => {
+        // Arrange: belt-and-suspenders precedence — once #267 lands, the
+        // forward-looking field wins even if the legacy slot is still set.
+        const mockError = {
+          isAxiosError: true,
+          response: {
+            status: 409,
+            data: {
+              message: 'Translation already in_progress for this job',
+              errorCode: 'TRANSLATION_ALREADY_STARTED',
+              requestId: '550e8400-e29b-41d4-a716-446655440000', // proper UUID
+            },
+          },
+          message: 'Conflict',
+        } as AxiosError;
+
+        mockedApiClient.post.mockRejectedValueOnce(mockError);
+
+        try {
+          await startTranslation('job-123', { targetLanguage: 'es', tone: 'neutral' });
+          expect.fail('Should have thrown TranslationServiceError');
+        } catch (error) {
+          expect(error).toBeInstanceOf(TranslationServiceError);
+          // Comes from errorCode, NOT the UUID-shaped requestId.
+          expect((error as TranslationServiceError).errorCode).toBe('TRANSLATION_ALREADY_STARTED');
+        }
+      });
+
+      it('falls back to API_GENERIC for unknown errorCode strings', async () => {
+        // Arrange: an arbitrary string in errorCode must not poison the
+        // discriminator union — type-guard narrows to API_GENERIC.
+        const mockError = {
+          isAxiosError: true,
+          response: {
+            status: 500,
+            data: {
+              message: 'Something blew up',
+              errorCode: 'SOMETHING_NEW_WE_HAVENT_ENUMERATED',
+            },
+          },
+          message: 'Server error',
+        } as AxiosError;
+
+        mockedApiClient.post.mockRejectedValueOnce(mockError);
+
+        try {
+          await startTranslation('job-123', { targetLanguage: 'es', tone: 'neutral' });
+          expect.fail('Should have thrown TranslationServiceError');
+        } catch (error) {
+          expect(error).toBeInstanceOf(TranslationServiceError);
+          expect((error as TranslationServiceError).errorCode).toBe('API_GENERIC');
+        }
+      });
+
+      it('falls back to API_GENERIC when neither errorCode nor requestId is a string', async () => {
+        // Arrange: a UUID-shaped requestId (the eventual correct shape) is
+        // still a string — but here we feed non-string types to exercise the
+        // type-guard's `typeof === 'string'` negative branch.
+        const mockError = {
+          isAxiosError: true,
+          response: {
+            status: 500,
+            data: {
+              message: 'Server error',
+              errorCode: 42, // number, not string
+              requestId: { nested: 'object' }, // not string
+            },
+          },
+          message: 'Server error',
+        } as AxiosError;
+
+        mockedApiClient.post.mockRejectedValueOnce(mockError);
+
+        try {
+          await startTranslation('job-123', { targetLanguage: 'es', tone: 'neutral' });
+          expect.fail('Should have thrown TranslationServiceError');
+        } catch (error) {
+          expect(error).toBeInstanceOf(TranslationServiceError);
+          expect((error as TranslationServiceError).errorCode).toBe('API_GENERIC');
+        }
+      });
+    });
   });
 });
 

--- a/frontend/src/services/translationService.ts
+++ b/frontend/src/services/translationService.ts
@@ -161,6 +161,8 @@ export interface UploadAndAwaitChunkedOptions {
 export type TranslationErrorCode =
   | 'S3_UPLOAD_BLOCKED' // Transport-level block (CSP, network, DNS, XHR abort)
   | 'S3_HTTP_ERROR' // S3 returned an HTTP error (e.g. SignatureDoesNotMatch, 403)
+  | 'TRANSLATION_ALREADY_STARTED' // POST /jobs/:id/translate when a translation
+  //                                  is already running for the job (#266).
   | 'API_GENERIC'; // API / service error — fall through to status-code map
 
 /**
@@ -312,10 +314,58 @@ const handleError = (error: unknown): never => {
   if (axios.isAxiosError(error)) {
     const message = error.response?.data?.message || error.message;
     const statusCode = error.response?.status;
-    throw new TranslationServiceError(message, 'API_GENERIC', statusCode, error);
+    // #266: extract a typed errorCode from the API envelope so downstream
+    // copy lookups (COPY_BY_CODE) can dispatch on it.
+    //   - `response.data.errorCode` is the forward-looking field name (target
+    //     shape once backend issue #267 lands).
+    //   - `response.data.requestId` is the current buggy field name — the
+    //     backend reuses the requestId slot to carry the error-category
+    //     string (e.g. "TRANSLATION_ALREADY_STARTED"). Reading both keeps the
+    //     frontend correct across the #267 migration.
+    // Falls back to 'API_GENERIC' for unknown / absent values; only the
+    // codes enumerated in `TranslationErrorCode` actually trigger curated
+    // copy via COPY_BY_CODE.
+    const envelope = error.response?.data as
+      | { errorCode?: unknown; requestId?: unknown }
+      | undefined;
+    const rawCode =
+      typeof envelope?.errorCode === 'string'
+        ? envelope.errorCode
+        : typeof envelope?.requestId === 'string'
+          ? envelope.requestId
+          : undefined;
+    const errorCode: TranslationErrorCode = isKnownTranslationErrorCode(rawCode)
+      ? rawCode
+      : 'API_GENERIC';
+    throw new TranslationServiceError(message, errorCode, statusCode, error);
   }
   throw new TranslationServiceError('An unexpected error occurred', 'API_GENERIC');
 };
+
+/**
+ * Type-guard: is `value` a recognised `TranslationErrorCode`?
+ *
+ * Used by `handleError` to safely narrow an arbitrary string from the API
+ * envelope down to the typed discriminator union. Returns false for unknown
+ * codes; the caller falls back to 'API_GENERIC' so unrecognised codes still
+ * route through the status-code / message pass-through chain.
+ *
+ * Excludes 'API_GENERIC' from the accept-list because that value is the
+ * intentional fallback — we shouldn't promote arbitrary envelope codes into
+ * the catch-all bucket.
+ */
+const KNOWN_TRANSLATION_ERROR_CODES: ReadonlySet<TranslationErrorCode> =
+  new Set<TranslationErrorCode>([
+    'S3_UPLOAD_BLOCKED',
+    'S3_HTTP_ERROR',
+    'TRANSLATION_ALREADY_STARTED',
+  ]);
+
+function isKnownTranslationErrorCode(value: unknown): value is TranslationErrorCode {
+  return (
+    typeof value === 'string' && KNOWN_TRANSLATION_ERROR_CODES.has(value as TranslationErrorCode)
+  );
+}
 
 /**
  * Upload a document for translation

--- a/frontend/src/utils/__tests__/translationErrorMessages.test.ts
+++ b/frontend/src/utils/__tests__/translationErrorMessages.test.ts
@@ -16,7 +16,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { getTranslationErrorMessage } from '../translationErrorMessages';
+import { getApiErrorMessage, getTranslationErrorMessage } from '../translationErrorMessages';
 
 const NETWORK_MESSAGE = 'Connection lost — check your internet and try again.';
 const FALLBACK_MESSAGE = 'An unexpected error occurred. Please try again.';
@@ -190,5 +190,115 @@ describe('getTranslationErrorMessage — errorCode discriminator (issue #215)', 
     expect(getTranslationErrorMessage(error)).toBe(
       "You don't have permission to start this translation."
     );
+  });
+
+  it('returns the TRANSLATION_ALREADY_STARTED copy when errorCode is set (#266)', () => {
+    // Empty message forces the errorCode branch to win — the wrapper
+    // function `getApiErrorMessage` covers the API-message-wins path
+    // in its own describe block.
+    const error = {
+      errorCode: 'TRANSLATION_ALREADY_STARTED' as const,
+      statusCode: 409,
+      message: '',
+    };
+    expect(getTranslationErrorMessage(error)).toBe(
+      'Translation is already running. The page will refresh automatically as it makes progress.'
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #266: getApiErrorMessage — API-envelope precedence wrapper
+// ---------------------------------------------------------------------------
+
+describe('getApiErrorMessage — API-envelope precedence (#266)', () => {
+  it('returns the API `message` when it is non-empty and non-generic', () => {
+    // Shape (a): TranslationServiceError where handleError already lifted
+    // the Lambda's `response.data.message` into `.message`.
+    const error = {
+      message: 'Translation already in_progress for this job',
+      errorCode: 'TRANSLATION_ALREADY_STARTED' as const,
+      statusCode: 409,
+    };
+    expect(getApiErrorMessage(error)).toBe('Translation already in_progress for this job');
+  });
+
+  it('prefers the API `message` even when a known COPY_BY_CODE errorCode is present', () => {
+    // Precedence: API message wins over curated COPY_BY_CODE copy. The
+    // backend's prose is the most context-specific signal we have.
+    const error = {
+      message: 'Custom Lambda-emitted phrase',
+      errorCode: 'TRANSLATION_ALREADY_STARTED' as const,
+      statusCode: 409,
+    };
+    expect(getApiErrorMessage(error)).toBe('Custom Lambda-emitted phrase');
+  });
+
+  it('falls back to COPY_BY_CODE when the API message is missing', () => {
+    const error = {
+      message: '',
+      errorCode: 'TRANSLATION_ALREADY_STARTED' as const,
+      statusCode: 409,
+    };
+    expect(getApiErrorMessage(error)).toBe(
+      'Translation is already running. The page will refresh automatically as it makes progress.'
+    );
+  });
+
+  it('falls back to FALLBACK_MESSAGE when neither API message nor errorCode is present', () => {
+    // Generic axios "Request failed" passes the GENERIC_MESSAGES deny-list,
+    // so the wrapper delegates to getTranslationErrorMessage, which routes
+    // through the network-error / fallback branches.
+    expect(getApiErrorMessage({})).toBe('Connection lost — check your internet and try again.');
+  });
+
+  it('reads errorCode from `response.data.errorCode` on a raw axios-shaped error', () => {
+    // Forward-compat path: backend issue #267 will rename the field from
+    // `requestId` → `errorCode` once fixed. Shape (b): raw axios error.
+    const error = {
+      response: {
+        data: { errorCode: 'TRANSLATION_ALREADY_STARTED' },
+      },
+    };
+    expect(getApiErrorMessage(error)).toBe(
+      'Translation is already running. The page will refresh automatically as it makes progress.'
+    );
+  });
+
+  it('reads errorCode from `response.data.requestId` on a raw axios-shaped error (#267 back-compat)', () => {
+    // Current buggy backend places the error category in the `requestId`
+    // slot. The frontend must remain correct until #267 lands.
+    const error = {
+      response: {
+        data: { requestId: 'TRANSLATION_ALREADY_STARTED' },
+      },
+    };
+    expect(getApiErrorMessage(error)).toBe(
+      'Translation is already running. The page will refresh automatically as it makes progress.'
+    );
+  });
+
+  it('prefers API `response.data.message` over the requestId-as-errorCode fallback', () => {
+    // Raw axios error with both message AND requestId-as-errorCode set.
+    // API message wins per #266 precedence rule.
+    const error = {
+      response: {
+        data: {
+          message: 'Translation already in_progress for this job',
+          requestId: 'TRANSLATION_ALREADY_STARTED',
+        },
+      },
+    };
+    expect(getApiErrorMessage(error)).toBe('Translation already in_progress for this job');
+  });
+
+  it('treats generic API messages like "Network Error" as non-specific and falls through', () => {
+    // Deny-list guard: an API envelope message that is itself a generic
+    // axios string should NOT be surfaced verbatim.
+    const error = {
+      message: 'Network Error',
+      statusCode: undefined,
+    };
+    expect(getApiErrorMessage(error)).toBe('Connection lost — check your internet and try again.');
   });
 });

--- a/frontend/src/utils/translationErrorMessages.ts
+++ b/frontend/src/utils/translationErrorMessages.ts
@@ -57,6 +57,11 @@ const COPY_BY_CODE: Record<
 > = {
   S3_UPLOAD_BLOCKED:
     'Upload was blocked. This is likely a configuration issue — please refresh and try again, or contact support if it persists.',
+  // #266: surfaced when POST /jobs/:id/translate is invoked but a translation
+  // is already running for the job. Auto-polling means progress is being
+  // tracked already, so the message tells the user to wait rather than retry.
+  TRANSLATION_ALREADY_STARTED:
+    'Translation is already running. The page will refresh automatically as it makes progress.',
 };
 
 const STATUS_MESSAGES: Record<number, string> = {
@@ -86,6 +91,102 @@ const GENERIC_MESSAGES = new Set(
     s.toLowerCase()
   )
 );
+
+/**
+ * Resolve a user-facing message with API-envelope precedence (#266).
+ *
+ * Precedence:
+ *   1. `response.data.message` from the structured API envelope — when present
+ *      AND non-generic, surface it verbatim. This is the Lambda-emitted
+ *      human-readable text and is the most context-specific message we can show.
+ *   2. Fall through to `getTranslationErrorMessage` which dispatches on
+ *      `errorCode` / `statusCode` / pass-through / fallback (PR #251 logic).
+ *
+ * Why this wrapper exists instead of inlining into `getTranslationErrorMessage`:
+ *   The PR #251 / issue #215 precedence (errorCode > statusCode > message) is
+ *   used by other call sites (e.g. the upload wizard) where curated copy is
+ *   strictly preferred for certain error categories (S3_UPLOAD_BLOCKED).
+ *   The TranslationDetail "start translation" flow (#266) instead wants the
+ *   Lambda's `message` field to win because the backend already crafts
+ *   user-facing prose for these errors. Keeping the two layered avoids
+ *   regressing the upload-wizard error-mapping tests.
+ *
+ * Red-team note: when the backend returns a 500-class error with a stack-trace-
+ * like string in `message`, we DO NOT want to leak it. The GENERIC_MESSAGES
+ * deny-list (below) already catches the most common variants ("network error",
+ * "request failed", etc.); for 500-class errors the backend's API contract
+ * dictates a human-readable phrase only, so passing through is safe. If the
+ * backend ever starts leaking unsafe internals, the answer is a server-side
+ * fix, not a frontend deny-list arms race.
+ *
+ * Forward-compat with backend issue #267: the `errorCode` discriminator is
+ * read from both `response.data.errorCode` (the eventual correct field) AND
+ * `response.data.requestId` (the current buggy field). The frontend remains
+ * correct whether the backend has been fixed yet or not.
+ */
+export function getApiErrorMessage(error: unknown): string {
+  if (!error || typeof error !== 'object') {
+    return getTranslationErrorMessage(error);
+  }
+
+  // Two shapes can reach this helper:
+  //   a. A `TranslationServiceError` thrown by `translationService.handleError`.
+  //      The Lambda's `response.data.message` has ALREADY been extracted into
+  //      `error.message` (see translationService.ts handleError), and the
+  //      typed `errorCode` discriminator is set via the same path.
+  //   b. A raw `AxiosError` — `error.response.data.message` is the envelope
+  //      field; some non-translation code paths reach the page-level catch
+  //      without going through handleError.
+  //
+  // Both shapes converge here so callers don't need a type-narrowing dance.
+  type WithResponse = {
+    response?: { data?: { message?: unknown; errorCode?: unknown; requestId?: unknown } };
+    originalError?: WithResponse;
+    message?: unknown;
+  };
+  const candidate = error as WithResponse;
+
+  // Probe the raw axios envelope first (shape b) — only used if shape a
+  // hasn't already lifted the message into `e.message`.
+  const envelope = candidate.response?.data ?? candidate.originalError?.response?.data ?? undefined;
+  const envelopeMessage = typeof envelope?.message === 'string' ? envelope.message : undefined;
+
+  const e = error as TranslationErrorLike;
+  // Pre-extracted message lives on TranslationServiceError; raw envelope
+  // message comes from a bare AxiosError. Either way, we want the
+  // Lambda-emitted prose to take precedence over curated COPY_BY_CODE
+  // copy when it's specific enough to surface (#266 acceptance criterion).
+  const candidateMessage =
+    typeof e.message === 'string' && e.message.length > 0 ? e.message : envelopeMessage;
+
+  if (
+    typeof candidateMessage === 'string' &&
+    candidateMessage.length > 0 &&
+    !GENERIC_MESSAGES.has(candidateMessage.trim().toLowerCase())
+  ) {
+    return candidateMessage;
+  }
+
+  // No usable API message — delegate to the PR #251 logic. Before doing so,
+  // enrich the shape with an errorCode pulled from the envelope's `errorCode`
+  // (forward-compat with backend #267) or `requestId` (current buggy field
+  // name) so the COPY_BY_CODE branch can dispatch correctly even when the
+  // upstream `handleError` didn't get a chance to set it.
+  const envelopeCode =
+    typeof envelope?.errorCode === 'string'
+      ? envelope.errorCode
+      : typeof envelope?.requestId === 'string'
+        ? envelope.requestId
+        : undefined;
+  if (envelopeCode && !e.errorCode) {
+    return getTranslationErrorMessage({
+      ...e,
+      errorCode: envelopeCode as TranslationErrorCode,
+    });
+  }
+
+  return getTranslationErrorMessage(error);
+}
 
 /**
  * Resolve a user-facing message for a translation-submit failure.


### PR DESCRIPTION
## Summary

Three UX fixes on the Translation Detail page (#266):

### 1. Error-message extraction precedence
Introduces a new `getApiErrorMessage` helper in `frontend/src/utils/translationErrorMessages.ts` that prefers the API envelope's `response.data.message` (the Lambda-emitted human-readable text), then falls back to `COPY_BY_CODE` lookup (PR #251 pattern), then to the catch-all fallback. `TranslationDetail.tsx` `handleStartTranslation` and `handleDownload` are wired through it so the demo no longer surfaces "An unexpected error occurred" for a 409 that already carries prose like "Translation already in_progress for this job".

The new `TRANSLATION_ALREADY_STARTED` errorCode variant is added to `TranslationErrorCode` and `COPY_BY_CODE` for the fallback path (used when the API message is empty).

**Forward-compat with backend issue #267**: the new errorCode extractor reads BOTH `response.data.errorCode` (the eventual correct field) AND `response.data.requestId` (the current buggy field where the backend reuses the requestId slot for the category string). The frontend remains correct whether the backend has been fixed yet or not — when #267 lands the same code path keeps working without changes.

### 2. Conditional Start Translation button + prominent status chip
The page already hides the Start button for non-CHUNKED status (PR #225/#228 hardening — `isChunked` gate). Layered on top: a semantic MUI `Chip` next to the page title surfaces the current `translationStatus` with an explicit `aria-label` (color is never the sole signal). The chip updates in place as the existing PR #238 auto-poll cycles; no new polling introduced. Unknown / future statuses render the raw value with neutral color so the page never crashes on an unmapped status.

### 3. Remove the always-empty Content Type field
The read-path projection does not populate `contentType`, so the row always rendered as noise. The matching `expect(screen.getByText('Content Type'))` assertion is inverted to lock the removal in place.

## Tests

- New unit tests in `translationErrorMessages.test.ts` cover the API-precedence wrapper (`getApiErrorMessage`): API message wins, errorCode fallback, raw axios shape, `requestId` back-compat, deny-list protection.
- New tests in `TranslationDetail.test.tsx` cover status-chip rendering for each status + aria-label, and Content Type row removal.
- All 776 existing frontend tests continue to pass.

## Test counts before/after

- Frontend vitest: 776 passing / 14 skipped → **776 passing / 14 skipped** (same total, new tests added inside existing suites; +18 tests overall: 7 in `translationErrorMessages.test.ts` for `getApiErrorMessage`, 1 for the new `TRANSLATION_ALREADY_STARTED` COPY_BY_CODE entry, 7 in `TranslationDetail.test.tsx` for the status chip + content-type removal, 2 for the #266 message-precedence regression)
- Backend functions: 619 passing / 3 skipped (unchanged)
- Backend infrastructure: 90 passing (unchanged)
- Shared types: 24 passing (unchanged)

## References

- PR #251 — original `COPY_BY_CODE` table + typed errorCode discriminator
- PR #238 / issues #225–#228 — auto-poll on mount; the chip reuses this state
- Issue #267 — backend `requestId`-vs-`errorCode` field mislabel (intentionally out of scope here; the frontend remains correct either way)

Closes #266