### PR TITLE
tech-debt(api): preserve backend message on 500+ (#284)

### DIFF
--- a/frontend/src/pages/__tests__/RegisterPage.test.tsx
+++ b/frontend/src/pages/__tests__/RegisterPage.test.tsx
@@ -406,9 +406,14 @@ describe('RegisterPage - Integration Tests', () => {
 
         const alert = await screen.findByText(/account created\./i);
         expect(alert).toBeInTheDocument();
-        // The api.ts 5xx branch overrides the backend message with
-        // ERROR_MESSAGES.SERVER_ERROR ("Server error. Please try again
-        // later.") — non-generic, passes through the extractor verbatim.
+        // Post-#284 the api.ts 5xx branch surfaces the backend message
+        // verbatim when it is specific (mirrors the 403 precedence
+        // PR #283 added). "Internal server error" is NOT in the
+        // GENERIC_BACKEND_MESSAGES deny-list so it passes through
+        // verbatim — which still satisfies the /server error/i match
+        // here. The unifying invariant for this test is: the message
+        // mentions "server error" AND does NOT promote the email-
+        // verification hint.
         expect(alert.textContent).toMatch(/server error/i);
         expect(alert.textContent).not.toMatch(/check your email/i);
       });

--- a/frontend/src/utils/__tests__/api.test.ts
+++ b/frontend/src/utils/__tests__/api.test.ts
@@ -876,17 +876,189 @@ describe('API Client - Response Error Interceptor', () => {
     }
   });
 
-  it('should handle server errors (500+)', async () => {
+  // Issue #284: 500+ backend-message precedence (sibling of #275 / PR #283).
+  //
+  // Pre-#284 the 500+ branch clobbered every backend message with the
+  // generic `ERROR_MESSAGES.SERVER_ERROR` constant, the same bug class
+  // as #275. Post-#284 the precedence matches the 403 branch exactly:
+  // specific backend message wins; generic backend message OR absent
+  // backend message falls back to the `ERROR_MESSAGES.SERVER_ERROR`
+  // constant. The deny-list guard prevents an opaque "Request failed"
+  // / "An unexpected error occurred" from re-introducing the issue #266
+  // bug class.
+  //
+  // The 401 branch above remains intentionally different — the curated
+  // SESSION_EXPIRED copy must always win on terminal 401.
+
+  it('500+: surfaces specific backend message verbatim (issue #284 load-bearing case)', async () => {
     const { createApiClient } = await import('../api');
     const client = createApiClient();
 
-    // Mock adapter to simulate 500 error
+    // Mock adapter to simulate a 500 carrying a specific, actionable
+    // backend phrase. The pre-#284 implementation would clobber
+    // `error.message` with "Server error. Please try again later." —
+    // destroying useful operator/dev signal (e.g. a translation worker
+    // returning "Translation provider quota exhausted — retry in 5
+    // minutes.").
     client.defaults.adapter = async () => {
       const error: any = new Error('Request failed with status code 500');
       error.isAxiosError = true;
       error.response = {
         status: 500,
-        data: { message: 'Internal server error' },
+        data: {
+          message: 'Translation provider quota exhausted — retry in 5 minutes.',
+          requestId: 'req-xyz',
+        },
+        statusText: 'Internal Server Error',
+        headers: {},
+        config: {},
+      };
+      throw error;
+    };
+
+    try {
+      await client.get('/crash');
+      expect.fail('Should have thrown an error');
+    } catch (error: any) {
+      expect(error.status).toBe(500);
+      expect(error.message).toBe('Translation provider quota exhausted — retry in 5 minutes.');
+      // The raw envelope is preserved for downstream consumers.
+      expect(error.data).toEqual({
+        message: 'Translation provider quota exhausted — retry in 5 minutes.',
+        requestId: 'req-xyz',
+      });
+    }
+  });
+
+  it('500+: falls back to SERVER_ERROR constant when backend message is in the GENERIC deny-list', async () => {
+    const { createApiClient } = await import('../api');
+    const client = createApiClient();
+
+    // API Gateway integration 500 (no specific prose, just "Request
+    // failed"). Surfacing "Request failed" verbatim would re-introduce
+    // the issue #266 "An unexpected error occurred" class problem, so
+    // the deny-list routes us to the curated SERVER_ERROR copy.
+    client.defaults.adapter = async () => {
+      const error: any = new Error('Request failed with status code 500');
+      error.isAxiosError = true;
+      error.response = {
+        status: 500,
+        data: { message: 'Request failed' },
+        statusText: 'Internal Server Error',
+        headers: {},
+        config: {},
+      };
+      throw error;
+    };
+
+    try {
+      await client.get('/crash');
+      expect.fail('Should have thrown an error');
+    } catch (error: any) {
+      expect(error.status).toBe(500);
+      expect(error.message).toBe('Server error. Please try again later.');
+    }
+  });
+
+  it('500+: falls back to SERVER_ERROR constant when response body has no message field', async () => {
+    const { createApiClient } = await import('../api');
+    const client = createApiClient();
+
+    // Some 5xx responses (e.g. raw upstream timeouts, opaque API Gateway
+    // 504s) carry no message field at all. Fall back to the curated copy.
+    client.defaults.adapter = async () => {
+      const error: any = new Error('Request failed with status code 502');
+      error.isAxiosError = true;
+      error.response = {
+        status: 502,
+        data: {},
+        statusText: 'Bad Gateway',
+        headers: {},
+        config: {},
+      };
+      throw error;
+    };
+
+    try {
+      await client.get('/crash');
+      expect.fail('Should have thrown an error');
+    } catch (error: any) {
+      expect(error.status).toBe(502);
+      expect(error.message).toBe('Server error. Please try again later.');
+    }
+  });
+
+  it('500+: falls back to SERVER_ERROR constant when backend message is whitespace only', async () => {
+    const { createApiClient } = await import('../api');
+    const client = createApiClient();
+
+    client.defaults.adapter = async () => {
+      const error: any = new Error('Request failed with status code 503');
+      error.isAxiosError = true;
+      error.response = {
+        status: 503,
+        data: { message: '   \t  \n' },
+        statusText: 'Service Unavailable',
+        headers: {},
+        config: {},
+      };
+      throw error;
+    };
+
+    try {
+      await client.get('/crash');
+      expect.fail('Should have thrown an error');
+    } catch (error: any) {
+      expect(error.status).toBe(503);
+      expect(error.message).toBe('Server error. Please try again later.');
+    }
+  });
+
+  it('500+: falls back to SERVER_ERROR constant when response body is not an object', async () => {
+    const { createApiClient } = await import('../api');
+    const client = createApiClient();
+
+    // Defensive: if some upstream layer returns a string body (e.g. an
+    // HTML error page from a misconfigured proxy that axios decoded as
+    // text), the extractor must not treat that as a usable message.
+    client.defaults.adapter = async () => {
+      const error: any = new Error('Request failed with status code 500');
+      error.isAxiosError = true;
+      error.response = {
+        status: 500,
+        // axios may sometimes pass through plain-string error bodies
+        // when content-type isn't json. The extractor returns undefined
+        // for any non-object data.
+        data: 'Internal Server Error',
+        statusText: 'Internal Server Error',
+        headers: {},
+        config: {},
+      };
+      throw error;
+    };
+
+    try {
+      await client.get('/crash');
+      expect.fail('Should have thrown an error');
+    } catch (error: any) {
+      expect(error.status).toBe(500);
+      expect(error.message).toBe('Server error. Please try again later.');
+    }
+  });
+
+  it('500+: deny-list match is case-insensitive (defense against backend casing drift)', async () => {
+    const { createApiClient } = await import('../api');
+    const client = createApiClient();
+
+    // Backend or upstream may emit "REQUEST FAILED" or "An Unexpected
+    // Error Occurred" depending on layer/locale. The deny-list normalizes
+    // via .toLowerCase() so all variants fall back to the curated copy.
+    client.defaults.adapter = async () => {
+      const error: any = new Error('Request failed with status code 500');
+      error.isAxiosError = true;
+      error.response = {
+        status: 500,
+        data: { message: 'An Unexpected Error Occurred' },
         statusText: 'Internal Server Error',
         headers: {},
         config: {},

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -73,6 +73,14 @@ const GENERIC_BACKEND_MESSAGES = new Set(
  * `UserNotConfirmedException`. Extracted as a helper rather than
  * inlined so other status-code branches can adopt the same pattern
  * if needed without re-implementing the deny-list logic.
+ *
+ * Issue #284 (sibling): the 500+ branch adopted the same precedence
+ * rule, making this helper the shared implementation for both 403 and
+ * 500+ message extraction. The 401 branch is intentionally NOT a
+ * caller — the curated `SESSION_EXPIRED` copy must always win on
+ * terminal 401. Kept module-private at two callers per the
+ * GENERIC_BACKEND_MESSAGES comment ("If a third caller appears,
+ * promote this constant to a shared util").
  */
 function extractBackendMessage(data: unknown): string | undefined {
   if (!data || typeof data !== 'object') {
@@ -504,9 +512,25 @@ async function responseErrorInterceptor(error: unknown): Promise<unknown> {
   }
 
   // Handle server errors (500+)
+  //
+  // Issue #284 (sibling of #275 / PR #283): mirror the precedence rule the
+  // 403 branch established. Prefer the backend's user-facing prose when
+  // present and specific; only fall back to the curated
+  // `ERROR_MESSAGES.SERVER_ERROR` constant when the backend message is
+  // absent OR matches the `GENERIC_BACKEND_MESSAGES` deny-list. The
+  // pre-fix code unconditionally clobbered the backend message, the same
+  // bug class as #275 — discovered while scoping PR #283 and called out
+  // as out-of-scope in that PR's body, then filed as #284 for parity.
+  //
+  // The 401 branch above is intentionally DIFFERENT: the curated
+  // `SESSION_EXPIRED` copy must always win on terminal 401 (the session
+  // is dead regardless of backend prose). Do not propagate this pattern
+  // there.
   if (axiosError.response.status >= 500) {
+    const backendMessage = extractBackendMessage(axiosError.response.data);
+
     const apiError: ApiError = {
-      message: ERROR_MESSAGES.SERVER_ERROR,
+      message: backendMessage ?? ERROR_MESSAGES.SERVER_ERROR,
       status: axiosError.response.status,
       data: axiosError.response.data,
     };


### PR DESCRIPTION
## Summary

The axios response-error interceptor's 500+ branch in `frontend/src/utils/api.ts` unconditionally overwrote the backend's `message` with the generic `ERROR_MESSAGES.SERVER_ERROR` constant ("Server error. Please try again later."). This silently destroyed user-facing prose any future backend 5xx emitter would produce (e.g. a translation worker emitting `"Translation provider quota exhausted — retry in 5 minutes."`) — the exact same bug class as #275, scoped out of PR #283 and filed as #284 for parity.

This PR applies the precedence rule PR #283 established for 403, now to 500+: surface the backend message verbatim when it is specific; fall back to the curated `ERROR_MESSAGES.SERVER_ERROR` constant when the message is absent, empty/whitespace, on a non-object body, or in the `GENERIC_BACKEND_MESSAGES` deny-list. The fix reuses the existing module-private `extractBackendMessage` helper without modification.

## Scope

**In scope:**
- `frontend/src/utils/api.ts` — 500+ interceptor branch precedence fix (one call site, one new conditional).
- `frontend/src/utils/__tests__/api.test.ts` — five new 500+ tests + one rewritten existing test, mirroring the 403 test matrix PR #283 added.
- `frontend/src/pages/__tests__/RegisterPage.test.tsx` — comment-only adjustment to keep the "/server error/i" test's rationale aligned with the new post-#284 behavior (the assertion itself is unchanged and still passes).

**Deliberately NOT in scope:**
- The 401 branch — the issue explicitly preserves it. The curated `SESSION_EXPIRED` copy must always win on terminal 401 because the session is dead regardless of backend prose. Touching it would have re-introduced #275-class regressions in the opposite direction.
- The 400/422 validation branch — its current behavior (`backendMessage || ERROR_MESSAGES.VALIDATION_ERROR`) does not use the deny-list, so a vague `"Request failed"` backend message could in theory surface verbatim. This is a known pre-existing pattern, not introduced by this PR, and out of scope per #284's framing.
- The `data?.message` "other HTTP errors" tail branch (`api.ts:518+`) — same shape as 400/422; same out-of-scope reasoning.
- Promoting `extractBackendMessage` to a shared util — see "Decisions" below; kept module-private at two callers.

## Helper-function decision: keep module-private

The existing comment block above `GENERIC_BACKEND_MESSAGES` in `api.ts` explicitly states: **"If a third caller appears, promote this constant to a shared util."** Before this PR there was one caller (403); after this PR there are two callers (403 + 500+). Per the comment's rule and the issue body's "promote if a third caller appears" guidance, I kept it module-private. Promoting at two callers would be speculative.

I updated the helper's docstring to reflect that it now has two callers and to spell out why the 401 branch is intentionally NOT a third caller (curated SESSION_EXPIRED copy must always win on terminal 401).

## Test coverage matrix

Mirror exactly the 403 matrix PR #283 added. Existing 500+ test (the original `'Internal server error'` fixture which expected the SERVER_ERROR override) was rewritten as the deny-list case to keep the negative-path coverage; five new cases added for the affirmative-path, empty-body, whitespace, non-object body, and case-insensitive-deny-list scenarios.

| # | Case | Backend body | Expected `error.message` |
| - | --- | --- | --- |
| 1 | Specific backend prose (load-bearing) | `{ message: "Translation provider quota exhausted — retry in 5 minutes.", requestId: "req-xyz" }` | verbatim backend prose |
| 2 | Deny-list match | `{ message: "Request failed" }` | `ERROR_MESSAGES.SERVER_ERROR` |
| 3 | Empty body | `{}` | `ERROR_MESSAGES.SERVER_ERROR` |
| 4 | Whitespace-only | `{ message: "   \t  \n" }` | `ERROR_MESSAGES.SERVER_ERROR` |
| 5 | Non-object body (string) | `"Internal Server Error"` | `ERROR_MESSAGES.SERVER_ERROR` |
| 6 | Mixed-case deny-list | `{ message: "An Unexpected Error Occurred" }` | `ERROR_MESSAGES.SERVER_ERROR` |

Each test asserts both `error.status` (covering 500/502/503 across the matrix) and `error.message`. The load-bearing case (#1) also asserts `error.data` to confirm the raw envelope is preserved for downstream consumers (e.g. `getApiErrorMessage` which reads `data.errorCode`).

## Test counts (frontend)

| Metric | Before | After | Net |
| --- | --- | --- | --- |
| Test files | 38 passed | 38 passed | unchanged |
| Tests | 836 passed, 14 skipped | 841 passed, 14 skipped | **+5** |
| `api.ts` coverage | (PR #283 baseline) | 99.14% statements / 93.61% branches | maintained |

Net delta: **+5 frontend unit tests** (one pre-existing 500 test rewritten as the deny-list case; five new cases added).

## Security / privacy considerations

The 500+ contract dictates a human-readable phrase only (mirrors the issue body's "Why this is safe" section). Three layers of defense remain after this PR:

1. **Server-side prose contract**: backend 5xx emitters in `backend/functions/**` are spec-bound to human-readable phrases and never embed stack traces in the wire body. The right fix for any leak there is server-side, not a frontend deny-list arms race.
2. **`GENERIC_BACKEND_MESSAGES` deny-list**: catches the most common vague variants (`"Request failed"`, `"An unexpected error occurred"`, `"Network error"`, `"Failed to fetch"`, `"Forbidden"`, `"Unauthorized"`), case-insensitive and trimmed.
3. **Non-object / empty / whitespace guards**: any malformed body shape falls back to the curated constant.

No new attack surface is introduced. The helper has been in production behind the 403 branch since PR #283 with no reported regressions.

## CI-parity validation (run locally, exact CI commands)

Cold install, exact CI commands in order. The CI's frontend pipeline is `lint-and-format` + `test-frontend`; both are mirrored below.

- [x] `cd shared-types && rm -rf node_modules && npm ci` — clean
- [x] `cd shared-types && npm run build` — clean (consumed by frontend type-check)
- [x] `cd frontend && rm -rf node_modules && npm ci` — clean (cold install, matches CI)
- [x] `cd frontend && npm run lint` — clean (eslint with `--max-warnings 0`)
- [x] `cd frontend && npm run format:check` — clean (`All matched files use Prettier code style!`)
- [x] `cd frontend && npm run type-check` — clean (`tsc --noEmit`)
- [x] `cd frontend && npm run test:coverage` — 841 passed, 14 skipped (`vitest run --coverage`)
- [x] `cd frontend && CI=true npm run build` — clean (matches CI's deploy build step)

No backend / infrastructure tests run — this is a frontend-only PR. The `.github/workflows/ci.yml` frontend jobs (`lint-and-format` and `test-frontend`) cover the exact step pool above.

## What I checked

- The 401 branch is byte-identical to pre-PR — confirmed via `git diff main -- frontend/src/utils/api.ts | grep -n "401\|SESSION_EXPIRED"` (no hits in the diff).
- `extractBackendMessage` callers: pre-PR = 1 (403), post-PR = 2 (403 + 500+). Confirmed with `grep -rn "extractBackendMessage" frontend/src/`.
- No file outside `frontend/` is touched. Confirmed via `git diff --stat main`.
- The RegisterPage 500 integration test's assertion (`/server error/i`) is preserved; only the adjacent comment is updated because "Internal server error" now surfaces verbatim (and still matches the case-insensitive substring assertion).
- The translationService tests that use `mockedApiClient.post.mockRejectedValueOnce` do NOT go through the interceptor and are unaffected.
- The `api.refresh.test.ts` 500-path test uses `expect.any(String)` for the message assertion and is unaffected by the change.
- `tsc --noEmit` covers the test files (per the frontend `tsconfig.json` includes).
- Branch protections, reviewer config, and merge gates are untouched — the human user merges PRs themselves per repo convention.

## Residuals / follow-ups for the user to consider

Not filed by me — listed for the user's decision:

1. **400 / 422 validation branch** does `axiosError.response.data?.message || ERROR_MESSAGES.VALIDATION_ERROR` — no deny-list guard. A vague `"Request failed"` backend message on a 400 would surface verbatim today. Different bug class from #275/#284 because validation errors typically carry specific field-level prose, but worth a future tightening pass if the validation surface ever leaks a generic phrase.
2. **Tail "other HTTP errors" branch** (`api.ts:518+`) has the same shape as 400/422 — no deny-list. Same reasoning.
3. **`extractBackendMessage` promotion**: per the established rule, promote to a shared util the moment a third caller appears. Most likely candidate is the 400/422 hardening above.

Closes #284