### PR TITLE
fix(auth): RegisterPage auto-login surfaces actual error cause (#276)

### DIFF
--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -8,9 +8,13 @@
  *   1. POST /auth/register succeeds (201, no tokens returned by real backend).
  *   2. Silently attempt login with the same credentials via the shared login().
  *   3a. Login succeeds  → navigate to /dashboard (user is already authenticated).
- *   3b. Login fails     → navigate to /login with a friendly message in router
- *       state so the user can sign in manually without losing their credentials.
- *       The RegisterForm surfaces the error; this page does NOT crash.
+ *   3b. Login fails     → navigate to /login with a router-state message of
+ *       the form `"Account created. <actual-cause>"`. The actual-cause text
+ *       is produced by the shared `getApiErrorMessage` extractor (issue
+ *       #276), so the user sees the real failure (rate limit, network outage,
+ *       email verification required, etc.) rather than a hardcoded
+ *       "check your email" hint that misfires on every non-verification
+ *       cause. The RegisterForm surfaces the error too; this page does NOT crash.
  */
 
 import { useNavigate } from 'react-router-dom';
@@ -19,6 +23,7 @@ import { RegisterForm } from '../components/Auth/RegisterForm';
 import { useAuth } from '../contexts/AuthContext';
 import { ROUTES } from '../config/constants';
 import type { RegisterRequest } from '../services/authService';
+import { getApiErrorMessage } from '../utils/translationErrorMessages';
 
 export default function RegisterPage() {
   const navigate = useNavigate();
@@ -49,14 +54,25 @@ export default function RegisterPage() {
     try {
       await login({ email: formData.email, password: formData.password });
       navigate(ROUTES.DASHBOARD);
-    } catch {
-      // Auto-login failed (e.g., prod env where email verification is still
-      // required, or a transient network error). Redirect to /login and pass
-      // a friendly hint so the user knows their account was created.
+    } catch (autoLoginError) {
+      // Issue #276: Registration succeeded but the auto-login leg failed.
+      // Possible causes are heterogeneous: 429 (Cognito rate limit on the
+      // immediate follow-up InitiateAuth), 403 (email verification required
+      // in prod), 5xx (transient backend), or a network outage. The previous
+      // implementation swallowed the error with `catch {}` and surfaced a
+      // hardcoded "check your email" hint regardless of cause — actively
+      // misleading for the rate-limit / network cases.
+      //
+      // We route the actual error through the shared `getApiErrorMessage`
+      // extractor (the same one the upload wizard and translation pages use)
+      // and prefix it with "Account created." so the user keeps the positive
+      // confirmation about the registration leg AND learns what to actually
+      // do next (verify email, wait and retry, etc.). The /login route reads
+      // `state.message` and renders it verbatim in an info <Alert>.
+      const errorMessage = getApiErrorMessage(autoLoginError);
       navigate(ROUTES.LOGIN, {
         state: {
-          message:
-            'Account created! Please sign in — check your email if verification is required.',
+          message: `Account created. ${errorMessage}`,
         },
       });
     }

--- a/frontend/src/pages/__tests__/RegisterPage.test.tsx
+++ b/frontend/src/pages/__tests__/RegisterPage.test.tsx
@@ -260,6 +260,159 @@ describe('RegisterPage - Integration Tests', () => {
       // Friendly message should be visible on the login page
       expect(screen.getByText(/account created/i)).toBeInTheDocument();
     });
+
+    /**
+     * Issue #276: surface the ACTUAL auto-login failure cause via
+     * `getApiErrorMessage`, not a hardcoded "check your email" hint.
+     *
+     * Each case below verifies that:
+     *   1. The user lands on /login (graceful fallback, no crash).
+     *   2. The router-state message starts with "Account created." (preserves
+     *      the positive confirmation about the registration leg).
+     *   3. The message body matches the cause-specific extractor output —
+     *      NOT the old hardcoded email-verification copy.
+     */
+    describe('Issue #276: error-cause-aware fallback message', () => {
+      it('429 rate limit → "Account created." + backend rate-limit message', async () => {
+        // Simulates Cognito's TooManyRequestsException tripping on the
+        // immediate post-register InitiateAuth call (login.ts:182-194).
+        server.use(
+          http.post(/\/auth\/login$/, () => {
+            return HttpResponse.json(
+              { message: 'Too many login attempts. Please try again later.' },
+              { status: 429 }
+            );
+          })
+        );
+
+        const user = userEvent.setup();
+        renderWithAppContext();
+
+        await fillAndSubmitForm(user);
+
+        // Lands on /login (not on dashboard, not stuck on /register).
+        await waitFor(
+          () => {
+            expect(screen.getByRole('button', { name: /log in/i })).toBeInTheDocument();
+          },
+          { timeout: 3000 }
+        );
+
+        // Prefix preserved.
+        const alert = await screen.findByText(/account created\./i);
+        expect(alert).toBeInTheDocument();
+        // Cause-specific message surfaced — NOT the old "check your email"
+        // copy. getApiErrorMessage passes the non-generic backend prose
+        // through verbatim.
+        expect(alert.textContent).toMatch(/too many login attempts/i);
+        // Negative assertion: the misleading hardcoded copy from before
+        // the #276 fix MUST NOT appear.
+        expect(alert.textContent).not.toMatch(/check your email/i);
+      });
+
+      it('403 UserNotConfirmedException → "Account created." + backend verification prose', async () => {
+        // Production scenario: Cognito requires email confirmation before
+        // login. After issue #275 lands, the backend prose passes through
+        // the 403 interceptor verbatim; before #275, ERROR_MESSAGES.UNAUTHORIZED
+        // is surfaced — both are non-misleading-in-context, the test below
+        // accepts either by asserting on the "Account created." prefix and
+        // absence of the OLD hardcoded "check your email if verification
+        // is required" string.
+        server.use(
+          http.post(/\/auth\/login$/, () => {
+            return HttpResponse.json(
+              { message: 'Please verify your email address before logging in.' },
+              { status: 403 }
+            );
+          })
+        );
+
+        const user = userEvent.setup();
+        renderWithAppContext();
+
+        await fillAndSubmitForm(user);
+
+        await waitFor(
+          () => {
+            expect(screen.getByRole('button', { name: /log in/i })).toBeInTheDocument();
+          },
+          { timeout: 3000 }
+        );
+
+        const alert = await screen.findByText(/account created\./i);
+        expect(alert).toBeInTheDocument();
+        // The user is NOT shown the misleading conditional phrasing
+        // ("check your email IF verification is required") regardless of
+        // which side of #275 we're on. They see either the verbatim backend
+        // prose ("Please verify your email…") or ERROR_MESSAGES.UNAUTHORIZED
+        // ("You do not have permission…"). Both are deterministic.
+        expect(alert.textContent).not.toMatch(/check your email if verification is required/i);
+      });
+
+      it('network error → "Account created." + NETWORK_MESSAGE-style copy', async () => {
+        // Simulates total transport failure between register-success and the
+        // login attempt. MSW's `HttpResponse.error()` triggers axios's
+        // ERR_NETWORK path (no response object reaches the interceptor).
+        server.use(
+          http.post(/\/auth\/login$/, () => {
+            return HttpResponse.error();
+          })
+        );
+
+        const user = userEvent.setup();
+        renderWithAppContext();
+
+        await fillAndSubmitForm(user);
+
+        await waitFor(
+          () => {
+            expect(screen.getByRole('button', { name: /log in/i })).toBeInTheDocument();
+          },
+          { timeout: 3000 }
+        );
+
+        const alert = await screen.findByText(/account created\./i);
+        expect(alert).toBeInTheDocument();
+        // Either the api.ts NETWORK_ERROR constant ("Network error. Please
+        // check your connection and try again.") OR the
+        // translationErrorMessages NETWORK_MESSAGE ("Connection lost — check
+        // your internet and try again.") — both pass through the extractor.
+        // The unifying invariant for the test is: the message mentions
+        // network/connection AND does NOT promote the old email-verification
+        // hint.
+        expect(alert.textContent).toMatch(/network|connection/i);
+        expect(alert.textContent).not.toMatch(/check your email/i);
+      });
+
+      it('500 server error → "Account created." + server-error copy', async () => {
+        // Simulates the generic 5xx catch-all from login.ts:197-208.
+        server.use(
+          http.post(/\/auth\/login$/, () => {
+            return HttpResponse.json({ message: 'Internal server error' }, { status: 500 });
+          })
+        );
+
+        const user = userEvent.setup();
+        renderWithAppContext();
+
+        await fillAndSubmitForm(user);
+
+        await waitFor(
+          () => {
+            expect(screen.getByRole('button', { name: /log in/i })).toBeInTheDocument();
+          },
+          { timeout: 3000 }
+        );
+
+        const alert = await screen.findByText(/account created\./i);
+        expect(alert).toBeInTheDocument();
+        // The api.ts 5xx branch overrides the backend message with
+        // ERROR_MESSAGES.SERVER_ERROR ("Server error. Please try again
+        // later.") — non-generic, passes through the extractor verbatim.
+        expect(alert.textContent).toMatch(/server error/i);
+        expect(alert.textContent).not.toMatch(/check your email/i);
+      });
+    });
   });
 
   describe('Loading States', () => {


### PR DESCRIPTION
## Summary

Fixes #276. The post-register auto-login `catch {}` block in `RegisterPage.tsx` was swallowing the actual error and surfacing a hardcoded `"Account created! Please sign in — check your email if verification is required."` regardless of cause — actively misleading whenever the auto-login failed for a reason other than email verification (Cognito's per-IP rate limit tripping on the immediate follow-up `InitiateAuth`, a transient 5xx, or a network outage). We now capture the error, route it through the shared `getApiErrorMessage` extractor (the same one the upload wizard and translation pages use), and prefix it with `"Account created. "` so the user keeps the positive confirmation about the registration leg AND learns what to actually do next.

## Before / After

**Before** (`frontend/src/pages/RegisterPage.tsx:49-62`):

```ts
try {
  await login({ email: formData.email, password: formData.password });
  navigate(ROUTES.DASHBOARD);
} catch {
  navigate(ROUTES.LOGIN, {
    state: {
      message:
        'Account created! Please sign in — check your email if verification is required.',
    },
  });
}
```

**After**:

```ts
try {
  await login({ email: formData.email, password: formData.password });
  navigate(ROUTES.DASHBOARD);
} catch (autoLoginError) {
  const errorMessage = getApiErrorMessage(autoLoginError);
  navigate(ROUTES.LOGIN, {
    state: {
      message: `Account created. ${errorMessage}`,
    },
  });
}
```

## Composition with Streams P + Q

- **Stream Q (#275)** preserves backend prose on 403 in the api.ts interceptor. When both fixes land, a 403 `UserNotConfirmedException` from `/auth/login` will (a) carry the backend's verification prose through the interceptor (Stream Q), (b) reach this catch block with that prose (this PR), and (c) be rendered verbatim via `getApiErrorMessage` (this PR). Pre-#275 the user sees `ERROR_MESSAGES.UNAUTHORIZED` instead — still non-misleading, just less specific. The order of landing does not matter.
- **Stream P (#274/#277/#278/#279)** touches `frontend/src/components/Auth/*.tsx` + `AuthContext.tsx`. No file overlap with this PR. The `useAuth().login()` call signature and error-throwing semantics are unchanged regardless of whether Option B (delete `AuthContext.error`) lands — RegisterPage still receives the same thrown error.

## LoginPage state.message handling — verified, no change needed

`frontend/src/pages/LoginPage.tsx:30-50` reads `(location.state as LoginLocationState | null)?.message` and renders it verbatim inside an MUI `<Alert severity="info">`. There is no string-matching on the old hardcoded copy, no length cap, and no post-processing — the new variable-length `"Account created. <real-cause>"` message will render correctly as-is.

## Test counts

| Package                 | Before          | After           | Delta |
| ----------------------- | --------------- | --------------- | ----- |
| Frontend                | 795 passed      | 799 passed      | +4    |
| Backend functions       | 626 passed      | 626 passed      | 0     |
| Backend infrastructure  | 91 passed       | 91 passed       | 0     |
| Shared types            | 24 passed       | 24 passed       | 0     |

Four new failure-mode tests in `frontend/src/pages/__tests__/RegisterPage.test.tsx > Issue #276`:

1. **429 rate limit** → asserts `"Account created."` prefix + backend rate-limit prose + absence of `"check your email"`.
2. **403 UserNotConfirmedException** → asserts `"Account created."` prefix + absence of the misleading `"check your email if verification is required"` conditional.
3. **Network error** (`HttpResponse.error()`) → asserts `"Account created."` prefix + a network/connection-mention + absence of `"check your email"`.
4. **500 server error** → asserts `"Account created."` prefix + server-error copy + absence of `"check your email"`.

Coverage: `RegisterPage.tsx` at **100%** statements/branches/funcs/lines.

## Validation evidence

```
cd frontend && rm -rf node_modules && npm ci          # OK
npx tsc --noEmit (cold + warm)                        # OK
npm run lint                                          # OK (0 warnings)
npx prettier --check (changed files)                  # OK
npx vitest --run --coverage                           # 38 files, 799 passed
cd backend/functions && npm test                      # 30 suites, 626 passed
cd backend/infrastructure && npm test                 # 91 passed
cd shared-types && npm test                           # 24 passed
```

## Test plan

- [x] `RegisterPage.tsx` — 100% line/branch coverage retained.
- [x] Auto-login success → `/dashboard` (regression guard).
- [x] Auto-login fails with 429 → `/login` shows real rate-limit message.
- [x] Auto-login fails with 403 → `/login` shows non-misleading verification message.
- [x] Auto-login fails with network outage → `/login` shows network message.
- [x] Auto-login fails with 500 → `/login` shows server-error message.
- [x] No changes to `LoginPage.tsx` (verified rendering path).
- [x] No file overlap with Streams P or Q.

Closes #276