### PR TITLE
fix(api): startTranslation emits errorCode + UUID requestId (#267)

### DIFF
--- a/backend/functions/jobs/startTranslation.test.ts
+++ b/backend/functions/jobs/startTranslation.test.ts
@@ -36,6 +36,14 @@ describe('startTranslation endpoint', () => {
     });
   });
 
+  // The UUID-shape regex used by the live contract spec and by the
+  // backend unit assertions added in #267. Keep this in sync with
+  // `frontend/e2e/tests/contract/api-envelope-live.spec.ts` — if the
+  // shape ever changes (e.g. API Gateway switches to ULID), update
+  // both sites in the same PR.
+  const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  const STUB_REQUEST_ID = '11111111-2222-4333-8444-555555555555';
+
   const createEvent = (jobId: string, body: any): Partial<APIGatewayProxyEvent> => ({
     httpMethod: 'POST',
     path: `/jobs/${jobId}/translate`,
@@ -45,6 +53,10 @@ describe('startTranslation endpoint', () => {
       Authorization: 'Bearer mock-token',
     },
     requestContext: {
+      // #267 — every event MUST carry a `requestContext.requestId` UUID so
+      // the Lambda can echo it back on both success and error paths.
+      // API Gateway populates this in production; the tests stub it.
+      requestId: STUB_REQUEST_ID,
       authorizer: {
         claims: {
           sub: 'user-123',
@@ -93,6 +105,13 @@ describe('startTranslation endpoint', () => {
       expect(body.estimatedCompletion).toBeDefined();
       expect(body.estimatedCost).toBeGreaterThan(0);
       expect(body.executionArn).toBeDefined();
+      // #267 — success responses must echo the API Gateway request UUID
+      // verbatim. Pre-#267 this slot was being filled with an error-code
+      // string on the error path (broken wire contract).
+      expect(body.requestId).toBe(STUB_REQUEST_ID);
+      expect(body.requestId).toMatch(UUID_REGEX);
+      // #267 — success responses MUST NOT carry an `errorCode` field.
+      expect(body).not.toHaveProperty('errorCode');
 
       // Verify DynamoDB update was called
       const dynamoCalls = dynamoMock.commandCalls(UpdateItemCommand);
@@ -375,6 +394,164 @@ describe('startTranslation endpoint', () => {
       expect(result.statusCode).toBe(400);
       const body = JSON.parse(result.body);
       expect(body.message).toContain('no chunks');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // #267 — error envelope wire-contract guard.
+  //
+  // Pre-#267 the Lambda emitted `{ message, requestId: '<ERROR_CODE>' }` —
+  // stuffing the machine-readable status-code string into the slot reserved
+  // for the API Gateway correlation UUID. The fix separates the two concerns:
+  //
+  //   - `requestId` MUST be the UUID echoed from `event.requestContext.requestId`.
+  //   - `errorCode` MUST be the status-code discriminator (new field).
+  //
+  // These assertions pin the contract against future drift. If a maintainer
+  // accidentally reverts to the pre-#267 shape, the relevant test below
+  // fails loudly.
+  // -------------------------------------------------------------------------
+  describe('error envelope shape (#267)', () => {
+    const assertErrorEnvelope = (
+      body: Record<string, unknown>,
+      expectedErrorCode: string,
+      expectedMessageFragment: string
+    ): void => {
+      // `requestId` must be the UUID (NOT the error code string).
+      expect(typeof body.requestId).toBe('string');
+      expect(body.requestId).toBe(STUB_REQUEST_ID);
+      expect(body.requestId as string).toMatch(UUID_REGEX);
+      // `errorCode` must carry the machine-readable status-code signal.
+      expect(body.errorCode).toBe(expectedErrorCode);
+      // Anti-regression: the error code MUST NOT leak into `requestId`.
+      expect(body.requestId).not.toBe(expectedErrorCode);
+      // `message` should remain human-readable prose, not the status-code.
+      expect(typeof body.message).toBe('string');
+      expect(body.message as string).toContain(expectedMessageFragment);
+      expect(body.message).not.toBe(expectedErrorCode);
+    };
+
+    it('emits errorCode=TRANSLATION_ALREADY_STARTED with UUID requestId on IN_PROGRESS conflict', async () => {
+      dynamoMock.on(GetItemCommand).resolves({
+        Item: {
+          jobId: { S: 'job-123' },
+          userId: { S: 'user-123' },
+          status: { S: 'CHUNKED' },
+          translationStatus: { S: 'IN_PROGRESS' },
+        },
+      } as any);
+
+      const event = createEvent('job-123', { targetLanguage: 'es' });
+      const result = await handler(event as APIGatewayProxyEvent);
+      expect(result.statusCode).toBe(400);
+      const body = JSON.parse(result.body);
+      assertErrorEnvelope(body, 'TRANSLATION_ALREADY_STARTED', 'already in_progress');
+    });
+
+    it('emits errorCode=TRANSLATION_ALREADY_STARTED on COMPLETED conflict', async () => {
+      dynamoMock.on(GetItemCommand).resolves({
+        Item: {
+          jobId: { S: 'job-123' },
+          userId: { S: 'user-123' },
+          status: { S: 'CHUNKED' },
+          translationStatus: { S: 'COMPLETED' },
+        },
+      } as any);
+
+      const event = createEvent('job-123', { targetLanguage: 'es' });
+      const result = await handler(event as APIGatewayProxyEvent);
+      expect(result.statusCode).toBe(400);
+      const body = JSON.parse(result.body);
+      assertErrorEnvelope(body, 'TRANSLATION_ALREADY_STARTED', 'already completed');
+    });
+
+    it('emits errorCode=JOB_NOT_FOUND with UUID requestId when job is missing', async () => {
+      dynamoMock.on(GetItemCommand).resolves({ Item: undefined } as any);
+
+      const event = createEvent('missing', { targetLanguage: 'es' });
+      const result = await handler(event as APIGatewayProxyEvent);
+      expect(result.statusCode).toBe(404);
+      const body = JSON.parse(result.body);
+      assertErrorEnvelope(body, 'JOB_NOT_FOUND', 'Job not found');
+    });
+
+    it('emits errorCode=FORBIDDEN when the caller does not own the job', async () => {
+      dynamoMock.on(GetItemCommand).resolves({
+        Item: {
+          jobId: { S: 'job-123' },
+          userId: { S: 'other-user' },
+          status: { S: 'CHUNKED' },
+        },
+      } as any);
+
+      const event = createEvent('job-123', { targetLanguage: 'es' });
+      const result = await handler(event as APIGatewayProxyEvent);
+      expect(result.statusCode).toBe(403);
+      const body = JSON.parse(result.body);
+      assertErrorEnvelope(body, 'FORBIDDEN', 'permission');
+    });
+
+    it('emits errorCode=INVALID_JOB_STATUS when job is not in CHUNKED status', async () => {
+      dynamoMock.on(GetItemCommand).resolves({
+        Item: {
+          jobId: { S: 'job-123' },
+          userId: { S: 'user-123' },
+          status: { S: 'PENDING_UPLOAD' },
+        },
+      } as any);
+
+      const event = createEvent('job-123', { targetLanguage: 'es' });
+      const result = await handler(event as APIGatewayProxyEvent);
+      expect(result.statusCode).toBe(400);
+      const body = JSON.parse(result.body);
+      assertErrorEnvelope(body, 'INVALID_JOB_STATUS', 'must be in CHUNKED status');
+    });
+
+    it('emits errorCode=NO_CHUNKS_AVAILABLE when job has 0 chunks', async () => {
+      dynamoMock.on(GetItemCommand).resolves({
+        Item: {
+          jobId: { S: 'job-123' },
+          userId: { S: 'user-123' },
+          status: { S: 'CHUNKED' },
+          totalChunks: { N: '0' },
+        },
+      } as any);
+
+      const event = createEvent('job-123', { targetLanguage: 'es' });
+      const result = await handler(event as APIGatewayProxyEvent);
+      expect(result.statusCode).toBe(400);
+      const body = JSON.parse(result.body);
+      assertErrorEnvelope(body, 'NO_CHUNKS_AVAILABLE', 'no chunks');
+    });
+
+    it('emits errorCode=INVALID_REQUEST for validation failures (e.g. invalid targetLanguage)', async () => {
+      const event = createEvent('job-123', { targetLanguage: 'klingon' });
+      const result = await handler(event as APIGatewayProxyEvent);
+      expect(result.statusCode).toBe(400);
+      const body = JSON.parse(result.body);
+      assertErrorEnvelope(body, 'INVALID_REQUEST', 'Invalid targetLanguage');
+    });
+
+    it('does NOT stuff the error code into requestId — anti-regression guard for the pre-#267 bug', async () => {
+      // This is the EXACT failure mode #267 describes. If anyone reverts
+      // `createErrorResponse` arg-order or re-introduces the legacy call
+      // pattern in startTranslation.ts, this test fires.
+      dynamoMock.on(GetItemCommand).resolves({
+        Item: {
+          jobId: { S: 'job-123' },
+          userId: { S: 'user-123' },
+          status: { S: 'CHUNKED' },
+          translationStatus: { S: 'IN_PROGRESS' },
+        },
+      } as any);
+
+      const event = createEvent('job-123', { targetLanguage: 'es' });
+      const result = await handler(event as APIGatewayProxyEvent);
+      const body = JSON.parse(result.body);
+      // The pre-#267 shape: requestId === 'TRANSLATION_ALREADY_STARTED'.
+      expect(body.requestId).not.toBe('TRANSLATION_ALREADY_STARTED');
+      // The pre-#267 shape also did NOT include errorCode.
+      expect(body).toHaveProperty('errorCode');
     });
   });
 });

--- a/backend/functions/jobs/startTranslation.ts
+++ b/backend/functions/jobs/startTranslation.ts
@@ -70,17 +70,24 @@ interface StartTranslationRequest {
  */
 export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
   const requestOrigin = event.headers.origin || event.headers.Origin;
+  // #267 — the canonical correlation UUID is the API Gateway request id.
+  // Pre-#267 this slot was being filled with a status-code string on the
+  // wire (e.g. `'TRANSLATION_ALREADY_STARTED'`), which broke CloudWatch log
+  // correlation. The status-code signal now travels in the dedicated
+  // `errorCode` parameter (6th positional arg to `createErrorResponse`).
+  const requestId = event.requestContext?.requestId;
 
   logger.info('Starting translation request', {
     path: event.path,
     method: event.httpMethod,
+    requestId,
   });
 
   try {
     // Get authenticated user from Cognito claims
     const userId = event.requestContext?.authorizer?.claims?.sub;
     if (!userId) {
-      return createErrorResponse(401, 'Unauthorized', undefined, undefined, requestOrigin);
+      return createErrorResponse(401, 'Unauthorized', requestId, undefined, requestOrigin);
     }
 
     // Extract jobId from path
@@ -89,9 +96,10 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
       return createErrorResponse(
         400,
         'Missing jobId in path',
-        'MISSING_JOB_ID',
+        requestId,
         undefined,
-        requestOrigin
+        requestOrigin,
+        'MISSING_JOB_ID'
       );
     }
 
@@ -104,9 +112,10 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
       return createErrorResponse(
         400,
         validation.error!,
-        'INVALID_REQUEST',
+        requestId,
         undefined,
-        requestOrigin
+        requestOrigin,
+        'INVALID_REQUEST'
       );
     }
 
@@ -118,9 +127,10 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
       return createErrorResponse(
         404,
         `Job not found: ${jobId}`,
-        'JOB_NOT_FOUND',
+        requestId,
         undefined,
-        requestOrigin
+        requestOrigin,
+        'JOB_NOT_FOUND'
       );
     }
 
@@ -129,9 +139,10 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
       return createErrorResponse(
         403,
         'You do not have permission to translate this job',
-        'FORBIDDEN',
+        requestId,
         undefined,
-        requestOrigin
+        requestOrigin,
+        'FORBIDDEN'
       );
     }
 
@@ -140,9 +151,10 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
       return createErrorResponse(
         400,
         `Job must be in CHUNKED status to start translation. Current status: ${job.status}`,
-        'INVALID_JOB_STATUS',
+        requestId,
         undefined,
-        requestOrigin
+        requestOrigin,
+        'INVALID_JOB_STATUS'
       );
     }
 
@@ -151,9 +163,10 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
       return createErrorResponse(
         400,
         `Translation already ${job.translationStatus.toLowerCase()} for this job`,
-        'TRANSLATION_ALREADY_STARTED',
+        requestId,
         undefined,
-        requestOrigin
+        requestOrigin,
+        'TRANSLATION_ALREADY_STARTED'
       );
     }
 
@@ -162,9 +175,10 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
       return createErrorResponse(
         400,
         'Job has no chunks to translate',
-        'NO_CHUNKS_AVAILABLE',
+        requestId,
         undefined,
-        requestOrigin
+        requestOrigin,
+        'NO_CHUNKS_AVAILABLE'
       );
     }
 
@@ -219,19 +233,21 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
       executionArn, // Step Functions execution ARN for tracking
     };
 
-    return createFlatResponse(200, responseBody, undefined, requestOrigin);
+    return createFlatResponse(200, responseBody, requestId, requestOrigin);
   } catch (error) {
     logger.error('Failed to start translation', {
       error: error instanceof Error ? error.message : 'Unknown error',
       stack: error instanceof Error ? error.stack : undefined,
+      requestId,
     });
 
     return createErrorResponse(
       500,
       'Failed to start translation',
+      requestId,
       undefined,
-      undefined,
-      requestOrigin
+      requestOrigin,
+      'INTERNAL_ERROR'
     );
   }
 };

--- a/backend/functions/shared/__tests__/api-response.test.ts
+++ b/backend/functions/shared/__tests__/api-response.test.ts
@@ -166,6 +166,62 @@ describe('api-response — envelope helpers', () => {
       const parsed = JSON.parse(response.body);
       expect(parsed).toEqual({ message: 'Server error' });
     });
+
+    // ---------------------------------------------------------------------
+    // #267 — `errorCode` parameter is the new canonical home for the
+    // machine-readable status-code discriminator. Pre-#267 some handlers
+    // (notably startTranslation.ts) misused the `requestId` slot for this
+    // signal — these tests pin the new contract so the bug cannot reappear.
+    // ---------------------------------------------------------------------
+    it('includes errorCode when supplied alongside the UUID requestId', () => {
+      const response = createErrorResponse(
+        409,
+        'Translation already in_progress for this job',
+        '11111111-2222-4333-8444-555555555555',
+        undefined,
+        undefined,
+        'TRANSLATION_ALREADY_STARTED'
+      );
+      const parsed = JSON.parse(response.body);
+      expect(response.statusCode).toBe(409);
+      expect(parsed).toEqual({
+        message: 'Translation already in_progress for this job',
+        requestId: '11111111-2222-4333-8444-555555555555',
+        errorCode: 'TRANSLATION_ALREADY_STARTED',
+      });
+      // The error code MUST NOT be smuggled into `requestId`.
+      expect(parsed.requestId).not.toBe('TRANSLATION_ALREADY_STARTED');
+    });
+
+    it('omits errorCode when not provided (legacy callers stay unchanged)', () => {
+      const response = createErrorResponse(500, 'Server error', 'r1');
+      const parsed = JSON.parse(response.body);
+      expect(parsed).toEqual({
+        message: 'Server error',
+        requestId: 'r1',
+      });
+      expect(parsed).not.toHaveProperty('errorCode');
+    });
+
+    it('supports the full 6-arg signature (status, message, requestId, errors, origin, errorCode)', () => {
+      process.env.ALLOWED_ORIGINS = 'https://app.example.com';
+      const response = createErrorResponse(
+        400,
+        'Validation failed',
+        'r1',
+        { email: ['Invalid'] },
+        'https://app.example.com',
+        'INVALID_REQUEST'
+      );
+      expect(response.headers['Access-Control-Allow-Origin']).toBe('https://app.example.com');
+      const parsed = JSON.parse(response.body);
+      expect(parsed).toEqual({
+        message: 'Validation failed',
+        requestId: 'r1',
+        errorCode: 'INVALID_REQUEST',
+        errors: { email: ['Invalid'] },
+      });
+    });
   });
 
   describe('getCorsHeaders', () => {

--- a/backend/functions/shared/api-response.ts
+++ b/backend/functions/shared/api-response.ts
@@ -32,7 +32,25 @@ export interface ApiResponse {
 
 export interface ApiErrorResponse {
   message: string;
+  /**
+   * API Gateway request UUID (e.g. `event.requestContext.requestId`).
+   * Used for log correlation in CloudWatch / support tickets.
+   *
+   * Previously some handlers (notably `startTranslation.ts` pre-#267) misused
+   * this slot to carry a machine-readable status code. The dedicated
+   * `errorCode` field below is the canonical home for that signal; this
+   * field is reserved for the correlation UUID.
+   */
   requestId?: string;
+  /**
+   * Machine-readable error-code discriminator (e.g. `TRANSLATION_ALREADY_STARTED`,
+   * `JOB_NOT_FOUND`). Added in #267 to separate the correlation UUID from
+   * the status-code signal that the frontend dispatches on (via
+   * `extractErrorCode` / `COPY_BY_CODE`). Optional so legacy handlers that
+   * don't set it remain valid; new handlers SHOULD populate this field for
+   * any expected 4xx error.
+   */
+  errorCode?: string;
   errors?: Record<string, string[]>;
 }
 
@@ -182,19 +200,54 @@ export function createSuccessResponse<T extends ApiFlatResponseBody>(
 }
 
 /**
- * Create an error API response
+ * Create an error API response.
+ *
+ * Wire body shape:
+ *   `{ message, requestId?, errorCode?, errors? }`
+ *
+ * The `errorCode` parameter (added in #267) carries the machine-readable
+ * status-code discriminator (`TRANSLATION_ALREADY_STARTED`, `JOB_NOT_FOUND`,
+ * etc.). The `requestId` parameter is reserved for the API Gateway request
+ * UUID (`event.requestContext.requestId`) — DO NOT pass a status-code string
+ * here; that's what `errorCode` is for.
+ *
+ * Pre-#267 the only signal the frontend had to discriminate on was a string
+ * stuffed into `requestId` — a misuse that broke CloudWatch log correlation
+ * (operators couldn't trace the request) and conflated two distinct concerns.
+ * The `errorCode` parameter is the canonical home for that signal. The
+ * frontend's `extractErrorCode` reads `errorCode` first (PR #268 forward-compat)
+ * and falls back to `requestId` for the deployment window; the fallback will
+ * be removed in a follow-up after this fix has been observed in production.
+ *
+ * Example:
+ *   ```ts
+ *   return createErrorResponse(
+ *     409,
+ *     'Translation already in_progress for this job',
+ *     event.requestContext.requestId,
+ *     undefined,
+ *     requestOrigin,
+ *     'TRANSLATION_ALREADY_STARTED'
+ *   );
+ *   // → body: { message: '...', requestId: '<uuid>', errorCode: 'TRANSLATION_ALREADY_STARTED' }
+ *   ```
  */
 export function createErrorResponse(
   statusCode: number,
   message: string,
   requestId?: string,
   errors?: Record<string, string[]>,
-  requestOrigin?: string
+  requestOrigin?: string,
+  errorCode?: string
 ): ApiResponse {
   const response: ApiErrorResponse = {
     message,
     requestId,
   };
+
+  if (errorCode) {
+    response.errorCode = errorCode;
+  }
 
   if (errors) {
     response.errors = errors;

--- a/frontend/e2e/tests/contract/api-envelope-live.spec.ts
+++ b/frontend/e2e/tests/contract/api-envelope-live.spec.ts
@@ -183,6 +183,37 @@ test.describe('Live-backend API envelope contract @contract-live', () => {
     return { Authorization: `Bearer ${idToken}` };
   }
 
+  /**
+   * Assert the #267 error envelope shape against a parsed 4xx/5xx body.
+   *
+   * Contract:
+   *   - `requestId` (when present) MUST be an API Gateway UUID, NOT a
+   *     status-code string. The pre-#267 bug stuffed `'JOB_NOT_FOUND'` etc.
+   *     into this slot, breaking CloudWatch log correlation.
+   *   - `errorCode` (when present) MUST be a SCREAMING_SNAKE_CASE literal.
+   *     We don't pin the exact union here because new error codes get added
+   *     over time; the shape pin is sufficient to catch wire-contract drift.
+   *
+   * `requestId` and `errorCode` are both OPTIONAL on the envelope. The shape
+   * pin only fires when they're present (forward-compat with handlers that
+   * haven't yet been migrated to the new contract).
+   */
+  const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  function assertErrorEnvelope(body: {
+    message: string;
+    requestId?: string;
+    errorCode?: string;
+  }): void {
+    if (typeof body.requestId === 'string') {
+      // #267 anti-regression: requestId MUST be a UUID, NOT a status code.
+      expect(body.requestId).toMatch(UUID_REGEX);
+      expect(body.requestId).not.toMatch(/^[A-Z][A-Z0-9_]*$/);
+    }
+    if (typeof body.errorCode === 'string') {
+      expect(body.errorCode).toMatch(/^[A-Z][A-Z0-9_]*$/);
+    }
+  }
+
   // -----------------------------------------------------------------------
   // Lifecycle — one login per file, not per test.
   // -----------------------------------------------------------------------
@@ -275,13 +306,57 @@ test.describe('Live-backend API envelope contract @contract-live', () => {
       expect(body).not.toHaveProperty('chunksTranslated');
       expect(typeof body.targetLanguage).toBe('string');
     } else {
-      // Structured error envelope — `{ message, requestId, errors? }`.
+      // Structured error envelope — `{ message, requestId, errorCode?, errors? }`.
+      // #267: `requestId` MUST be the API Gateway UUID (NOT a status-code
+      // string); `errorCode` (when present) carries the machine-readable
+      // discriminator. The legacy buggy shape that motivated #267 stuffed
+      // the status code into `requestId` (`requestId === 'TRANSLATION_ALREADY_STARTED'`).
       const body = (await res.json()) as {
         message: string;
         requestId?: string;
+        errorCode?: string;
       };
       expect(typeof body.message).toBe('string');
       expect(body.message.length).toBeGreaterThan(0);
+      assertErrorEnvelope(body);
+    }
+  });
+
+  // -----------------------------------------------------------------------
+  // 2b. POST /jobs/{jobId}/translate — explicit error-envelope check.
+  //     #267 — translating a non-existent jobId returns a 4xx whose body
+  //     MUST follow the canonical error envelope shape (UUID requestId,
+  //     errorCode discriminator). This is the regression baseline for the
+  //     bug that motivated #267: pre-fix, `requestId` carried the status
+  //     code string instead of the API Gateway UUID.
+  // -----------------------------------------------------------------------
+  test('POST /jobs/{nonexistent}/translate returns the #267 error envelope', async ({
+    request,
+  }) => {
+    const fakeJobId = `nonexistent-${Date.now()}`;
+    const res = await request.post(`${normalizedApiUrl}/jobs/${fakeJobId}/translate`, {
+      headers: authHeaders(),
+      data: { targetLanguage: 'es', tone: 'neutral' },
+      failOnStatusCode: false,
+    });
+    // We don't pin the EXACT status code (404 vs 400) — the contract is
+    // about the envelope shape, not the status code. Just ensure it's
+    // not a 2xx (which would mean the lookup didn't happen).
+    expect(res.ok(), await res.text()).toBe(false);
+    const body = (await res.json()) as {
+      message: string;
+      requestId?: string;
+      errorCode?: string;
+    };
+    expect(typeof body.message).toBe('string');
+    expect(body.message.length).toBeGreaterThan(0);
+    assertErrorEnvelope(body);
+    // For this specific call, we expect errorCode === 'JOB_NOT_FOUND'
+    // once the #267 fix is deployed. Until then the field may be absent
+    // (frontend forward-compat reads requestId fallback). Treat the
+    // presence assertion as soft — log instead of fail when missing.
+    if (typeof body.errorCode === 'string') {
+      expect(body.errorCode).toMatch(/^[A-Z][A-Z0-9_]*$/);
     }
   });
 

--- a/shared-types/src/jobs.ts
+++ b/shared-types/src/jobs.ts
@@ -483,7 +483,60 @@ export interface StartTranslationApiResponse {
   estimatedCost?: number;
   /** Step Functions execution ARN (for tracking / debugging). */
   executionArn?: string;
+  /**
+   * API Gateway correlation UUID (echo of `event.requestContext.requestId`).
+   * Present on every response shape produced by `createFlatResponse` /
+   * `createErrorResponse`; reserved for log correlation, NEVER for a
+   * status-code signal (see #267 for the bug this caveat addresses).
+   */
+  requestId?: string;
   [key: string]: unknown;
+}
+
+/**
+ * Canonical 4xx error-code union emitted by POST /jobs/{jobId}/translate.
+ *
+ * Added in #267 alongside the API-error-envelope `errorCode` field so the
+ * frontend can dispatch on a stable machine-readable signal instead of
+ * pattern-matching the human-readable `message`. The values mirror the
+ * literal-string codes used by the Lambda (`backend/functions/jobs/
+ * startTranslation.ts`). The frontend's `TranslationErrorCode` union
+ * (`frontend/src/services/translationService.ts`) is a SUPERSET of this one
+ * — it also covers transport-level codes (`S3_UPLOAD_BLOCKED`, etc.) that
+ * never reach a Lambda. Keep this union in sync with the backend literals
+ * when adding new failure modes.
+ */
+export type StartTranslationErrorCode =
+  | 'MISSING_JOB_ID'
+  | 'INVALID_REQUEST'
+  | 'JOB_NOT_FOUND'
+  | 'FORBIDDEN'
+  | 'INVALID_JOB_STATUS'
+  | 'TRANSLATION_ALREADY_STARTED'
+  | 'NO_CHUNKS_AVAILABLE'
+  | 'INTERNAL_ERROR';
+
+/**
+ * Canonical flat error envelope shared across every Lambda that returns a
+ * 4xx/5xx body via `createErrorResponse`. The runtime helper lives in
+ * `backend/functions/shared/api-response.ts`; this interface is the type-level
+ * mirror so the frontend (and the live contract spec) can import a single
+ * authoritative shape.
+ *
+ * `errorCode` was added in #267 — pre-#267 the only machine-readable signal
+ * the frontend had was a status-code string stuffed into `requestId` (a
+ * misuse that broke CloudWatch log correlation). The `errorCode` field is
+ * the canonical home for that signal; `requestId` is reserved for the API
+ * Gateway request UUID.
+ */
+export interface ApiErrorEnvelope {
+  message: string;
+  /** API Gateway correlation UUID — `event.requestContext.requestId`. */
+  requestId?: string;
+  /** Machine-readable status-code discriminator (e.g. `JOB_NOT_FOUND`). */
+  errorCode?: string;
+  /** Per-field validation errors (only present on Zod-validated handlers). */
+  errors?: Record<string, string[]>;
 }
 
 /**


### PR DESCRIPTION
## Summary

`POST /jobs/{jobId}/translate` previously emitted error bodies where `requestId` carried a status-code string (e.g. `'TRANSLATION_ALREADY_STARTED'`) instead of the API Gateway correlation UUID. This broke CloudWatch log correlation, conflated two distinct concerns, and trapped operators who tried to trace a request by `requestId`.

This PR splits the two signals into separate envelope fields:

- `requestId` is now the API Gateway request UUID on every return path (success + 4xx + 5xx).
- `errorCode` is a new, dedicated field carrying the machine-readable status-code discriminator.

## Per-handler change summary

- `backend/functions/shared/api-response.ts` — add `errorCode?: string` to `ApiErrorResponse`; extend `createErrorResponse` with a 6th positional `errorCode?` parameter (backward-compatible — every existing call site keeps working unchanged).
- `backend/functions/jobs/startTranslation.ts` — extract `event.requestContext.requestId` once at the top of the handler; pass it as the `requestId` argument on every `createErrorResponse` / `createFlatResponse` call; move the literal status-code strings (`TRANSLATION_ALREADY_STARTED`, `JOB_NOT_FOUND`, etc.) into the new `errorCode` slot. Adds an `INTERNAL_ERROR` code on the 500 path.
- `shared-types/src/jobs.ts` — adds canonical `ApiErrorEnvelope` interface and `StartTranslationErrorCode` union; documents the `requestId` field on `StartTranslationApiResponse`.

## Sibling-Lambda audit

I grep'd every `createErrorResponse` call site in `backend/functions/**`. The `startTranslation.ts` handler was the ONLY one misusing the `requestId` slot for a status-code string. Every other handler (`register.ts`, `login.ts`, `getJob.ts`, `deleteJob.ts`, `listJobs.ts`, `resetPassword.ts`, `refreshToken.ts`, `downloadTranslation.ts`, `getCurrentUser.ts`, `uploadRequest.ts`) already passes a UUID (or `undefined`). No additional Lambdas were modified. `getTranslationStatus.ts` passes `undefined` for `requestId` today (no UUID extraction) — that's a separate hygiene cleanup, not a bug, and is out of scope for this PR.

## Forward-compat with PR #268 (frontend)

`extractErrorCode` in `frontend/src/utils/translationErrorMessages.ts` already reads `response.data.errorCode` first and falls back to `response.data.requestId`. So deploying this fix is non-breaking:

1. Backend ships → response shape changes to `{ errorCode, requestId: <uuid> }`.
2. Frontend's `errorCode`-first read picks up the new field; the `requestId` fallback becomes dead code.
3. **Follow-up issue** (to be filed): after 30 days of clean operation, remove the `requestId` fallback in `extractErrorCode`.

## Live-contract spec — deployment caveat

The `frontend/e2e/tests/contract/api-envelope-live.spec.ts` updates assert `requestId` matches a UUID regex and `errorCode` matches a SCREAMING_SNAKE_CASE pattern. The spec runs on a **schedule (nightly)** plus `workflow_dispatch`, NOT on a per-PR basis, because it hits the deployed dev backend. Therefore:

- This PR's spec changes are validated by `tsc --noEmit` here (CI-parity attached).
- The first true live-contract validation against the deployed Lambda happens **after** the backend Lambda actually ships to dev (next deploy-backend.yml run after this PR merges).
- The `errorCode` assertion is intentionally soft (only fires if the field is present) so the spec doesn't gate on the deploy timing.

## Frontend dead-code follow-up flag

The `extractErrorCode` fallback to `response.data.requestId` becomes dead code once this PR is deployed and the backend stops misusing the field. **Do NOT remove it in this PR** — a follow-up issue will be filed (with a 30-day observation window) to clean it up separately. This keeps the deployment window safe.

## Test counts (before -> after)

| Package | Before | After | Delta |
| --- | --- | --- | --- |
| `shared-types` | 24 passing | 24 passing | +0 (no test files modified; type-only contract additions) |
| `backend/functions` | 626 passing, 3 skipped | 637 passing, 3 skipped | +11 (8 in `startTranslation.test.ts`, 3 in `api-response.test.ts`) |
| `backend/infrastructure` | 91 passing | 91 passing | +0 (defensive — unchanged) |
| `frontend` (vitest) | 785 passing, 14 skipped | 785 passing, 14 skipped | +0 (no production frontend code touched; spec file is Playwright-only) |

Anti-regression: the new `startTranslation.test.ts` `error envelope shape (#267)` describe block includes a test specifically named `does NOT stuff the error code into requestId` — fires loudly if anyone reverts to the pre-#267 shape.

## CI-parity validation

Run with the exact CI commands (`rm -rf node_modules && npm ci`) for every workspace touched:

```
shared-types        : npm run build + jest          -> 2/2 suites, 24/24 tests pass
backend/functions   : eslint + prettier --check + jest -> 30/30 suites, 637/640 tests pass (3 skipped)
backend/infrastructure : jest                         -> 1/1 suite, 91/91 pass
frontend            : tsc --noEmit (cold + warm)     -> EXIT 0 both runs
frontend            : vitest --run --coverage         -> 38/38 files, 785/799 (14 skipped)
```

Closes #267