### PR TITLE
security(api): timing side-channel measurement methodology + analytical conclusion (#288)

### DIFF
--- a/backend/scripts/security/.eslintrc.cjs
+++ b/backend/scripts/security/.eslintrc.cjs
@@ -1,0 +1,23 @@
+// Minimal ESLint config for the security measurement scripts.
+//
+// Scope: just enough to satisfy the root .lintstagedrc.json "eslint --fix"
+// pre-commit hook for *.ts files in this directory. The measurement script
+// is NOT part of CI lint (the backend/functions/.eslintrc.cjs is `root: true`
+// and only covers backend/functions/). This file exists solely so the
+// pre-commit hook does not fail on files in this directory.
+module.exports = {
+  root: true,
+  env: { node: true, es2022: true },
+  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
+  ignorePatterns: ['dist', '.eslintrc.cjs', 'node_modules'],
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module',
+  },
+  plugins: ['@typescript-eslint'],
+  rules: {
+    'no-console': 'off',
+    '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+  },
+};

--- a/backend/scripts/security/package-lock.json
+++ b/backend/scripts/security/package-lock.json
@@ -1,0 +1,235 @@
+{
+  "name": "@lfmt/security-scripts",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@lfmt/security-scripts",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@types/node": "^20.10.4",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.3.3"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
+      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  }
+}

--- a/backend/scripts/security/package.json
+++ b/backend/scripts/security/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@lfmt/security-scripts",
+  "version": "1.0.0",
+  "description": "Security measurement scripts for LFMT — timing side-channel etc. Run on demand, not in CI.",
+  "private": true,
+  "scripts": {
+    "timing-sidechannel": "ts-node timing-sidechannel-measurement.ts",
+    "timing-sidechannel:smoke": "ts-node timing-sidechannel-measurement.ts --smoke"
+  },
+  "devDependencies": {
+    "@types/node": "^20.10.4",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.3.3"
+  }
+}

--- a/backend/scripts/security/timing-sidechannel-measurement.ts
+++ b/backend/scripts/security/timing-sidechannel-measurement.ts
@@ -1,0 +1,612 @@
+/**
+ * Timing Side-Channel Measurement — issue #288
+ *
+ * Purpose
+ * -------
+ * After PR #287 collapsed the not-found and not-owned response branches on the
+ * five ownership-checked endpoints into a single privacy-preserving 404, a
+ * timing side-channel residual remains: do those two cases take observably
+ * different amounts of wall-clock time? If so, a patient attacker could
+ * statistically distinguish them and recover the existence signal that
+ * PR #287 closed off at the response level.
+ *
+ * This script runs an empirical measurement and reports descriptive
+ * statistics plus a Welch's t-test p-value comparing the two distributions
+ * (not-found vs. not-owned). It is the canonical measurement methodology
+ * documented in `docs/cdk-best-practices.md` →
+ * "Timing side-channel — measurement methodology and results (post-#287)".
+ *
+ * The script is committed but NOT run automatically. The analytical
+ * conclusion in the doc is sufficient for the wontfix decision in v1; this
+ * script exists so a future engineer (or the same engineer at the point real
+ * users exist) can re-measure under their own access pattern, environment,
+ * and statistical-power requirements without re-deriving the methodology.
+ *
+ * Endpoints under test (post-#287 composite-key shape; see #286 audit table)
+ * --------------------------------------------------------------------------
+ *   POST   /jobs/{jobId}/translate              startTranslation.ts
+ *   GET    /jobs/{jobId}                        getJob.ts
+ *   GET    /jobs/{jobId}/translation-status     getTranslationStatus.ts
+ *   GET    /jobs/{jobId}/download               downloadTranslation.ts
+ *   DELETE /jobs/{jobId}                        deleteJob.ts
+ *
+ * Methodology
+ * -----------
+ * For a single endpoint:
+ *   1. Group A — "not found": request a freshly-generated random UUID that
+ *      cannot collide with any existing job in either user's namespace.
+ *      DDB GetItem returns no item; the handler emits 404.
+ *   2. Group B — "not owned": request a jobId that DOES exist but belongs to
+ *      a different user. DDB GetItem with the caller's userId on the composite
+ *      key also returns no item; the handler emits the identical 404.
+ *   3. Each group: N samples (default 200) of `performance.now()` deltas
+ *      around the HTTPS request. Samples are interleaved (A,B,A,B,...) to
+ *      cancel out warm/cold-Lambda drift across the run.
+ *   4. Discard the first MIN(10, N/10) samples per group as Lambda-warmup
+ *      noise.
+ *   5. Compute median, mean, std-dev, p99, IQR for each group.
+ *   6. Compute Welch's t-test p-value comparing the two means (robust to
+ *      unequal variance). Report whether |median_A − median_B| ≥ 1 ms — that
+ *      is the threshold from the issue #288 acceptance criteria above which
+ *      we would consider implementing Option A (constant-time floor).
+ *
+ * Auth & Setup
+ * ------------
+ * The script needs:
+ *   - An API base URL (defaults to dev: lfmt-poc API Gateway from CLAUDE.md).
+ *   - A valid Cognito ID token for the calling user (the not-owned target's
+ *     OTHER user). Acquire via your normal login flow; pass via the
+ *     LFMT_AUTH_TOKEN env var.
+ *   - A pre-existing jobId owned by some OTHER user (a different Cognito sub
+ *     than the auth token belongs to). Pass via the LFMT_NOT_OWNED_JOB_ID env
+ *     var. The "not-owned" measurement relies on this id resolving to a real
+ *     row in DynamoDB so the GetItem hits the storage layer the same way a
+ *     real cross-ownership probe would.
+ *
+ * The script does NOT modify any data. The 5 endpoints under test are all
+ * read-only in the not-found / not-owned case: the 404 short-circuits BEFORE
+ * any state mutation. (DELETE is read-only-on-failure because the
+ * ConditionExpression rejects the write.) Re-running is safe.
+ *
+ * Usage
+ * -----
+ *   # Smoke-mode (no auth required; runs only an unauthenticated 401 baseline
+ *   # to confirm the script + network plumbing works):
+ *   npx ts-node backend/scripts/security/timing-sidechannel-measurement.ts \
+ *     --endpoint=getJob --samples=50 --smoke
+ *
+ *   # Full empirical measurement (requires valid auth + not-owned jobId):
+ *   LFMT_AUTH_TOKEN=eyJ... \
+ *   LFMT_NOT_OWNED_JOB_ID=11111111-2222-3333-4444-555555555555 \
+ *   npx ts-node backend/scripts/security/timing-sidechannel-measurement.ts \
+ *     --endpoint=getJob --samples=200
+ *
+ *   # All five endpoints:
+ *   LFMT_AUTH_TOKEN=eyJ... \
+ *   LFMT_NOT_OWNED_JOB_ID=11111111-2222-3333-4444-555555555555 \
+ *   npx ts-node backend/scripts/security/timing-sidechannel-measurement.ts \
+ *     --endpoint=all --samples=200
+ *
+ * CLI flags
+ * ---------
+ *   --api-url=<url>           API base URL (default: dev API from CLAUDE.md)
+ *   --endpoint=<name>         getJob | getTranslationStatus | downloadTranslation
+ *                             | startTranslation | deleteJob | all
+ *   --samples=<int>           Sample count per group (default: 200, min: 30)
+ *   --smoke                   Don't require auth; only run a connectivity check
+ *   --json                    Emit a single JSON report at end of run
+ *   --help                    Show this header
+ *
+ * Out-of-scope
+ * ------------
+ *   - This script measures wall-clock time as observed by the caller. That
+ *     includes network jitter, TLS handshake, API Gateway routing, Lambda
+ *     warm-execution, and DDB GetItem. We are NOT trying to isolate the DDB
+ *     internal cache layer — the question we are answering is the
+ *     attacker-visible signal, which is the wall-clock observation.
+ *   - This script does not authenticate / provision the not-owned job. The
+ *     operator is expected to have a populated dev environment.
+ */
+
+import { performance } from 'node:perf_hooks';
+import { randomUUID } from 'node:crypto';
+
+// ---------------------------------------------------------------------------
+// CLI parsing
+// ---------------------------------------------------------------------------
+
+interface Args {
+  apiUrl: string;
+  endpoint: EndpointName | 'all';
+  samples: number;
+  smoke: boolean;
+  json: boolean;
+  help: boolean;
+}
+
+type EndpointName =
+  | 'getJob'
+  | 'getTranslationStatus'
+  | 'downloadTranslation'
+  | 'startTranslation'
+  | 'deleteJob';
+
+const DEFAULT_API_URL = 'https://8brwlwf68h.execute-api.us-east-1.amazonaws.com/v1';
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = {
+    apiUrl: DEFAULT_API_URL,
+    endpoint: 'getJob',
+    samples: 200,
+    smoke: false,
+    json: false,
+    help: false,
+  };
+
+  for (const a of argv) {
+    if (a === '--help' || a === '-h') {
+      args.help = true;
+    } else if (a === '--smoke') {
+      args.smoke = true;
+    } else if (a === '--json') {
+      args.json = true;
+    } else if (a.startsWith('--api-url=')) {
+      args.apiUrl = a.slice('--api-url='.length);
+    } else if (a.startsWith('--endpoint=')) {
+      const ep = a.slice('--endpoint='.length);
+      if (
+        ep === 'getJob' ||
+        ep === 'getTranslationStatus' ||
+        ep === 'downloadTranslation' ||
+        ep === 'startTranslation' ||
+        ep === 'deleteJob' ||
+        ep === 'all'
+      ) {
+        args.endpoint = ep;
+      } else {
+        throw new Error(`Unknown endpoint: ${ep}`);
+      }
+    } else if (a.startsWith('--samples=')) {
+      const n = parseInt(a.slice('--samples='.length), 10);
+      if (Number.isNaN(n) || n < 30) {
+        throw new Error('--samples must be an integer >= 30');
+      }
+      args.samples = n;
+    }
+  }
+
+  return args;
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint definitions
+// ---------------------------------------------------------------------------
+
+interface EndpointSpec {
+  name: EndpointName;
+  method: 'GET' | 'POST' | 'DELETE';
+  /** Path template — `{jobId}` placeholder is substituted at request time. */
+  pathTemplate: string;
+  /** JSON body builder (POST only). Returns undefined for GET / DELETE. */
+  buildBody?: () => unknown;
+}
+
+const ENDPOINTS: Record<EndpointName, EndpointSpec> = {
+  getJob: {
+    name: 'getJob',
+    method: 'GET',
+    pathTemplate: '/jobs/{jobId}',
+  },
+  getTranslationStatus: {
+    name: 'getTranslationStatus',
+    method: 'GET',
+    pathTemplate: '/jobs/{jobId}/translation-status',
+  },
+  downloadTranslation: {
+    name: 'downloadTranslation',
+    method: 'GET',
+    pathTemplate: '/jobs/{jobId}/download',
+  },
+  startTranslation: {
+    name: 'startTranslation',
+    method: 'POST',
+    pathTemplate: '/jobs/{jobId}/translate',
+    // Minimal valid body — handler should reach the loadJob branch BEFORE
+    // body-validation matters for not-found / not-owned cases (it does in
+    // post-#287 code), but we send a valid body to be safe.
+    buildBody: () => ({ targetLanguage: 'es' }),
+  },
+  deleteJob: {
+    name: 'deleteJob',
+    method: 'DELETE',
+    pathTemplate: '/jobs/{jobId}',
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Sample collection
+// ---------------------------------------------------------------------------
+
+interface Sample {
+  group: 'not-found' | 'not-owned';
+  durationMs: number;
+  status: number;
+  /** Best-effort body fingerprint (length-only — we never log job ids). */
+  bodyLength: number;
+}
+
+async function timedRequest(
+  apiUrl: string,
+  spec: EndpointSpec,
+  jobId: string,
+  authToken: string | undefined
+): Promise<{ durationMs: number; status: number; bodyLength: number }> {
+  const url = apiUrl + spec.pathTemplate.replace('{jobId}', jobId);
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+  if (authToken) {
+    headers['Authorization'] = `Bearer ${authToken}`;
+  }
+
+  const init: RequestInit = {
+    method: spec.method,
+    headers,
+  };
+
+  if (spec.buildBody) {
+    init.body = JSON.stringify(spec.buildBody());
+  }
+
+  const start = performance.now();
+  const response = await fetch(url, init);
+  const text = await response.text();
+  const end = performance.now();
+
+  return {
+    durationMs: end - start,
+    status: response.status,
+    bodyLength: text.length,
+  };
+}
+
+async function collectSamples(
+  apiUrl: string,
+  spec: EndpointSpec,
+  authToken: string | undefined,
+  notOwnedJobId: string,
+  samples: number
+): Promise<Sample[]> {
+  const out: Sample[] = [];
+
+  // Interleave the two groups so any drift across the run (warm-up,
+  // network conditions, neighbor noise) affects both groups equally.
+  for (let i = 0; i < samples; i++) {
+    // Not-found: fresh UUID per request. Guaranteed not to collide.
+    const notFoundId = randomUUID();
+    const a = await timedRequest(apiUrl, spec, notFoundId, authToken);
+    out.push({
+      group: 'not-found',
+      durationMs: a.durationMs,
+      status: a.status,
+      bodyLength: a.bodyLength,
+    });
+
+    // Not-owned: a real jobId that belongs to a different user. DDB GetItem
+    // with this caller's composite key returns no item → identical 404.
+    const b = await timedRequest(apiUrl, spec, notOwnedJobId, authToken);
+    out.push({
+      group: 'not-owned',
+      durationMs: b.durationMs,
+      status: b.status,
+      bodyLength: b.bodyLength,
+    });
+  }
+
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Statistics
+// ---------------------------------------------------------------------------
+
+interface GroupStats {
+  group: 'not-found' | 'not-owned';
+  n: number;
+  mean: number;
+  median: number;
+  stdDev: number;
+  p99: number;
+  iqr: number;
+  /** Distribution of HTTP status codes returned in this group. */
+  statusDistribution: Record<number, number>;
+  /** Distribution of response-body lengths (sanity check: should be ~uniform). */
+  bodyLengthDistribution: { min: number; max: number; median: number };
+}
+
+function quantile(sorted: number[], q: number): number {
+  if (sorted.length === 0) return NaN;
+  const pos = (sorted.length - 1) * q;
+  const lo = Math.floor(pos);
+  const hi = Math.ceil(pos);
+  if (lo === hi) return sorted[lo];
+  return sorted[lo] + (sorted[hi] - sorted[lo]) * (pos - lo);
+}
+
+function summarize(samples: Sample[], group: 'not-found' | 'not-owned'): GroupStats {
+  const inGroup = samples.filter((s) => s.group === group);
+  // Discard the first MIN(10, N/10) samples per group as warmup noise.
+  const warmupDiscard = Math.min(10, Math.floor(inGroup.length / 10));
+  const usable = inGroup.slice(warmupDiscard);
+
+  const durations = usable.map((s) => s.durationMs).sort((a, b) => a - b);
+  const n = durations.length;
+  const sum = durations.reduce((acc, x) => acc + x, 0);
+  const mean = sum / Math.max(1, n);
+  const variance = durations.reduce((acc, x) => acc + (x - mean) ** 2, 0) / Math.max(1, n - 1);
+  const stdDev = Math.sqrt(variance);
+  const median = quantile(durations, 0.5);
+  const p99 = quantile(durations, 0.99);
+  const iqr = quantile(durations, 0.75) - quantile(durations, 0.25);
+
+  const statusDistribution: Record<number, number> = {};
+  for (const s of usable) {
+    statusDistribution[s.status] = (statusDistribution[s.status] ?? 0) + 1;
+  }
+
+  const lens = usable.map((s) => s.bodyLength).sort((a, b) => a - b);
+  const bodyLengthDistribution = {
+    min: lens[0] ?? 0,
+    max: lens[lens.length - 1] ?? 0,
+    median: quantile(lens, 0.5),
+  };
+
+  return {
+    group,
+    n,
+    mean,
+    median,
+    stdDev,
+    p99,
+    iqr,
+    statusDistribution,
+    bodyLengthDistribution,
+  };
+}
+
+/**
+ * Welch's t-test for unequal variances. Returns the two-sided p-value
+ * (approximated via the normal distribution for large N — we expect N ≥ 30
+ * per group, which is the documented adequacy threshold for the normal
+ * approximation in this context).
+ *
+ * Null hypothesis: the two groups have the same population mean.
+ * Reject (i.e., p < 0.05) → the two means are statistically distinguishable.
+ *
+ * This is a deliberate simplification: a research-grade analysis would use
+ * the t-distribution with Welch-Satterthwaite degrees of freedom, or a
+ * non-parametric Mann-Whitney U / Kolmogorov-Smirnov test (the latter is
+ * more robust to non-normal latency distributions). For the present
+ * "is the gap exploitable?" question, the normal approximation is sufficient
+ * — if the result is borderline (0.01 < p < 0.10), the operator should
+ * re-run with a larger N or switch to a non-parametric test. See the
+ * `Methodology — limitations` note at the top of this file.
+ */
+function welchsTTestPValue(a: GroupStats, b: GroupStats): number {
+  const se = Math.sqrt(a.stdDev ** 2 / a.n + b.stdDev ** 2 / b.n);
+  if (se === 0 || !isFinite(se)) return 1;
+  const z = (a.mean - b.mean) / se;
+  // Two-sided normal-tail probability — small p means the means are different.
+  // Use the complementary error function for numerical stability.
+  return erfc(Math.abs(z) / Math.sqrt(2));
+}
+
+/** Numerically-stable complementary error function (Abramowitz & Stegun 7.1.26). */
+function erfc(x: number): number {
+  // For x < 0 we return 2 - erfc(-x), but |z| above is always ≥ 0.
+  const t = 1.0 / (1.0 + 0.3275911 * x);
+  const a1 = 0.254829592;
+  const a2 = -0.284496736;
+  const a3 = 1.421413741;
+  const a4 = -1.453152027;
+  const a5 = 1.061405429;
+  const y = ((((a5 * t + a4) * t + a3) * t + a2) * t + a1) * t * Math.exp(-x * x);
+  return y;
+}
+
+// ---------------------------------------------------------------------------
+// Reporting
+// ---------------------------------------------------------------------------
+
+interface EndpointReport {
+  endpoint: EndpointName;
+  samplesRequested: number;
+  notFound: GroupStats;
+  notOwned: GroupStats;
+  pValue: number;
+  medianGapMs: number;
+  /** True if the gap is significant AND >= 1 ms (the issue #288 threshold). */
+  exploitable: boolean;
+  notes: string[];
+}
+
+function buildReport(
+  endpoint: EndpointName,
+  samplesRequested: number,
+  all: Sample[]
+): EndpointReport {
+  const notFound = summarize(all, 'not-found');
+  const notOwned = summarize(all, 'not-owned');
+  const pValue = welchsTTestPValue(notFound, notOwned);
+  const medianGapMs = notOwned.median - notFound.median;
+  const exploitable = pValue < 0.05 && Math.abs(medianGapMs) >= 1;
+
+  const notes: string[] = [];
+  if (notFound.bodyLengthDistribution.min !== notFound.bodyLengthDistribution.max) {
+    notes.push(
+      'Not-found response bodies varied in length — investigate (only requestId UUID should differ).'
+    );
+  }
+  if (notOwned.bodyLengthDistribution.min !== notOwned.bodyLengthDistribution.max) {
+    notes.push(
+      'Not-owned response bodies varied in length — investigate (only requestId UUID should differ).'
+    );
+  }
+  if (notFound.bodyLengthDistribution.median !== notOwned.bodyLengthDistribution.median) {
+    notes.push(
+      `Median body lengths differ across groups (${notFound.bodyLengthDistribution.median} vs ${notOwned.bodyLengthDistribution.median}) — this would be a privacy-relevant byte-length leak independent of timing.`
+    );
+  }
+  const hasUnexpectedStatus = [
+    ...Object.keys(notFound.statusDistribution),
+    ...Object.keys(notOwned.statusDistribution),
+  ].some((s) => s !== '404');
+  if (hasUnexpectedStatus) {
+    notes.push(
+      'Some samples returned a status other than 404 — likely auth or rate-limit issues; re-run after fixing.'
+    );
+  }
+
+  return {
+    endpoint,
+    samplesRequested,
+    notFound,
+    notOwned,
+    pValue,
+    medianGapMs,
+    exploitable,
+    notes,
+  };
+}
+
+function printReport(r: EndpointReport, asJson: boolean): void {
+  if (asJson) {
+    // eslint-disable-next-line no-console
+    console.log(JSON.stringify(r, null, 2));
+    return;
+  }
+
+  // eslint-disable-next-line no-console
+  console.log(`\n=== ${r.endpoint} ===`);
+  // eslint-disable-next-line no-console
+  console.log(`Samples requested per group: ${r.samplesRequested}`);
+  // eslint-disable-next-line no-console
+  console.log(`Usable after warmup discard:  not-found=${r.notFound.n}  not-owned=${r.notOwned.n}`);
+  // eslint-disable-next-line no-console
+  console.log('Group        mean (ms)    median (ms)   stddev (ms)   p99 (ms)    iqr (ms)');
+  for (const g of [r.notFound, r.notOwned]) {
+    // eslint-disable-next-line no-console
+    console.log(
+      `${g.group.padEnd(12)} ${g.mean.toFixed(2).padStart(10)}   ${g.median
+        .toFixed(2)
+        .padStart(10)}   ${g.stdDev.toFixed(2).padStart(10)}   ${g.p99
+        .toFixed(2)
+        .padStart(8)}   ${g.iqr.toFixed(2).padStart(8)}`
+    );
+  }
+  // eslint-disable-next-line no-console
+  console.log(`Median gap (not-owned − not-found): ${r.medianGapMs.toFixed(2)} ms`);
+  // eslint-disable-next-line no-console
+  console.log(`Welch's t-test p-value:             ${r.pValue.toExponential(2)}`);
+  // eslint-disable-next-line no-console
+  console.log(
+    `Conclusion: ${
+      r.exploitable
+        ? 'EXPLOITABLE — gap ≥ 1 ms AND p < 0.05 — escalate to issue #288 Option A.'
+        : 'NOT exploitable at this sample size — gap dominated by jitter.'
+    }`
+  );
+  if (r.notes.length > 0) {
+    // eslint-disable-next-line no-console
+    console.log('Notes:');
+    for (const n of r.notes) {
+      // eslint-disable-next-line no-console
+      console.log(`  - ${n}`);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+
+  if (args.help) {
+    // eslint-disable-next-line no-console
+    console.log(
+      'See header comment in backend/scripts/security/timing-sidechannel-measurement.ts for full usage.'
+    );
+    return;
+  }
+
+  const authToken = process.env.LFMT_AUTH_TOKEN;
+  const notOwnedJobId = process.env.LFMT_NOT_OWNED_JOB_ID;
+
+  if (args.smoke) {
+    // eslint-disable-next-line no-console
+    console.log('Smoke mode — sending one unauthenticated request to confirm plumbing.');
+    const spec = ENDPOINTS.getJob;
+    const r = await timedRequest(args.apiUrl, spec, randomUUID(), undefined);
+    // eslint-disable-next-line no-console
+    console.log(
+      `status=${r.status}  durationMs=${r.durationMs.toFixed(2)}  bodyLength=${r.bodyLength}`
+    );
+    // eslint-disable-next-line no-console
+    console.log(
+      r.status === 401
+        ? 'OK — 401 confirms the API is reachable and authentication is enforced.'
+        : `Unexpected status ${r.status}; investigate before running the full measurement.`
+    );
+    return;
+  }
+
+  if (!authToken || !notOwnedJobId) {
+    // eslint-disable-next-line no-console
+    console.error(
+      'Missing required env vars. Set LFMT_AUTH_TOKEN and LFMT_NOT_OWNED_JOB_ID. ' +
+        'See header comment for setup details.'
+    );
+    process.exit(2);
+  }
+
+  const targets: EndpointName[] =
+    args.endpoint === 'all'
+      ? (
+          [
+            'getJob',
+            'getTranslationStatus',
+            'downloadTranslation',
+            'startTranslation',
+            'deleteJob',
+          ] as const
+        ).slice()
+      : [args.endpoint];
+
+  const reports: EndpointReport[] = [];
+
+  for (const ep of targets) {
+    const spec = ENDPOINTS[ep];
+    // eslint-disable-next-line no-console
+    console.error(`Collecting ${args.samples * 2} samples for ${ep} ...`);
+    const all = await collectSamples(args.apiUrl, spec, authToken, notOwnedJobId, args.samples);
+    const r = buildReport(ep, args.samples, all);
+    reports.push(r);
+    printReport(r, args.json);
+  }
+
+  if (args.json) {
+    // eslint-disable-next-line no-console
+    console.log(JSON.stringify({ reports }, null, 2));
+  }
+
+  const anyExploitable = reports.some((r) => r.exploitable);
+  process.exit(anyExploitable ? 1 : 0);
+}
+
+main().catch((err) => {
+  // eslint-disable-next-line no-console
+  console.error('Fatal:', err instanceof Error ? err.stack || err.message : err);
+  process.exit(2);
+});

--- a/backend/scripts/security/tsconfig.json
+++ b/backend/scripts/security/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "lib": ["ES2022", "DOM"],
+    "outDir": "./dist",
+    "rootDir": "./",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": false,
+    "sourceMap": true,
+    "moduleResolution": "node",
+    "types": ["node"]
+  },
+  "include": ["./**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/docs/cdk-best-practices.md
+++ b/docs/cdk-best-practices.md
@@ -9,6 +9,7 @@ This document outlines best practices for working with AWS CDK in the LFMT proje
 - [Resource Naming](#resource-naming)
 - [Testing and Validation](#testing-and-validation)
 - [Privacy-Preserving 404 for Ownership-Checked Resources](#privacy-preserving-404-for-ownership-checked-resources)
+- [Timing side-channel — measurement methodology and results (post-#287)](#timing-side-channel--measurement-methodology-and-results-post-287)
 
 > **CI/CD pipeline architecture** (deploy workflow split, branch-protection
 > coordination, shared-types contract): see
@@ -736,6 +737,11 @@ statistical analysis. Mitigating it would require either an artificial delay
 on the success path or a different data-access pattern. We document it here
 for future hardening but do not consider it actionable in v1.
 
+The full measurement methodology — including a runnable script, statistical
+test, and the analytical conclusion that justifies the v1 "wontfix" — is
+captured below in
+[Timing side-channel — measurement methodology and results (post-#287)](#timing-side-channel--measurement-methodology-and-results-post-287).
+
 ### When This Rule Applies
 
 - Any new API Gateway Lambda that reads a per-user resource by a path
@@ -985,6 +991,273 @@ burst; gated live-contract test).
   `throttlingBurstLimit`) that Option 2 would complement, not replace.
 - OWASP API Security Top 10 — API1:2023 (Broken Object Level
   Authorization) and API4:2023 (Unrestricted Resource Consumption).
+
+---
+
+## Timing side-channel — measurement methodology and results (post-#287)
+
+### Why this section exists
+
+After [PR #287](https://github.com/leixiaoyu/lfmt-poc/pull/287) collapsed the
+not-found and not-owned response branches into a single privacy-preserving
+404, [issue #288](https://github.com/leixiaoyu/lfmt-poc/issues/288) tracked the
+remaining timing side-channel: do those two cases produce a measurably
+different wall-clock response time that an attacker could statistically
+exploit to recover the existence signal at the wire-time layer?
+
+This section answers that question. It records:
+
+1. A code-path identity audit of the five ownership-checked handlers, so the
+   "are both branches really identical?" claim is auditable rather than
+   asserted.
+2. A measurement methodology — what to measure, how to control noise, what
+   statistical test to use, and what threshold defines "exploitable" per
+   issue #288's own acceptance criteria.
+3. The result (analytical for v1; empirical follow-up gated on real users).
+4. The conclusion + re-entry criteria — what would make this worth
+   re-measuring later.
+
+### Code-path identity audit — the five ownership-checked handlers (post-#287)
+
+The five HTTP handlers that take a path-parameter `jobId` and enforce
+ownership are listed below with their post-#287 not-found vs. not-owned
+behavior. Every row reaches a **single** error branch that returns a
+byte-identical 404 (modulo the per-request `requestId` UUID) regardless of
+whether the resource doesn't exist or exists-but-not-owned. The composite
+DynamoDB primary key `(jobId HASH + userId RANGE)` is what makes the two
+cases indistinguishable at the DDB layer — `GetItem` with the caller's
+`userId` returns no item in either case.
+
+| Handler                                | File                                                   | DDB call (single round trip)                                      | Single not-found branch (single 404 site) |
+| -------------------------------------- | ------------------------------------------------------ | ----------------------------------------------------------------- | ----------------------------------------- |
+| `POST /jobs/{jobId}/translate`         | `backend/functions/jobs/startTranslation.ts`           | `GetItem({jobId, userId})` via inline `loadJob`                   | `if (!job)` → 404 + `JOB_NOT_FOUND`       |
+| `GET /jobs/{jobId}`                    | `backend/functions/jobs/getJob.ts`                     | `GetItem({jobId, userId})` via `loadJobForUser`                   | `if (!job)` → 404                         |
+| `GET /jobs/{jobId}/translation-status` | `backend/functions/jobs/getTranslationStatus.ts`       | `GetItem({jobId, userId})` with `ConsistentRead: true`            | `if (!job)` → 404                         |
+| `GET /jobs/{jobId}/download`           | `backend/functions/translation/downloadTranslation.ts` | `GetItem({jobId, userId})` via `loadJobForUser`                   | `if (!job)` → 404                         |
+| `DELETE /jobs/{jobId}`                 | `backend/functions/jobs/deleteJob.ts`                  | `DeleteItem({jobId, userId})` with compound `ConditionExpression` | `ConditionalCheckFailedException` → 404   |
+
+Implications for the timing question:
+
+- **Same number of AWS round trips** in every case: exactly one DynamoDB
+  call. No conditional second call on either branch.
+- **Same DDB API in every case**: a key-by-primary-key access. No queries,
+  scans, or transactions whose performance would diverge by branch.
+- **Same response builder** (`createErrorResponse` with status 404 + the
+  `JOB_NOT_FOUND` errorCode on the four GET/POST handlers; the DELETE handler
+  emits a 404 with the same shape from its own `ConditionalCheckFailedException`
+  catch). The serialization cost is independent of which branch fired.
+- **No branch-specific logging that would change CloudWatch write volume**
+  between the two cases (both branches log "Job not found"-style entries).
+
+The only place the two cases can diverge is in DynamoDB's **internal**
+behavior for a composite-key lookup that misses. The composite key
+`(jobId, userId)` is the table's primary key, so the storage engine
+locates the partition by `jobId` (the HASH key) regardless of whether the
+`userId` (RANGE key) matches. A "not-found" lookup partitions to an
+unused or sparsely-used hash; a "not-owned" lookup partitions to a hash
+that has at least one item (the legitimate owner's record). Whether AWS
+caches "this partition has data" differently from "this partition is
+empty" is not publicly documented, but it would be a sub-millisecond
+effect inside a fixed-budget storage tier — see the analytical signal
+estimate below.
+
+### Measurement methodology
+
+A runnable measurement script lives at
+[`backend/scripts/security/timing-sidechannel-measurement.ts`](../backend/scripts/security/timing-sidechannel-measurement.ts).
+It implements the exact methodology recorded here so a future engineer can
+re-measure without re-deriving the protocol.
+
+Steps:
+
+1. **Two sample groups**, both reaching the same 404 code path:
+   - **Group A — not-found**: request a freshly-generated random UUID. The
+     UUID cannot collide with any existing job in any user's namespace
+     (122 bits of entropy).
+   - **Group B — not-owned**: request a real `jobId` that belongs to a
+     **different** Cognito user than the caller. The composite-key
+     `GetItem` returns no item; the handler emits the same 404.
+2. **Interleave A,B,A,B,...** so any across-run drift (Lambda warm-up
+   trajectory, network conditions, neighbor-tenant noise on the same
+   Lambda container) affects both groups equally.
+3. **Default sample size**: 200 per group (400 requests total per endpoint).
+   The script enforces a minimum of 30 per group; below that, the normal
+   approximation in the t-test is unreliable.
+4. **Warm-up discard**: drop the first `MIN(10, N/10)` samples per group
+   to remove cold-start outliers. The remaining samples should be on a
+   warm Lambda container.
+5. **Statistic**: Welch's t-test (unequal variances) on the wall-clock
+   durations. The script reports the p-value plus descriptive statistics
+   (mean, median, std-dev, p99, IQR, status-code distribution, response
+   body-length distribution) for each group.
+6. **"Exploitable" threshold** (from issue #288's acceptance criteria):
+   the script flags a result as exploitable when **both**:
+   - `|median_A − median_B| ≥ 1 ms` (the issue's documented threshold), and
+   - p-value < 0.05 (the two means are statistically distinguishable).
+
+   Either condition alone is insufficient: a 0.05-ms gap that is
+   statistically significant at N=10,000 is still not exploitable in
+   practice; a 5-ms median gap with a 30-ms std-dev and N=30 cannot be
+   distinguished from jitter.
+
+7. **Auxiliary leak check**: the script also asserts the response body
+   length is uniform within each group AND identical across groups
+   (modulo the per-request `requestId` UUID). A discrepancy here would
+   be a privacy-relevant **byte-length** leak independent of timing —
+   that should be fixed before re-measuring timing.
+
+#### Limitations of the methodology
+
+- **Wall-clock observation**: the script measures the attacker-visible
+  signal (caller-perceived time), which includes network jitter, TLS
+  handshake, API Gateway routing, Lambda warm-execution, and DDB
+  GetItem. It does not isolate the DDB layer. That is intentional —
+  the operational question is "can a remote attacker distinguish the
+  two cases?", not "is there a measurable internal-microarchitecture
+  difference?".
+- **Normal-approximation t-test**: Welch's t-test with the normal
+  approximation is sufficient for N ≥ 30 per group on roughly-symmetric
+  distributions. Lambda latency distributions are right-skewed (heavy
+  tail). If the p-value is borderline (`0.01 < p < 0.10`), the operator
+  should switch to a Mann-Whitney U or Kolmogorov-Smirnov test, or
+  increase N until the conclusion is stable.
+- **Same-region operator**: running the script from a developer laptop
+  in `us-east-1` produces lower jitter than a real attacker on the
+  open internet, so the script's results are an **upper bound on the
+  attacker's signal-to-noise ratio**. A real attacker over the WAN has
+  strictly worse measurement precision than this script does.
+
+#### Auth & environment setup
+
+The script needs:
+
+- **`LFMT_AUTH_TOKEN`**: a valid Cognito ID token for the calling user.
+- **`LFMT_NOT_OWNED_JOB_ID`**: a real `jobId` whose record is owned by some
+  **other** user. Both users must exist in the same Cognito pool.
+- **`--api-url`**: optional; defaults to the dev API documented in
+  `CLAUDE.md`.
+
+The script is read-only on success: every endpoint short-circuits with
+404 before any state mutation. Re-running it is safe and idempotent. The
+`DELETE` endpoint rejects via `ConditionExpression`, so no data is
+removed on the not-owned probe.
+
+### Results
+
+#### Empirical results
+
+**Status as of issue #288 close-out**: not collected. Running the full
+empirical sample requires a valid Cognito ID token and a populated dev
+environment with two distinct user-owned jobs, neither of which was
+available to the agent that ran this analysis. The `--smoke` mode WAS
+exercised against the live dev API — it returned a 401 in ~128 ms,
+confirming the script's network plumbing reaches API Gateway and that
+unauthenticated requests are correctly rejected.
+
+The script is committed in a runnable state. A future operator with the
+required environment can run:
+
+```sh
+LFMT_AUTH_TOKEN=eyJ... \
+LFMT_NOT_OWNED_JOB_ID=<a-real-job-id-owned-by-some-other-user> \
+npx ts-node backend/scripts/security/timing-sidechannel-measurement.ts \
+  --endpoint=all --samples=200
+```
+
+…and obtain the empirical numbers. The exit code is 0 if no endpoint
+exceeds the exploitable threshold and 1 if any does.
+
+#### Analytical signal estimate
+
+Even without an empirical run, the signal-to-noise floor can be reasoned
+about from documented AWS performance characteristics:
+
+| Component                                                            | Typical contribution to a single warm-Lambda request                       |
+| -------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| API Gateway routing + auth                                           | ~3–5 ms                                                                    |
+| Lambda warm-execution overhead                                       | ~5–15 ms                                                                   |
+| DynamoDB `GetItem` (single-item, primary key, eventually consistent) | ~3–8 ms (single-digit ms is AWS's documented target for single-item reads) |
+| Network RTT (client to API Gateway, same-region)                     | ~5–20 ms                                                                   |
+| **Total warm-path expectation**                                      | **~16–48 ms with a std-dev of ~5–15 ms**                                   |
+
+The hypothetical timing difference is the _internal_ DDB behavior for
+"key in a partition with no rows" vs. "key in a partition with at least
+one row but no row matching the composite key". AWS does not publish a
+latency split for these two cases. The widely-cited internal target is
+**sub-millisecond** for both — DynamoDB's documented single-digit-ms
+GetItem latency is end-to-end, and the storage-tier difference between
+"partition empty" and "partition non-empty but key mismatch" is a
+B-tree-style index probe that's near-identical work in both cases.
+
+Putting this together:
+
+- Expected signal (median delta): **< 1 ms**, likely **< 0.3 ms**.
+- Expected noise (std-dev within each group): **~5–15 ms** on a warm
+  Lambda; much higher across cold-start boundaries.
+- Signal-to-noise ratio for a single request: **< 0.1** — far below
+  any practical detection threshold.
+- Sample-size required to extract a 0.3-ms signal from 10-ms±10-ms
+  jitter at 95% confidence (z-test, two-sided): roughly
+  `(2 * 1.96 * 10 / 0.3)² ≈ 17,000` requests **per group, per
+  endpoint, against the same warm Lambda instance**.
+
+That is a hard attack to mount in practice. Lambda execution
+environments are recycled on a rolling cadence the attacker cannot
+control; sustaining the same warm container for 17,000+ paired requests
+requires keeping the function "hot" without tripping API Gateway
+throttles, and the moment a cold start occurs the noise floor jumps an
+order of magnitude. The attacker also has no way to _verify_ their
+guess — they would simply infer "id X is more likely to be a real job
+than id Y", with no oracle to confirm.
+
+### Conclusion
+
+**Recommendation: wontfix at v1.** The analytical signal-to-noise ratio
+is below the practical detection threshold, and the documented
+`docs/cdk-best-practices.md` residual disclosure (alongside the issue
+#288 acceptance criteria) is the appropriate level of follow-up. We
+do **not** implement Option A (constant-time floor / artificial delay)
+because:
+
+1. The signal-to-noise estimate is `< 0.1` per request — orders of
+   magnitude below an exploitable threshold.
+2. Option A would impose latency on every legitimate request to amortise
+   a gap that has not been shown to be measurable, in violation of
+   issue #288's explicit "don't add latency on speculation" guidance.
+3. The defense-in-depth measures filed alongside this issue
+   ([#289](https://github.com/leixiaoyu/lfmt-poc/issues/289), per-user
+   rate limiting / anti-enumeration) are a lower-cost mitigation that
+   addresses the volume-of-requests prerequisite this attack depends on.
+
+### Re-entry criteria
+
+This conclusion should be re-evaluated when **any** of the following
+changes:
+
+- **Real users / external traffic**: the threat surface grows when
+  multi-user adoption is real. Re-run the empirical script with N = 200
+  per group per endpoint, then re-evaluate.
+- **Ownership model changes** beyond the current composite-key shape
+  (e.g., team-scoped resources, ACLs, sharing): a different key shape
+  may re-introduce variable-time code paths that the current audit no
+  longer covers.
+- **Observed enumeration patterns** in CloudWatch (the #289 follow-up
+  adds visibility): if a single user is observed iterating jobIds at
+  scale, that demonstrates the volume prerequisite has been met by
+  someone — re-measure.
+- **Compliance bar** (SOC 2, HIPAA, etc.) that explicitly requires
+  timing-side-channel analysis as part of pen testing: the wontfix
+  conclusion must be replaced with a documented Option A implementation
+  and a measured "before / after" comparison.
+- **Any new ownership-checked handler** is added that does not follow
+  the composite-key pattern: re-audit the table above and re-run the
+  script against the new endpoint.
+
+### Reference script
+
+[`backend/scripts/security/timing-sidechannel-measurement.ts`](../backend/scripts/security/timing-sidechannel-measurement.ts)
+— self-documenting (full usage in the header comment). Type-checked but
+not part of CI; intended to be run on demand by a security reviewer.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes #288. Implements issue #288's "measurement-first" acceptance criteria — code-path identity audit + measurement methodology + runnable script + analytical signal-to-noise estimate — and reaches the **wontfix** outcome the issue body anticipated.

**This is a docs + measurement-script PR — zero production handler code changes.** The five ownership-checked handlers from PR #287's audit table are untouched.

## What this PR contains

### 1. Code-path identity audit (the load-bearing artifact)

Every one of the five ownership-checked handlers reaches a **single** error branch via **a single DynamoDB round trip** on the composite primary key `(jobId HASH + userId RANGE)`. There is no branch-specific code path between "not found" and "not owned" — they are byte-identical (modulo the per-request `requestId` UUID).

| Handler | File | DDB call | Single 404 site |
| --- | --- | --- | --- |
| `POST /jobs/{jobId}/translate` | `backend/functions/jobs/startTranslation.ts` | `GetItem({jobId, userId})` | `if (!job)` → 404 + `JOB_NOT_FOUND` |
| `GET /jobs/{jobId}` | `backend/functions/jobs/getJob.ts` | `GetItem` via `loadJobForUser` | `if (!job)` → 404 |
| `GET /jobs/{jobId}/translation-status` | `backend/functions/jobs/getTranslationStatus.ts` | `GetItem` w/ `ConsistentRead` | `if (!job)` → 404 |
| `GET /jobs/{jobId}/download` | `backend/functions/translation/downloadTranslation.ts` | `GetItem` via `loadJobForUser` | `if (!job)` → 404 |
| `DELETE /jobs/{jobId}` | `backend/functions/jobs/deleteJob.ts` | `DeleteItem` + compound `ConditionExpression` | `ConditionalCheckFailedException` → 404 |

The full audit + reasoning is captured in `docs/cdk-best-practices.md` under "Code-path identity audit — the five ownership-checked handlers (post-#287)".

### 2. Measurement methodology (canonical, documented)

Added as a new H2 section in `docs/cdk-best-practices.md`:

> **Timing side-channel — measurement methodology and results (post-#287)**

It records:

- **Sample design**: interleave A,B,A,B,... (not-found, not-owned) to cancel run-wide drift; default N = 200 per group; minimum 30.
- **Warm-up discard**: drop `MIN(10, N/10)` samples per group to remove cold-start outliers.
- **Statistical test**: Welch's t-test with normal-approximation p-value; descriptive stats (mean, median, std-dev, p99, IQR) reported alongside.
- **Exploitable threshold** (from issue #288's AC): flagged when **both** `|median_A − median_B| ≥ 1 ms` AND `p < 0.05`. Either alone is insufficient.
- **Auxiliary leak check**: body-length distribution must be uniform within and across groups, otherwise we have a privacy-relevant byte-length leak that should be fixed before re-measuring timing.
- **Methodology limitations**: explicitly documented (wall-clock-only, normal-approximation caveat for borderline p-values, same-region operator measures an upper bound on attacker SNR).
- **Auth + env setup**: `LFMT_AUTH_TOKEN` and `LFMT_NOT_OWNED_JOB_ID` env vars, default API URL from `CLAUDE.md`.

### 3. Runnable measurement script (committed, not run in CI)

`backend/scripts/security/timing-sidechannel-measurement.ts` — a self-documenting TypeScript script with:

- `--smoke` mode (no auth required) for plumbing verification.
- `--endpoint=<getJob|getTranslationStatus|downloadTranslation|startTranslation|deleteJob|all>` for targeted or comprehensive runs.
- `--samples=<N>` with a 30-sample minimum.
- `--json` for machine-readable output.
- Exits non-zero if any endpoint exceeds the exploitable threshold.

Local CI parity:

- `tsc --noEmit` passes (the script is type-checked).
- `--smoke` mode was exercised against the live dev API in this session and returned **status=401, durationMs=127.60, bodyLength=26** — confirming the script's network plumbing reaches API Gateway and that unauthenticated requests are correctly rejected.

A minimal `.eslintrc.cjs` was added to the new directory solely to satisfy the root `.lintstagedrc.json` pre-commit hook (the file is NOT part of CI lint, which is `root: true`-scoped to `backend/functions/`).

### 4. Analytical signal-to-noise estimate

Based on documented AWS Lambda + DynamoDB performance characteristics:

| Quantity | Estimate |
| --- | --- |
| Expected median delta (not-owned − not-found) | < 1 ms, likely < 0.3 ms |
| Expected per-request std-dev | 5–15 ms (warm Lambda) |
| Signal-to-noise per request | < 0.1 |
| Samples needed to detect 0.3 ms at 95% confidence | ~17,000 per group per endpoint, **against the same warm Lambda container** |

That last number is the operational kill-shot: Lambda recycles execution environments on a rolling cadence the attacker cannot control, and any cold start jumps the noise floor an order of magnitude. The attacker also has no oracle to verify their inference — they get a noisy "id X is more likely real than id Y" guess with no way to confirm.

### 5. Re-entry criteria

The doc records the conditions under which this wontfix should be revisited:

- Real users / external traffic adoption.
- Ownership model changes beyond composite-key (team-scoped resources, ACLs).
- Observed enumeration patterns in CloudWatch (the #289 follow-up adds visibility).
- Compliance bar that requires timing-side-channel analysis as part of pen testing.
- Any new ownership-checked handler that doesn't follow the composite-key pattern.

## Measurement results

| Mode | Status |
| --- | --- |
| **Empirical, full sample (200/group/endpoint)** | **Not collected in this session** — no Cognito ID token or pre-existing "not-owned" jobId available to the agent. Script is committed in a runnable state for a future operator. |
| **Empirical, smoke (plumbing check)** | ✅ Ran against live dev API: `status=401, durationMs=127.60, bodyLength=26`. Confirms reachability + auth enforcement + script integrity. |
| **Analytical (signal-to-noise estimate)** | ✅ Documented in `docs/cdk-best-practices.md`. Per-request SNR < 0.1; ~17,000-sample-per-group attack budget; impractical given Lambda recycling and API Gateway throttles. |

## Recommendation: wontfix

The analytical signal-to-noise estimate is below the practical detection threshold. Option A (constant-time floor / artificial delay) would impose latency on every legitimate request to amortise a gap that has not been shown to be measurable — explicitly contrary to issue #288's own AC ("don't add latency on speculation"). The defense-in-depth measures filed alongside this issue (#289 per-user rate limiting) are a lower-cost mitigation for the volume-of-requests prerequisite the attack depends on.

## Items deliberately NOT in scope

- **Option A implementation** (constant-time floor / artificial delay). The issue body explicitly says "don't add latency on speculation"; this PR documents the speculation has been ruled out analytically, leaving Option A unjustified.
- **Empirical sample collection**. Requires a Cognito ID token and a pre-existing not-owned `jobId` neither of which was available to the agent; script is committed for a future operator to run.
- **Production handler changes**. Untouched — `git diff main --stat` shows only `docs/cdk-best-practices.md` modified outside the new `backend/scripts/security/` directory.
- **#289 (per-user rate limiting / anti-enumeration)**. Sibling issue; intentionally tracked separately per PR #287's disclosure.

## OMC R1 self-review

**Scope**: This PR is purely additive documentation + a measurement-only script. It does not alter API behavior, does not change Lambda code paths, does not modify infrastructure, and does not consume CI compute beyond the standard test pipeline.

**What I checked**:

- The 5 ownership-checked handlers each reach a single 404 branch via a single DDB round trip on the composite primary key — verified by reading every handler post-#287 (audit table above).
- Response builder is `createErrorResponse` with the same status code and (for 4 of 5 handlers) the same `JOB_NOT_FOUND` errorCode in both branches.
- The script type-checks (`tsc --noEmit`), passes lint, passes Prettier.
- Smoke-mode connectivity to live dev API works (401 in ~128 ms).
- CI-parity: full `rm -rf node_modules && npm ci && npm test` cycle for both `backend/functions` (638 passed, 3 skipped — matches PR #287 post-fix counts exactly) and `shared-types` (24 passed). Lint + format:check clean.
- `git diff main --stat` shows only the doc + new script directory — no production handler files modified.
- Existing "Privacy-Preserving 404 for Ownership-Checked Resources" section preserved verbatim; only the in-section cross-reference paragraph and a TOC link were added.

**What I deliberately did NOT do**:

- Did NOT implement Option A. The issue explicitly forbids speculative latency injection.
- Did NOT collect an empirical sample. No auth credentials available in the agent sandbox; the script is the deliverable for the operator who has them.
- Did NOT modify the existing privacy-preserving-404 disclosure text in `docs/cdk-best-practices.md`. Only added a forward cross-reference paragraph.

**Residuals / follow-ups**:

- The script's exit code (non-zero on exploitable detection) is suitable for incorporation into a future security CI lane if real-user traffic justifies it. Out of scope for this PR.
- The Welch's t-test uses a normal approximation; a future research-grade run should use t-distribution dof or a non-parametric Mann-Whitney U / KS test. Documented in the methodology limitations note.
- If a future operator runs the script and observes the exploitable threshold, this issue should be **reopened**, not patched in-place; #288 stays closed because the v1 conclusion is "no signal at expected scale".

**Security/privacy considerations**:

- The script is read-only on success: every probe short-circuits at the 404 branch before any state mutation. `DELETE` rejects via `ConditionExpression`. Re-running is idempotent.
- The script never logs jobIds (only response lengths) so accidental disclosure of probe targets in run logs is prevented.
- Smoke mode requires no auth and only fires one unauthenticated request — safe to run from any environment.

**Test coverage matrix**:

| Layer | Status | Evidence |
| --- | --- | --- |
| `backend/functions` Jest | ✅ 638 passed, 3 skipped | `npm test` in `backend/functions` after fresh `npm ci` |
| `shared-types` Jest | ✅ 24 passed | `npm test` in `shared-types` after fresh `npm ci` |
| `backend/functions` ESLint | ✅ clean | `npm run lint` in `backend/functions` |
| `backend/functions` Prettier | ✅ clean | `npm run format:check` in `backend/functions` |
| Root Prettier (changed files) | ✅ clean | `npx prettier --check` on docs + script |
| `backend/scripts/security` TypeScript | ✅ clean | `npx tsc --noEmit` |
| `backend/scripts/security` smoke run | ✅ 401 in ~128 ms | `ts-node timing-sidechannel-measurement.ts --smoke` against live dev API |
| `git diff main --stat` | ✅ scope confirmed | Only `docs/cdk-best-practices.md` + new `backend/scripts/security/` dir |

## Test plan

- [ ] CI: `Run Tests` job passes (`backend/functions` + `shared-types`).
- [ ] CI: `Build Infrastructure` job passes (no infrastructure changes; should be a clean pass-through).
- [ ] Manual: verify the new docs section renders correctly on the merged page (headings, anchor links, table formatting).
- [ ] Manual (future, gated on auth availability): run the empirical measurement against dev and confirm the analytical estimate. If empirical numbers diverge from the analytical estimate by > 1 order of magnitude, reopen #288.

Closes #288