### PR TITLE
fix(api): preserve backend message on 403 (#275)

### DIFF
--- a/frontend/src/utils/__tests__/api.test.ts
+++ b/frontend/src/utils/__tests__/api.test.ts
@@ -583,11 +583,70 @@ describe('API Client - Response Error Interceptor', () => {
     }
   });
 
-  it('should handle 403 Forbidden', async () => {
+  // Issue #275: 403 backend-message precedence.
+  //
+  // Pre-#275 the 403 branch clobbered every backend message with the
+  // generic `ERROR_MESSAGES.UNAUTHORIZED` constant, silently destroying
+  // user-facing prose like the email-verification guidance emitted by
+  // `backend/functions/auth/login.ts:175` for `UserNotConfirmedException`.
+  // Post-#275 the precedence is: specific backend message wins; generic
+  // backend message OR absent backend message falls back to the
+  // `ERROR_MESSAGES.UNAUTHORIZED` constant (the deny-list guard prevents
+  // an opaque "Forbidden" / "Request failed" from re-introducing the
+  // issue #266 "An unexpected error occurred" class of bug).
+
+  it('403: surfaces specific backend message verbatim (issue #275 load-bearing case)', async () => {
     const { createApiClient } = await import('../api');
     const client = createApiClient();
 
-    // Mock adapter to simulate 403 error
+    // Mock adapter to simulate the 403 from login.ts:175 for an
+    // unconfirmed-user login. The pre-#275 implementation would
+    // clobber `error.message` with "You do not have permission to
+    // perform this action." — destroying the only recovery action
+    // the backend gave the user.
+    client.defaults.adapter = async () => {
+      const error: any = new Error('Request failed with status code 403');
+      error.isAxiosError = true;
+      error.response = {
+        status: 403,
+        data: {
+          message:
+            'Please verify your email address before logging in. Check your inbox for the verification link.',
+          requestId: 'req-abc',
+        },
+        statusText: 'Forbidden',
+        headers: {},
+        config: {},
+      };
+      throw error;
+    };
+
+    try {
+      await client.post('/auth/login', { email: 'x', password: 'y' });
+      expect.fail('Should have thrown an error');
+    } catch (error: any) {
+      expect(error.status).toBe(403);
+      expect(error.message).toBe(
+        'Please verify your email address before logging in. Check your inbox for the verification link.'
+      );
+      // The raw envelope is preserved for downstream consumers
+      // (e.g. `getApiErrorMessage` which also reads `data.errorCode`).
+      expect(error.data).toEqual({
+        message:
+          'Please verify your email address before logging in. Check your inbox for the verification link.',
+        requestId: 'req-abc',
+      });
+    }
+  });
+
+  it('403: falls back to UNAUTHORIZED constant when backend message is in the GENERIC deny-list', async () => {
+    const { createApiClient } = await import('../api');
+    const client = createApiClient();
+
+    // API Gateway authorizer 403 (no specific prose, just "Forbidden").
+    // Surfacing "Forbidden" verbatim would re-introduce the issue #266
+    // "An unexpected error occurred" class problem, so the deny-list
+    // routes us to the curated UNAUTHORIZED copy.
     client.defaults.adapter = async () => {
       const error: any = new Error('Request failed with status code 403');
       error.isAxiosError = true;
@@ -609,6 +668,135 @@ describe('API Client - Response Error Interceptor', () => {
       expect(error.message).toBe('You do not have permission to perform this action.');
     }
   });
+
+  it('403: falls back to UNAUTHORIZED constant when response body has no message field', async () => {
+    const { createApiClient } = await import('../api');
+    const client = createApiClient();
+
+    // Some 403 responses (e.g. opaque API Gateway 403s, raw blocked
+    // responses) carry no message field at all. Fall back to the
+    // curated copy.
+    client.defaults.adapter = async () => {
+      const error: any = new Error('Request failed with status code 403');
+      error.isAxiosError = true;
+      error.response = {
+        status: 403,
+        data: {},
+        statusText: 'Forbidden',
+        headers: {},
+        config: {},
+      };
+      throw error;
+    };
+
+    try {
+      await client.get('/admin');
+      expect.fail('Should have thrown an error');
+    } catch (error: any) {
+      expect(error.status).toBe(403);
+      expect(error.message).toBe('You do not have permission to perform this action.');
+    }
+  });
+
+  it('403: falls back to UNAUTHORIZED constant when backend message is whitespace only', async () => {
+    const { createApiClient } = await import('../api');
+    const client = createApiClient();
+
+    client.defaults.adapter = async () => {
+      const error: any = new Error('Request failed with status code 403');
+      error.isAxiosError = true;
+      error.response = {
+        status: 403,
+        data: { message: '   \t  \n' },
+        statusText: 'Forbidden',
+        headers: {},
+        config: {},
+      };
+      throw error;
+    };
+
+    try {
+      await client.get('/admin');
+      expect.fail('Should have thrown an error');
+    } catch (error: any) {
+      expect(error.status).toBe(403);
+      expect(error.message).toBe('You do not have permission to perform this action.');
+    }
+  });
+
+  it('403: falls back to UNAUTHORIZED constant when response body is not an object', async () => {
+    const { createApiClient } = await import('../api');
+    const client = createApiClient();
+
+    // Defensive: if some upstream layer returns a string body, the
+    // extractor must not treat that as a usable message.
+    client.defaults.adapter = async () => {
+      const error: any = new Error('Request failed with status code 403');
+      error.isAxiosError = true;
+      error.response = {
+        status: 403,
+        // axios may sometimes pass through plain-string error bodies
+        // when content-type isn't json. The extractor returns undefined
+        // for any non-object data.
+        data: 'Forbidden',
+        statusText: 'Forbidden',
+        headers: {},
+        config: {},
+      };
+      throw error;
+    };
+
+    try {
+      await client.get('/admin');
+      expect.fail('Should have thrown an error');
+    } catch (error: any) {
+      expect(error.status).toBe(403);
+      expect(error.message).toBe('You do not have permission to perform this action.');
+    }
+  });
+
+  it('403: deny-list match is case-insensitive (defense against backend casing drift)', async () => {
+    const { createApiClient } = await import('../api');
+    const client = createApiClient();
+
+    // Backend or API Gateway may send "FORBIDDEN" or "forbidden" depending
+    // on layer. The deny-list normalizes via .toLowerCase() so all variants
+    // fall back to the curated copy.
+    client.defaults.adapter = async () => {
+      const error: any = new Error('Request failed with status code 403');
+      error.isAxiosError = true;
+      error.response = {
+        status: 403,
+        data: { message: 'FORBIDDEN' },
+        statusText: 'Forbidden',
+        headers: {},
+        config: {},
+      };
+      throw error;
+    };
+
+    try {
+      await client.get('/admin');
+      expect.fail('Should have thrown an error');
+    } catch (error: any) {
+      expect(error.status).toBe(403);
+      expect(error.message).toBe('You do not have permission to perform this action.');
+    }
+  });
+
+  // 401-path regression guard:
+  //
+  // Issue #275's fix only changed the 403 branch — the 401 branch's
+  // behavior is intentionally DIFFERENT (when a refresh has already
+  // been attempted OR there is no refresh token, the curated
+  // SESSION_EXPIRED constant always wins, regardless of backend prose,
+  // because the session is dead). The real 401 path is exhaustively
+  // covered by `api.refresh.test.ts` (which uses axios-mock-adapter to
+  // properly attach axiosError.config so the refresh-flow guard fires).
+  // We deliberately do not duplicate that coverage here with a
+  // hand-constructed axios error — earlier attempts at this would
+  // either skip the 401 branch entirely (when axiosError.config is
+  // undefined) or accidentally pass for the wrong reason.
 
   it('should handle network errors (no response)', async () => {
     const { createApiClient } = await import('../api');

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -25,6 +25,74 @@ export interface ApiError {
 }
 
 /**
+ * Generic message strings that are too vague to surface to the user.
+ *
+ * Mirror of the `GENERIC_MESSAGES` deny-list in
+ * `frontend/src/utils/translationErrorMessages.ts` (PR #251 / issue #266).
+ * The list is intentionally inlined rather than imported because:
+ *   - The translationErrorMessages module is auth-context-free and
+ *     pulling api.ts into its dependency graph would create a circular
+ *     dependency the wrapping `getApiErrorMessage` helper already
+ *     dispatches through.
+ *   - Keeping the deny-list in this file means the universal interceptor
+ *     fallback decision is self-contained and inspectable in one place.
+ * If a third caller appears, promote this constant to a shared util.
+ */
+const GENERIC_BACKEND_MESSAGES = new Set(
+  [
+    'network error',
+    'an unexpected error occurred',
+    'request failed',
+    'failed to fetch',
+    'forbidden',
+    'unauthorized',
+  ].map((s) => s.toLowerCase())
+);
+
+/**
+ * Extract a usable user-facing message from an axios error-response body.
+ *
+ * Returns `undefined` when the caller should fall back to a curated
+ * generic constant (`ERROR_MESSAGES.UNAUTHORIZED` etc.). Returns the
+ * backend's `message` verbatim when it is specific enough to surface.
+ *
+ * Rules (mirrors `getApiErrorMessage` precedence in translationErrorMessages.ts):
+ *   - `data` is not an object → undefined (no envelope to read)
+ *   - `data.message` is missing / non-string / empty / whitespace → undefined
+ *   - `data.message` matches the GENERIC_BACKEND_MESSAGES deny-list
+ *     (case-insensitive, trimmed) → undefined. This guards against
+ *     issue #266's "An unexpected error occurred" class of bug, where
+ *     a backend leak of a vague string would otherwise REPLACE a more
+ *     useful curated constant.
+ *   - Otherwise → the trimmed message verbatim.
+ *
+ * Introduced for issue #275: the 403 interceptor branch used to
+ * unconditionally clobber the backend message with the generic
+ * `ERROR_MESSAGES.UNAUTHORIZED` constant, destroying the email-
+ * verification guidance from `login.ts:175` for unconfirmed-user
+ * `UserNotConfirmedException`. Extracted as a helper rather than
+ * inlined so other status-code branches can adopt the same pattern
+ * if needed without re-implementing the deny-list logic.
+ */
+function extractBackendMessage(data: unknown): string | undefined {
+  if (!data || typeof data !== 'object') {
+    return undefined;
+  }
+  const candidate = (data as { message?: unknown }).message;
+  if (typeof candidate !== 'string') {
+    return undefined;
+  }
+  const trimmed = candidate.trim();
+  if (trimmed.length === 0) {
+    return undefined;
+  }
+  if (GENERIC_BACKEND_MESSAGES.has(trimmed.toLowerCase())) {
+    return undefined;
+  }
+  return trimmed;
+}
+
+/**
  * Generate a unique request ID for tracing
  */
 function generateRequestId(): string {
@@ -387,9 +455,25 @@ async function responseErrorInterceptor(error: unknown): Promise<unknown> {
   }
 
   // Handle 403 Forbidden
+  //
+  // Issue #275: prefer the backend's user-facing prose when present (e.g.,
+  // "Please verify your email address before logging in." emitted by
+  // `backend/functions/auth/login.ts:175` for `UserNotConfirmedException`).
+  // Only fall back to the generic `ERROR_MESSAGES.UNAUTHORIZED` constant
+  // when the backend message is absent OR matches the
+  // `GENERIC_BACKEND_MESSAGES` deny-list — otherwise an opaque
+  // "Forbidden" or "Request failed" string from API Gateway would
+  // re-introduce the original issue-#266 "An unexpected error occurred"
+  // class problem.
+  //
+  // Precedence mirrors `getApiErrorMessage` in
+  // `frontend/src/utils/translationErrorMessages.ts` so the two code
+  // paths agree on what counts as a usable backend message.
   if (axiosError.response?.status === 403) {
+    const backendMessage = extractBackendMessage(axiosError.response.data);
+
     const apiError: ApiError = {
-      message: ERROR_MESSAGES.UNAUTHORIZED,
+      message: backendMessage ?? ERROR_MESSAGES.UNAUTHORIZED,
       status: 403,
       data: axiosError.response.data,
     };


### PR DESCRIPTION
## Summary

The axios response-error interceptor's 403 branch in `frontend/src/utils/api.ts` unconditionally overwrote the backend's `message` with the generic `ERROR_MESSAGES.UNAUTHORIZED` constant ("You do not have permission to perform this action."). This silently destroyed user-facing prose emitted by `backend/functions/auth/login.ts:175` for `UserNotConfirmedException`, so unconfirmed-email users saw the generic copy instead of "Please verify your email address before logging in. Check your inbox for the verification link." — losing the only recovery action the backend provides.

This PR introduces an `extractBackendMessage` helper (in `frontend/src/utils/api.ts`) that mirrors the precedence rule from `getApiErrorMessage` in `frontend/src/utils/translationErrorMessages.ts`: surface the backend message verbatim when it is specific; fall back to the curated `ERROR_MESSAGES.UNAUTHORIZED` constant when the message is absent, empty/whitespace, on a non-object body, or in the `GENERIC_BACKEND_MESSAGES` deny-list (which guards against opaque strings like "Forbidden" or "Request failed" re-introducing the issue #266 bug class).

## Helper function

- **Name**: `extractBackendMessage(data: unknown): string | undefined`
- **Location**: `frontend/src/utils/api.ts` (module-private, alongside the `GENERIC_BACKEND_MESSAGES` deny-list it consults)

The helper is intentionally inlined rather than imported from `translationErrorMessages.ts`. Cross-file edits are minimized, the deny-list is self-contained in the file that uses it, and pulling api.ts into `translationErrorMessages.ts`'s dependency graph would risk a circular import (the latter already dispatches API errors via `getApiErrorMessage` which itself references the envelope shape).

## Composition with Stream P (#274/#277/#278/#279)

Stream P's PR will modify the auth forms + `AuthContext` to route caught errors through `getApiErrorMessage` instead of raw `err.message`. The two changes COMPOSE:

- **Pre-#275, pre-Stream P**: The interceptor clobbered the 403 message → the form rendered the generic UNAUTHORIZED constant.
- **Post-#275, pre-Stream P**: The interceptor surfaces the backend's verbatim prose → the form renders the correct verification message via raw `err.message`.
- **Post-#275, post-Stream P**: The interceptor surfaces backend prose → the form renders it via `getApiErrorMessage`, which has the same precedence rule the interceptor now mirrors. Identical user-visible outcome.

No file overlap with Stream P (`AuthContext.tsx`, `LoginForm.tsx`, `RegisterForm.tsx`, `ForgotPasswordForm.tsx`). No file overlap with Stream R (#276, `RegisterPage.tsx`).

## Test counts before/after

| Workspace | Before (file-count / passed) | After (file-count / passed) |
| --- | --- | --- |
| frontend | 38 / 795 | 38 / 800 |
| backend/functions | 30 / 626 | 30 / 626 |
| backend/infrastructure | 1 / 91 | 1 / 91 |
| shared-types | 2 / 24 | 2 / 24 |

Frontend coverage post-change: **97.96% statements / 93.47% branches** (api.ts: 99.1% / 93.61%).

Net delta: **+5 frontend unit tests** (one pre-existing 403 test rewritten as the deny-list case; five new cases for the specific-message, empty-body, whitespace-only-message, non-object-body, and case-insensitive-deny-list scenarios).

## Backend 403 prose audit (security check)

I walked every backend handler that returns a 403 to verify the prose is safe to surface verbatim:

| Handler | 403 prose | Safe to surface? |
| --- | --- | --- |
| `backend/functions/auth/login.ts:175` | "Please verify your email address before logging in. Check your inbox for the verification link." | **Yes** — generic guidance, no PII or resource-existence leak. This is the load-bearing case for #275. |
| `backend/functions/jobs/startTranslation.ts:130` | "You do not have permission to translate this job" + `errorCode: 'FORBIDDEN'` | **Pre-existing concern, NOT introduced by this PR.** The handler returns 404 first when the job doesn't exist (line 117-125), so a 403 confirms the job exists but isn't owned by the caller — a mild resource-existence leak. This is a **backend** issue (the prose itself isn't more revealing than the status code), not a frontend issue. Filing as out-of-scope follow-up — see below. |

No other backend handler in `backend/functions/**` returns a 403 (verified by grep of all `createErrorResponse(403` / `, 403,` patterns).

## Sibling-status-code overrides (out-of-scope finding)

While scoping this fix I noticed `api.ts:423-430` (the 500+ branch) ALSO replaces the backend message with the curated `ERROR_MESSAGES.SERVER_ERROR` constant. This is the same bug class as #275 but per the issue's "Out of scope" section the 403-only scope is preserved. Per the agent instructions:

> If you find a sibling 401/500 override that has the same bug class, file a follow-up issue rather than expanding scope.

A backend-side reaffirmation: the issue's "Why this is safe" section observes that the 500-class API contract dictates a human-readable phrase only. If the future backend signal warrants surfacing, a follow-up should:

1. Adopt the same `extractBackendMessage` helper (now exported-ready in api.ts; trivially promotable).
2. Add unit tests mirroring the 403 ones in this PR.

The 401 branch is intentionally different (the curated SESSION_EXPIRED copy must always win on terminal 401, regardless of backend prose, because the session is dead). No change recommended there.

I will file the 500+ follow-up as a separate issue, NOT in this PR.

## Out of scope

- Stream P: auth forms + AuthContext error extraction (#274/#277/#278/#279)
- Stream R: RegisterPage navigation (#276)
- `startTranslation.ts:130` existence-leak (separate backend concern)
- `api.ts:423-430` 500-class bug-class match (separate follow-up)

## Test plan

- [x] `npm ci && npx tsc --noEmit` (cold + warm) — frontend
- [x] `npm run lint` — frontend
- [x] `npx prettier --check .` — frontend
- [x] `npx vitest --run --coverage` — frontend (CI-parity command)
- [x] `npm test` — backend/functions
- [x] `npm test` — backend/infrastructure
- [x] `npm test` — shared-types

Closes #275