### PR TITLE
fix(ui): TranslationDetail page-load error uses getApiErrorMessage (#269)

### DIFF
--- a/frontend/src/pages/TranslationDetail.tsx
+++ b/frontend/src/pages/TranslationDetail.tsx
@@ -300,12 +300,18 @@ export const TranslationDetail: React.FC = () => {
   }, [is403, navigate]);
 
   if (queryError && !job && !isLoading) {
-    let errorMessage = 'Failed to load translation details';
-    if (queryError instanceof Error) {
-      errorMessage = queryError.message;
-    }
+    // #269: route through the API-precedence extractor (same helper used for
+    // action errors above at lines 205 / 252) so the user sees the Lambda's
+    // `response.data.message` field when present, then any curated
+    // COPY_BY_CODE phrase, then a generic fallback. The previous
+    // `queryError.message` extraction surfaced the axios top-level message
+    // ("Request failed with status code 404") instead of the API envelope's
+    // structured user-facing prose ("Job not found").
+    let errorMessage = getApiErrorMessage(queryError);
 
     // Special-case: 403 error message override (navigation handled by useEffect above).
+    // The backend 403 body may leak resource-existence information; hardcode
+    // the user-facing string regardless of what the extractor returned.
     if (is403) {
       errorMessage = 'You do not have permission to view this translation';
     }

--- a/frontend/src/pages/__tests__/TranslationDetail.test.tsx
+++ b/frontend/src/pages/__tests__/TranslationDetail.test.tsx
@@ -920,12 +920,87 @@ describe('TranslationDetail', () => {
 
       await waitFor(
         () => {
-          expect(screen.getByText('Network error')).toBeInTheDocument();
+          // 'Network error' is in GENERIC_MESSAGES, so getApiErrorMessage
+          // falls through to the NETWORK_MESSAGE phrase instead of leaking
+          // the raw axios string. Asserting this pins the precedence chain.
+          expect(
+            screen.getByText(/Connection lost — check your internet and try again/i)
+          ).toBeInTheDocument();
         },
         { timeout: 3000 }
       );
+      // MUST NOT be the catch-all fallback.
+      expect(screen.queryByText(/An unexpected error occurred/i)).not.toBeInTheDocument();
+    });
 
-      expect(screen.getByRole('alert')).toHaveTextContent('Network error');
+    // #269: error-message precedence on the PAGE-LOAD failure branch.
+    //
+    // The bug: navigating to /translation/<invalid-id> rendered the catch-all
+    // "An unexpected error occurred" (via raw `queryError.message`) instead of
+    // the Lambda's structured `response.data.message` field. Wiring the
+    // page-load early-return through `getApiErrorMessage` fixes it.
+    //
+    // These tests pin both the happy path (structured-envelope `message`
+    // shows verbatim) AND the COPY_BY_CODE fallback (curated phrase when
+    // the API message is absent but an errorCode is known) on the
+    // fatal-load branch, mirroring the action-error precedence tests
+    // landed in PR #268.
+    it('surfaces the API envelope `message` on page-load failure (#269)', async () => {
+      // Mimic what translationService.handleError would emit for an axios
+      // call that hit a structured error envelope: the message has already
+      // been lifted from response.data.message into err.message.
+      const apiError = new TranslationServiceError('Job not found', 'API_GENERIC', 404);
+      vi.mocked(translationService.getJobStatus).mockRejectedValue(apiError);
+
+      renderComponent();
+
+      await waitFor(
+        () => {
+          expect(screen.getByText('Job not found')).toBeInTheDocument();
+        },
+        { timeout: 3000 }
+      );
+      // MUST NOT be the catch-all fallback the user reported in #266 / #269.
+      expect(screen.queryByText(/An unexpected error occurred/i)).not.toBeInTheDocument();
+      // The "Go to Translation History" recovery action must still render.
+      expect(screen.getByRole('link', { name: /Go to Translation History/i })).toBeInTheDocument();
+    });
+
+    it('falls back to a curated phrase on page-load 429 with no message (#269)', async () => {
+      // 429 with no message body — getApiErrorMessage's API-precedence branch
+      // is skipped and dispatch falls through to STATUS_MESSAGES[429].
+      const rateLimited = new TranslationServiceError('', 'API_GENERIC', 429);
+      vi.mocked(translationService.getJobStatus).mockRejectedValue(rateLimited);
+
+      renderComponent();
+
+      await waitFor(
+        () => {
+          // Curated phrase from translationErrorMessages.STATUS_MESSAGES[429].
+          expect(screen.getByText(/rate limit reached/i)).toBeInTheDocument();
+        },
+        { timeout: 3000 }
+      );
+      expect(screen.queryByText(/An unexpected error occurred/i)).not.toBeInTheDocument();
+    });
+
+    it('preserves the 403 hardcoded copy on page-load failure (#269 regression guard)', async () => {
+      // The 403 special-case override must continue to suppress whatever
+      // getApiErrorMessage would otherwise return, because backend 403
+      // bodies may leak resource-existence information.
+      vi.mocked(translationService.getJobStatus).mockRejectedValue(
+        new TranslationServiceError('Resource exists but you cannot see it', 'API_GENERIC', 403)
+      );
+
+      renderComponent();
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('You do not have permission to view this translation')
+        ).toBeInTheDocument();
+      });
+      // Backend prose MUST NOT have been surfaced.
+      expect(screen.queryByText(/Resource exists but you cannot see it/i)).not.toBeInTheDocument();
     });
 
     // ----- #236 regression tests -----


### PR DESCRIPTION
## Summary

PR #268 fixed the action-error path on `TranslationDetail.tsx` to route through `getApiErrorMessage`, but the page-load early-return branch (lines 302-322) still extracted `errorMessage` from `queryError.message`. That returns the axios top-level string (`"Request failed with status code 404"`) instead of the API envelope's structured user-facing prose (`"Job not found"`). This change wires the page-load branch through the same `getApiErrorMessage` extractor, preserving the 403 hardcoded override (backend 403 bodies may leak resource-existence information).

`Closes #269`

## Before / After

```ts
// Before — TranslationDetail.tsx:302-322
if (queryError && !job && !isLoading) {
  let errorMessage = 'Failed to load translation details';
  if (queryError instanceof Error) {
    errorMessage = queryError.message;          // axios top-level string
  }
  if (is403) {
    errorMessage = 'You do not have permission to view this translation';
  }
  // ...render Alert
}
```

```ts
// After
if (queryError && !job && !isLoading) {
  // Same extractor used for action errors above (PR #268, lines 205 / 252).
  // Prefers response.data.message -> COPY_BY_CODE -> generic fallback.
  let errorMessage = getApiErrorMessage(queryError);
  // 403 override preserved — backend 403 body may leak existence info.
  if (is403) {
    errorMessage = 'You do not have permission to view this translation';
  }
  // ...render Alert
}
```

## Test additions

`frontend/src/pages/__tests__/TranslationDetail.test.tsx`:

1. **`surfaces the API envelope 'message' on page-load failure (#269)`** — mocks `getJobStatus` to reject with `TranslationServiceError('Job not found', 'API_GENERIC', 404)` and asserts the alert renders `"Job not found"`, NOT `"An unexpected error occurred"`.
2. **`falls back to a curated phrase on page-load 429 with no message (#269)`** — empty `message` + 429 statusCode dispatches to `STATUS_MESSAGES[429]` ("rate limit reached…").
3. **`preserves the 403 hardcoded copy on page-load failure (#269 regression guard)`** — pins the 403 override against any backend prose leak.
4. The pre-existing `should show error when query fails with a generic error` test was tightened: with the extractor in place, `'Network error'` now resolves to the curated `NETWORK_MESSAGE` ("Connection lost — check your internet and try again.") instead of leaking the raw axios string. This is a behavior improvement, not a regression.

All 788 frontend tests pass (38 files), 97.84% overall coverage, 96.85% on `TranslationDetail.tsx`.

## Out-of-scope findings (filed for future cleanup)

Audit of `frontend/src/pages/` for sibling error-render paths that bypass `getApiErrorMessage`. **None of these are folded into this PR — scope kept minimal per the issue's explicit guidance.**

1. `frontend/src/pages/TranslationDetail.tsx:138-145` — inline `queryErrorMessage` -> `displayError` derivation. Uses `queryError instanceof Error ? queryError.message : 'Failed to load translation details'`. Renders inline (not the fatal-load early return) when an in-progress query fails after data has already loaded. Same antipattern as the fix.
2. `frontend/src/pages/TranslationCompare.tsx:112-116` — load-time catch sets `setDownloadError(err.message)` directly for `TranslationServiceError`. Skips `GENERIC_MESSAGES` filter + `COPY_BY_CODE` precedence.
3. `frontend/src/pages/TranslationHistory.tsx:69-73` — history-list load-failure catch sets `setError(err.message)` directly. Same pattern.
4. `frontend/src/pages/TranslationHistory.tsx:121-125` — history-download catch sets `setError(err.message)` directly. Same pattern.

These four sites all rely on `TranslationServiceError.message` (which is already lifted from `response.data.message` by `handleError`), so the user-visible bug class is milder than the page-load case fixed here — but they still bypass the curated COPY_BY_CODE phrases and the GENERIC_MESSAGES deny-list. A follow-up meta-issue will track the consolidation sweep.

## Items deliberately NOT in scope

- The four sibling error-render sites above (note: meta-issue to follow)
- Backend `requestId` field mislabel (#267)
- Adding new error codes to `COPY_BY_CODE`
- Broader auth-error UX improvements

## Test plan

- [x] `npx tsc --noEmit` clean (cold + warm cache)
- [x] `npm run lint` clean
- [x] `npx prettier --check .` clean
- [x] `npx vitest --run --coverage` — 38 files / 788 tests pass, 97.84% overall coverage
- [x] `backend/functions` — 626 tests pass (defensive sibling-package check)
- [x] `backend/infrastructure` — 91 tests pass
- [x] `shared-types` — 24 tests pass
- [ ] CI green on PR (will verify via `gh pr view --json statusCheckRollup`)
- [ ] Manual smoke: navigate to `/translation/<invalid-id>` in mock mode, observe `"Job not found"` (or whichever envelope `message`) renders instead of `"An unexpected error occurred"`